### PR TITLE
Use npm trusted publishing and add dependency automation

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+patreon: ar27111994
+ko_fi: ar27111994
+liberapay: ar27111994
+buy_me_a_coffee: ar27111994
+thanks_dev: d/gh/ar27111994

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    groups:
+      npm-version-updates:
+        patterns:
+          - "*"
+      npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-version-updates:
+        patterns:
+          - "*"
+      github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,10 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+
+env:
+  NODE_VERSION: "24"
+  NPM_VERSION: "11.5.1"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,6 +22,8 @@ jobs:
     name: release checks (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -33,9 +38,14 @@ jobs:
         # actions/setup-node@v4
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           cache: npm
+
+      - name: Install npm with trusted publishing support
+        run: |
+          npm install --global npm@${{ env.NPM_VERSION }}
+          npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -50,7 +60,7 @@ jobs:
         run: npm pack --dry-run --json --ignore-scripts
 
       - name: Verify publish dry run
-        run: npm publish --dry-run --ignore-scripts --provenance --access public
+        run: npm publish --dry-run --ignore-scripts --access public
 
   publish:
     name: publish
@@ -58,6 +68,9 @@ jobs:
     needs: release-checks
     if: startsWith(github.ref, 'refs/tags/v')
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Check out repository
@@ -68,9 +81,14 @@ jobs:
         # actions/setup-node@v4
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           cache: npm
+
+      - name: Install npm with trusted publishing support
+        run: |
+          npm install --global npm@${{ env.NPM_VERSION }}
+          npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -78,7 +96,10 @@ jobs:
       - name: Audit production dependencies
         run: npm audit --omit=dev
 
-      - name: Publish package
-        run: npm publish --ignore-scripts --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build package
+        run: npm run build
+
+      - name: Publish package with npm trusted publishing
+        run: |
+          unset NODE_AUTH_TOKEN
+          npm publish --ignore-scripts --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ All notable changes to this project will be documented in this file.
 - guarded HTTP helpers with origin allowlists, timeouts, and response byte limits for external content reads
 - domain-specific discovery modules for demand profiling, source indexing, source utilization, package/reference/local/GitHub/official-index harvesting, catalog selection, and catalog trust utilities
 - focused install-domain modules, domain-local manifest validators, and localized type modules that preserve stable public barrel entrypoints while reducing large shared files
-- scoped public package identity as `@ar27111994/agent-harness`, package metadata, npm `files` allowlist, prepack build, packed-artifact smoke validation, and release workflow with provenance-ready publish checks
+- scoped public package identity as `@ar27111994/agent-harness`, package metadata, npm `files` allowlist, prepack build, packed-artifact smoke validation, and release workflow with OIDC trusted publishing, provenance-ready publish checks, and package build validation in the publish job
+- Dependabot version and security update configuration for npm packages and GitHub Actions plus repository funding metadata and README npm/sponsor badges
 - mutable state-root support through `--state-root` and `AGENT_HARNESS_STATE_ROOT`, with packaged CLI defaults writing lifecycle output to workspace-local `.agent-harness/` instead of the package install directory
 - `quarantine list/inspect/approve/reject` review commands with review logging for quarantined mirror artifacts
 - optional `discover enrich` AI-assisted enrichment reports through an explicitly configured OpenAI-compatible endpoint

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](./package.json)
 [![Quality](https://github.com/ar27111994/agent-harness/actions/workflows/quality.yml/badge.svg)](https://github.com/ar27111994/agent-harness/actions/workflows/quality.yml)
 [![Latest Release](https://img.shields.io/github/v/release/ar27111994/agent-harness?display_name=tag)](https://github.com/ar27111994/agent-harness/releases)
+[![npm version](https://img.shields.io/npm/v/%40ar27111994%2Fagent-harness?logo=npm&color=CB3837)](https://www.npmjs.com/package/@ar27111994/agent-harness)
+[![npm downloads](https://img.shields.io/npm/dm/%40ar27111994%2Fagent-harness?logo=npm&color=CB3837)](https://www.npmjs.com/package/@ar27111994/agent-harness)
+[![Sponsor](https://img.shields.io/badge/Sponsor-support-ff69b4?logo=githubsponsors&logoColor=white)](#sponsor)
 
 `agent-harness` is a Node.js 22+ TypeScript CLI, published as `@ar27111994/agent-harness`, for discovering, curating, staging, activating, and wiring reusable AI-agent assets into developer workspaces.
 
@@ -28,6 +31,7 @@ It is built around one generic command surface and a host-adapter model. The lif
 - [FAQ](#faq)
 - [Current boundaries](#current-boundaries)
 - [Related documentation](#related-documentation)
+- [Sponsor](#sponsor)
 - [License](#license)
 
 ## What this project does
@@ -1083,6 +1087,14 @@ Known boundaries:
 - `IMPLEMENTATION-PLAN.md` — milestone-oriented execution plan
 - `FUTURE-IMPROVEMENTS.md` — follow-up ideas and architectural extensions
 - `CONTRIBUTING.md` — contribution workflow and hygiene
+
+## Sponsor
+
+[![Patreon](https://img.shields.io/badge/Support-Patreon-FF424D?logo=patreon&logoColor=white)](https://www.patreon.com/cw/ar27111994)
+[![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-29ABE0?logo=kofi&logoColor=white)](https://ko-fi.com/ar27111994)
+[![Liberapay](https://img.shields.io/badge/Support-Liberapay-F6C915?logo=liberapay&logoColor=black)](https://liberapay.com/ar27111994)
+[![Buy Me a Coffee](https://img.shields.io/badge/Support-Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=000000)](https://buymeacoffee.com/ar27111994)
+[![thanks.dev](https://img.shields.io/badge/Support-thanks.dev-181717?logo=github&logoColor=white)](https://thanks.dev/d/gh/ar27111994)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Move npm publishing to GitHub Actions OIDC trusted publishing by removing `NPM_TOKEN` usage, scoping `id-token: write` to the publish job, running the release workflow on Node.js 24, and publishing with npm 11.5.1+ trusted-publishing support.
- Add Dependabot configuration for weekly npm and GitHub Actions version updates, with grouped security-update PRs.
- Add repository funding metadata plus npm and sponsor badges/links in the README.
- Update the v1.0.0 changelog entry to include the release-infra, Dependabot, and funding/badge updates.

## Validation

- `npm run validate`
- `npm run build`
- `npm audit --omit=dev`
- `git diff --check`

## Follow-up needed after merge

- In npm package settings for `@ar27111994/agent-harness`, configure the trusted publisher as GitHub Actions with organization/user `ar27111994`, repository `agent-harness`, and workflow filename `release.yml`.
- Ensure Dependabot security updates are enabled in the repository security settings if they are not already enabled; this PR adds the version-update config and groups security-update PRs when Dependabot security updates are active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled Dependabot for automated dependency and security update checks
  * Added GitHub sponsorship configuration supporting multiple funding platforms
  * Updated release workflow with Node.js 24 and improved npm publishing

* **Documentation**
  * Added sponsor badges and links to README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->