### PR TITLE
Resolve open audit, review, and docstring coverage issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ All notable changes to this project will be documented in this file.
 - install bundle discovery now derives lock paths from registered host adapter bundle defaults and warns when expected locks are missing
 - duplicate checked-in local source definitions were removed in favor of runtime-generated local sources with dynamic endpoints
 - shared mirror path guards are reused by both mirror acquisition and bundle installation, and GitHub timeout handling uses one `AbortError` helper
+- guarded HTTP fetches now resolve and pin public DNS answers before requests, mirror evidence reads reject symlink escapes, GitHub mirror downloads verify raw-byte upstream blob SHAs, and prompt-injection quarantine detection covers normalized jailbreak and secret-exfiltration variants
+- recommendation selection now preserves policy minimums above one, keeps hard source/duplicate caps in fallback selection, and keeps suggested bundles within activation budgets
+- native and VS Code wire-in now preserve applied preview state, reuse activation asset path sanitization, and avoid clobbering user-owned global skill-location preferences
+- rebuild, scanning, discovery, activation, and install flows now use workspace roots consistently, skip generated discovery output, reuse demand-signal file reads, atomically stage activation runtime views before swapping, merge bundle membership, mirror audit-only assets, reject truncated GitHub snapshots, and validate all Copilot workspace profile selection arrays
+- public exported declarations now include API docstrings with a regression test that fails when exported source declarations lack JSDoc coverage
 
 ## [0.2.0] - 2026-04-27
 

--- a/src/activate.ts
+++ b/src/activate.ts
@@ -1,7 +1,9 @@
+import { rename } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
   copyPath,
+  ensureCleanDirectory,
   ensureDirectory,
   pathExists,
   readJsonFile,
@@ -9,7 +11,6 @@ import {
   removePath,
   toPosixPath,
   writeJsonFile,
-  writeJsonFileWithSnapshot,
 } from "./files.js";
 import { listHostAdapters } from "./host-adapters/registry.js";
 import { getOptionValue } from "./lib/cli-options.js";
@@ -44,6 +45,9 @@ const ACTIVATION_HOSTS = [
 ] as const satisfies readonly ActivationHost[];
 const SHARED_HOST_TARGET = "shared" as const satisfies HostTarget;
 
+/**
+ * Dispatches the activate CLI command group.
+ */
 export async function runActivate(
   args: string[],
   _workingDirectory: string,
@@ -117,7 +121,14 @@ async function activateHost(
 ): Promise<void> {
   const activeAssets = new Set<string>();
   const runtimeRoot = join(projectRoot, "activate", host);
-  await ensureDirectory(runtimeRoot);
+  const stagingRuntimeRoot = `${runtimeRoot}.tmp`;
+  await ensureDirectory(join(projectRoot, "activate"));
+  await ensureCleanDirectory(stagingRuntimeRoot);
+  const previousActivationManifest =
+    await readJsonFileOrNull<ActivationManifest>(
+      join(runtimeRoot, ACTIVATION_MANIFEST_FILE),
+      assertActivationManifest,
+    );
   const recommendationReport = await readJsonFileOrNull<RecommendationReport>(
     join(projectRoot, "state", "recommendations.json"),
     assertRecommendationReport,
@@ -200,7 +211,7 @@ async function activateHost(
         continue;
       }
       const destinationRoot = join(
-        runtimeRoot,
+        stagingRuntimeRoot,
         sanitizeAssetId(packageManifest.assetId),
       );
       candidates.push({ packageManifest, destinationRoot });
@@ -214,7 +225,7 @@ async function activateHost(
     activationBudget,
   );
 
-  await writeJsonFile(join(runtimeRoot, `${host}-overlay-plan.json`), {
+  await writeJsonFile(join(stagingRuntimeRoot, `${host}-overlay-plan.json`), {
     schemaVersion: 1,
     host,
     generatedAt: new Date().toISOString(),
@@ -308,7 +319,7 @@ async function activateHost(
     }
 
     await writeJsonFile(
-      join(runtimeRoot, "workspace-profile-manifest.json"),
+      join(stagingRuntimeRoot, "workspace-profile-manifest.json"),
       copilotProfileManifest,
     );
   }
@@ -336,11 +347,42 @@ async function activateHost(
     ],
   };
 
-  await writeJsonFileWithSnapshot(
-    join(runtimeRoot, ACTIVATION_MANIFEST_FILE),
-    join(runtimeRoot, ACTIVATION_PREVIOUS_MANIFEST_FILE),
+  if (previousActivationManifest) {
+    await writeJsonFile(
+      join(stagingRuntimeRoot, ACTIVATION_PREVIOUS_MANIFEST_FILE),
+      previousActivationManifest,
+    );
+  }
+  await writeJsonFile(
+    join(stagingRuntimeRoot, ACTIVATION_MANIFEST_FILE),
     activationManifest,
   );
+
+  await swapActivationRuntimeRoot(runtimeRoot, stagingRuntimeRoot);
+}
+
+async function swapActivationRuntimeRoot(
+  runtimeRoot: string,
+  stagingRuntimeRoot: string,
+): Promise<void> {
+  const backupRuntimeRoot = `${runtimeRoot}.previous`;
+  await removePath(backupRuntimeRoot);
+  const hadRuntimeRoot = await pathExists(runtimeRoot);
+
+  if (hadRuntimeRoot) {
+    await rename(runtimeRoot, backupRuntimeRoot);
+  }
+
+  try {
+    await rename(stagingRuntimeRoot, runtimeRoot);
+  } catch (error) {
+    if (hadRuntimeRoot && !(await pathExists(runtimeRoot))) {
+      await rename(backupRuntimeRoot, runtimeRoot).catch(() => undefined);
+    }
+    throw error;
+  }
+
+  await removePath(backupRuntimeRoot);
 }
 
 function filterBundleIdsForHost(

--- a/src/asset-content.ts
+++ b/src/asset-content.ts
@@ -5,6 +5,9 @@ import { sanitizeAssetId } from "./lib/safe-paths.js";
 import { fetchOfficialIndexPageContent } from "./official-index.js";
 import type { AssetCatalogEntry } from "./types.js";
 
+/**
+ * Resolves asset content from the provided inputs.
+ */
 export async function resolveAssetContent(options: {
   activationRoot: string;
   assetId: string;

--- a/src/config/env-file.ts
+++ b/src/config/env-file.ts
@@ -1,6 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+/**
+ * Describes dot env load result data exchanged by the lifecycle pipeline.
+ */
 export interface DotEnvLoadResult {
   path: string;
   loaded: boolean;

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -14,6 +14,9 @@ const DEFAULT_AI_ENRICHMENT_ALLOWED_ORIGINS = [
   "https://api.together.xyz",
 ] as const;
 
+/**
+ * Describes runtime config data exchanged by the lifecycle pipeline.
+ */
 export interface RuntimeConfig {
   env: NodeJS.ProcessEnv;
   aiEnrichment: {
@@ -46,11 +49,17 @@ export interface RuntimeConfig {
 
 let runtimeConfig: RuntimeConfig | null = null;
 
+/**
+ * Returns get runtime config for the provided inputs.
+ */
 export function getRuntimeConfig(): RuntimeConfig {
   runtimeConfig ??= loadRuntimeConfig(process.env);
   return runtimeConfig;
 }
 
+/**
+ * Loads runtime config from project state.
+ */
 export function loadRuntimeConfig(env: NodeJS.ProcessEnv): RuntimeConfig {
   const homeDirectory =
     nonEmptyString(env.AGENT_HARNESS_HOME) ??
@@ -121,10 +130,16 @@ export function loadRuntimeConfig(env: NodeJS.ProcessEnv): RuntimeConfig {
   };
 }
 
+/**
+ * Clears clear runtime config process-local state.
+ */
 export function clearRuntimeConfig(): void {
   runtimeConfig = null;
 }
 
+/**
+ * Clears clear runtime config for tests process-local state.
+ */
 export function clearRuntimeConfigForTests(): void {
   clearRuntimeConfig();
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -65,6 +65,9 @@ import type {
   SelectionReport,
 } from "./types.js";
 
+/**
+ * Dispatches the discover CLI command group.
+ */
 export async function runDiscover(
   args: string[],
   workingDirectory: string,
@@ -114,6 +117,9 @@ async function generateDemandProfile(
   console.log(`Demand profile written to ${toPosixPath(outputPath)}`);
 }
 
+/**
+ * Re-exports demand profile construction for programmatic discovery callers.
+ */
 export { buildDemandProfile } from "./domains/discovery/demand-profile.js";
 
 async function generateCatalog(projectRoot: string): Promise<void> {

--- a/src/domains/discovery/ai-enrichment.ts
+++ b/src/domains/discovery/ai-enrichment.ts
@@ -7,7 +7,7 @@ import {
   writeJsonFile,
 } from "../../files.js";
 import {
-  assertAllowedPublicHttpUrl,
+  assertAllowedPublicHttpUrlWithDns,
   fetchJsonWithGuards,
 } from "../../lib/http.js";
 import {
@@ -30,6 +30,9 @@ interface AiEnrichmentReport {
 
 const OUTPUT_PATH = ["discover", "output", "ai-enrichment.json"] as const;
 
+/**
+ * Writes ai enrichment report to project state.
+ */
 export async function writeAiEnrichmentReport(
   projectRoot: string,
 ): Promise<void> {
@@ -62,7 +65,10 @@ export async function writeAiEnrichmentReport(
   );
 
   try {
-    const url = assertAllowedPublicHttpUrl(endpointUrl, config.allowedOrigins);
+    const url = await assertAllowedPublicHttpUrlWithDns(
+      endpointUrl,
+      config.allowedOrigins,
+    );
     const response = await fetchJsonWithGuards(url.toString(), {
       allowedOrigins: config.allowedOrigins,
       body: JSON.stringify({

--- a/src/domains/discovery/catalog-inspection.ts
+++ b/src/domains/discovery/catalog-inspection.ts
@@ -10,6 +10,9 @@ import {
   SELECTED_CATALOG_OUTPUT_PATH,
 } from "./output-paths.js";
 
+/**
+ * Provides print catalog stats for the lifecycle pipeline.
+ */
 export async function printCatalogStats(projectRoot: string): Promise<void> {
   const catalogEntries = await readJsonLinesFile<AssetCatalogEntry>(
     join(projectRoot, ...CATALOG_OUTPUT_PATH),
@@ -41,6 +44,9 @@ export async function printCatalogStats(projectRoot: string): Promise<void> {
   console.log(JSON.stringify(stats, null, 2));
 }
 
+/**
+ * Provides inspect catalog for the lifecycle pipeline.
+ */
 export async function inspectCatalog(
   projectRoot: string,
   args: string[],

--- a/src/domains/discovery/catalog-selection.ts
+++ b/src/domains/discovery/catalog-selection.ts
@@ -6,6 +6,9 @@ import type {
   SelectionRegistry,
 } from "../../types.js";
 
+/**
+ * Groups catalog entries for selection in the lifecycle pipeline.
+ */
 export function groupCatalogEntriesForSelection(
   catalogEntries: AssetCatalogEntry[],
 ): Map<string, AssetCatalogEntry[]> {
@@ -21,6 +24,9 @@ export function groupCatalogEntriesForSelection(
   return groupedEntries;
 }
 
+/**
+ * Compares selection candidate values for stable ordering.
+ */
 export function compareSelectionCandidates(
   left: AssetCatalogEntry,
   right: AssetCatalogEntry,
@@ -95,6 +101,9 @@ export function compareSelectionCandidates(
   return left.id.localeCompare(right.id);
 }
 
+/**
+ * Builds selection reason from the provided inputs.
+ */
 export function buildSelectionReason(
   selectedEntry: AssetCatalogEntry,
   selectionRegistry: SelectionRegistry,

--- a/src/domains/discovery/catalog-utils.ts
+++ b/src/domains/discovery/catalog-utils.ts
@@ -10,6 +10,9 @@ import type {
   SourceDefinition,
 } from "../../types.js";
 
+/**
+ * Provides count by for the lifecycle pipeline.
+ */
 export function countBy<T>(
   items: T[],
   getKey: (item: T) => string,
@@ -24,6 +27,9 @@ export function countBy<T>(
   return counts;
 }
 
+/**
+ * Defines generic capability tokens shared by the lifecycle pipeline.
+ */
 export const GENERIC_CAPABILITY_TOKENS = new Set([
   "agent",
   "agents",
@@ -39,6 +45,9 @@ export const GENERIC_CAPABILITY_TOKENS = new Set([
   "subagents",
 ]);
 
+/**
+ * Builds risk from the provided inputs.
+ */
 export function buildRisk(
   hasHooks: boolean,
   hasExecScripts: boolean,
@@ -74,6 +83,9 @@ export function buildRisk(
   };
 }
 
+/**
+ * Provides classify context cost for the lifecycle pipeline.
+ */
 export function classifyContextCost(lineCount: number): AssetContextCost {
   if (lineCount <= 40) {
     return { sizeClass: "tiny", estimatedPromptWeight: 1 };
@@ -90,6 +102,9 @@ export function classifyContextCost(lineCount: number): AssetContextCost {
   return { sizeClass: "large", estimatedPromptWeight: 8 };
 }
 
+/**
+ * Provides compute portfolio fit for the lifecycle pipeline.
+ */
 export function computePortfolioFit(
   capabilities: string[],
   demandProfile: DemandProfile | null,
@@ -130,6 +145,9 @@ export function computePortfolioFit(
   return Number(Math.min(1, matchCount / demandTerms.size).toFixed(2));
 }
 
+/**
+ * Provides compute host fit for the lifecycle pipeline.
+ */
 export function computeHostFit(
   hosts: HostTarget[],
   compatibilityMode: CompatibilityMode,
@@ -153,6 +171,9 @@ export function computeHostFit(
   return 0;
 }
 
+/**
+ * Provides find duplicate group for the lifecycle pipeline.
+ */
 export function findDuplicateGroup(
   capabilities: string[],
   selectionRegistry: SelectionRegistry,
@@ -171,6 +192,9 @@ export function findDuplicateGroup(
   return undefined;
 }
 
+/**
+ * Builds candidate rank hint from the provided inputs.
+ */
 export function buildCandidateRankHint(authorityTier: string): string {
   if (
     authorityTier === "official-first-party" ||
@@ -190,6 +214,9 @@ export function buildCandidateRankHint(authorityTier: string): string {
   return "candidate-catalog";
 }
 
+/**
+ * Provides merge remote catalog entries for the lifecycle pipeline.
+ */
 export function mergeRemoteCatalogEntries(
   existingEntries: AssetCatalogEntry[],
   newEntries: AssetCatalogEntry[],
@@ -209,6 +236,9 @@ export function mergeRemoteCatalogEntries(
   return [...byId.values()].sort(compareAssetCatalogEntries);
 }
 
+/**
+ * Builds asset status from the provided inputs.
+ */
 export function buildAssetStatus(source: SourceDefinition): AssetStatus {
   const installEligible = source.rules.allowMirror && source.rules.allowInstall;
   return {
@@ -219,6 +249,9 @@ export function buildAssetStatus(source: SourceDefinition): AssetStatus {
   };
 }
 
+/**
+ * Provides compute trust score for the lifecycle pipeline.
+ */
 export function computeTrustScore(input: {
   authorityTier: string;
   sourceKind: string;
@@ -252,6 +285,9 @@ export function computeTrustScore(input: {
   );
 }
 
+/**
+ * Builds trust signals from the provided inputs.
+ */
 export function buildTrustSignals(input: {
   authorityTier: string;
   sourceKind: string;
@@ -275,6 +311,9 @@ export function buildTrustSignals(input: {
   return signals;
 }
 
+/**
+ * Provides enhance trust for entry for the lifecycle pipeline.
+ */
 export function enhanceTrustForEntry(
   entry: AssetCatalogEntry,
 ): AssetCatalogEntry {
@@ -350,10 +389,16 @@ export function enhanceTrustForEntry(
   };
 }
 
+/**
+ * Builds catalog id from the provided inputs.
+ */
 export function buildCatalogId(sourceId: string, assetPath: string): string {
   return `${sourceId}:${encodeCatalogPath(assetPath)}`;
 }
 
+/**
+ * Compares asset catalog entries values for stable ordering.
+ */
 export function compareAssetCatalogEntries(
   left: AssetCatalogEntry,
   right: AssetCatalogEntry,
@@ -361,6 +406,9 @@ export function compareAssetCatalogEntries(
   return left.id.localeCompare(right.id);
 }
 
+/**
+ * Provides split into keywords for the lifecycle pipeline.
+ */
 export function splitIntoKeywords(value: string): string[] {
   return value
     .toLowerCase()
@@ -370,10 +418,16 @@ export function splitIntoKeywords(value: string): string[] {
     .filter((token) => token.length >= 1);
 }
 
+/**
+ * Provides unique strings for the lifecycle pipeline.
+ */
 export function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)];
 }
 
+/**
+ * Provides last path segment for the lifecycle pipeline.
+ */
 export function lastPathSegment(value: string): string {
   const normalizedValue = value.replace(/\/+/gu, "/");
   const segments = normalizedValue
@@ -383,6 +437,9 @@ export function lastPathSegment(value: string): string {
   return lastSegment.replace(/\.(md|ts|js|mts|cts)$/u, "");
 }
 
+/**
+ * Provides humanize slug for the lifecycle pipeline.
+ */
 export function humanizeSlug(value: string): string {
   return value
     .split(/[-_/]+/u)
@@ -391,6 +448,9 @@ export function humanizeSlug(value: string): string {
     .join(" ");
 }
 
+/**
+ * Compares sources by priority values for stable ordering.
+ */
 export function compareSourcesByPriority(
   left: SourceDefinition,
   right: SourceDefinition,
@@ -428,10 +488,11 @@ function getCompatibilityRank(compatibilityMode: CompatibilityMode): number {
 }
 
 function encodeCatalogPath(assetPath: string): string {
-  return assetPath
+  const segments = assetPath
     .replace(/\\/gu, "/")
     .split("/")
-    .filter((segment) => segment.length > 0)
-    .map((segment) => segment.toLowerCase().replace(/[^a-z0-9-]+/gu, "-"))
-    .join("__");
+    .filter((segment) => segment.length > 0);
+  const encodedPath = encodeURIComponent(segments.join("/"));
+
+  return encodedPath.length > 0 ? encodedPath : "root";
 }

--- a/src/domains/discovery/demand-profile.ts
+++ b/src/domains/discovery/demand-profile.ts
@@ -17,6 +17,9 @@ import {
   sortSignalSet,
 } from "./signals.js";
 
+/**
+ * Builds demand profile from the provided inputs.
+ */
 export async function buildDemandProfile(
   scanRoot: string,
 ): Promise<DemandProfile> {

--- a/src/domains/discovery/demand-signals.ts
+++ b/src/domains/discovery/demand-signals.ts
@@ -1,4 +1,4 @@
-import { readJsonFileOrNull, readTextFileOrNull } from "../../files.js";
+import { readTextFileOrNull } from "../../files.js";
 import type { DemandSignalSet } from "../../types.js";
 import {
   collectDetectorSignals,
@@ -32,8 +32,38 @@ const LOGGING_TEXT_MARKERS = ["logger", "logging", "debugger", "debug"];
 const MOCKING_TEXT_MARKERS = ["mock", "mocking"];
 const REPLAY_TEXT_MARKERS = ["replay", "forwarding", "forwarder"];
 const WEBHOOK_TEXT_MARKERS = ["webhook", "webhooks"];
+const INSPECTABLE_FILE_NAMES = new Set([
+  "package.json",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "tsconfig.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "Cargo.toml",
+  "go.mod",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "Gemfile",
+  "composer.json",
+  "Package.swift",
+  "Dockerfile",
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  "deno.json",
+  "actor.json",
+  "input_schema.json",
+]);
 
+/**
+ * Provides should inspect file for the lifecycle pipeline.
+ */
 export function shouldInspectFile(fileName: string, filePath: string): boolean {
+  if (isActorJsonFile(fileName, filePath) || fileName === "input_schema.json") {
+    return true;
+  }
+
   if (
     fileName.endsWith(".csproj") ||
     fileName.endsWith(".tf") ||
@@ -54,29 +84,7 @@ export function shouldInspectFile(fileName: string, filePath: string): boolean {
     return true;
   }
 
-  const inspectableNames = new Set([
-    "package.json",
-    "package-lock.json",
-    "pnpm-lock.yaml",
-    "yarn.lock",
-    "tsconfig.json",
-    "pyproject.toml",
-    "requirements.txt",
-    "Cargo.toml",
-    "go.mod",
-    "pom.xml",
-    "build.gradle",
-    "build.gradle.kts",
-    "Gemfile",
-    "composer.json",
-    "Package.swift",
-    "Dockerfile",
-    "docker-compose.yml",
-    "docker-compose.yaml",
-    "deno.json",
-  ]);
-
-  if (inspectableNames.has(fileName)) {
+  if (INSPECTABLE_FILE_NAMES.has(fileName)) {
     return true;
   }
 
@@ -86,6 +94,9 @@ export function shouldInspectFile(fileName: string, filePath: string): boolean {
   );
 }
 
+/**
+ * Collects demand signals for file from the provided inputs.
+ */
 export async function collectDemandSignalsForFile(
   fileName: string,
   filePath: string,
@@ -94,35 +105,38 @@ export async function collectDemandSignalsForFile(
 
   collectDetectorSignals(fileName, filePath, matchedSignals);
 
+  const fileContent = shouldReadFileContent(fileName, filePath)
+    ? await readTextFileOrNull(filePath)
+    : null;
+
   if (fileName === "package.json") {
-    await enrichPackageJsonSignals(filePath, matchedSignals);
+    enrichPackageJsonSignals(fileContent, matchedSignals);
   }
 
   if (fileName === "requirements.txt") {
-    await enrichRequirementsSignals(filePath, matchedSignals);
+    enrichRequirementsSignals(fileContent, matchedSignals);
   }
 
   if (fileName === "pyproject.toml") {
-    await enrichPyProjectSignals(filePath, matchedSignals);
+    enrichPyProjectSignals(fileContent, matchedSignals);
   }
 
-  await enrichMultiEcosystemDependencySignals(
-    fileName,
-    filePath,
-    matchedSignals,
-  );
+  enrichMultiEcosystemDependencySignals(fileName, fileContent, matchedSignals);
 
   if (isActorJsonFile(fileName, filePath)) {
-    await enrichActorJsonSignals(filePath, matchedSignals);
+    enrichActorJsonSignals(fileContent, matchedSignals);
   }
 
   if (shouldReadTextForTechnologySignals(fileName)) {
-    await enrichGenericTextSignals(filePath, matchedSignals);
+    enrichGenericTextSignals(fileContent, matchedSignals);
   }
 
   return matchedSignals;
 }
 
+/**
+ * Returns whether the provided value matches actor json file.
+ */
 export function isActorJsonFile(fileName: string, filePath: string): boolean {
   return (
     /^actor\.json$/iu.test(fileName) || ACTOR_JSON_PATH_PATTERN.test(filePath)
@@ -253,11 +267,11 @@ function collectStaticSignals(
   return matchedSignals;
 }
 
-async function enrichPackageJsonSignals(
-  filePath: string,
+function enrichPackageJsonSignals(
+  content: string | null,
   matchedSignals: DemandSignalSet,
-): Promise<void> {
-  const packageJson = await readJsonFileOrNull<PackageJsonShape>(filePath);
+): void {
+  const packageJson = parseJsonOrNull<PackageJsonShape>(content);
 
   if (!packageJson) {
     return;
@@ -295,11 +309,10 @@ async function enrichPackageJsonSignals(
   addPackageDependencySignals(matchedSignals, "npm", [...dependencyNames]);
 }
 
-async function enrichRequirementsSignals(
-  filePath: string,
+function enrichRequirementsSignals(
+  content: string | null,
   matchedSignals: DemandSignalSet,
-): Promise<void> {
-  const content = await readTextFileOrNull(filePath);
+): void {
   if (!content) {
     return;
   }
@@ -319,11 +332,10 @@ async function enrichRequirementsSignals(
   addPackageDependencySignals(matchedSignals, "pypi", dependencyNames);
 }
 
-async function enrichPyProjectSignals(
-  filePath: string,
+function enrichPyProjectSignals(
+  content: string | null,
   matchedSignals: DemandSignalSet,
-): Promise<void> {
-  const content = await readTextFileOrNull(filePath);
+): void {
   if (!content) {
     return;
   }
@@ -472,11 +484,11 @@ function isPlainPackageName(value: string | undefined): value is string {
   return Boolean(value && /^[a-z0-9_.-]+$/iu.test(value));
 }
 
-async function enrichMultiEcosystemDependencySignals(
+function enrichMultiEcosystemDependencySignals(
   fileName: string,
-  filePath: string,
+  content: string | null,
   matchedSignals: DemandSignalSet,
-): Promise<void> {
+): void {
   if (
     fileName === "package.json" ||
     fileName === "requirements.txt" ||
@@ -485,7 +497,6 @@ async function enrichMultiEcosystemDependencySignals(
     return;
   }
 
-  const content = await readTextFileOrNull(filePath);
   if (!content) {
     return;
   }
@@ -565,11 +576,10 @@ function addPackageDependencySignals(
   addSignals(matchedSignals.tooling, normalizedNames);
 }
 
-async function enrichGenericTextSignals(
-  filePath: string,
+function enrichGenericTextSignals(
+  content: string | null,
   matchedSignals: DemandSignalSet,
-): Promise<void> {
-  const content = await readTextFileOrNull(filePath);
+): void {
   if (!content) {
     return;
   }
@@ -600,11 +610,11 @@ function shouldReadTextForTechnologySignals(fileName: string): boolean {
   );
 }
 
-async function enrichActorJsonSignals(
-  filePath: string,
+function enrichActorJsonSignals(
+  content: string | null,
   matchedSignals: DemandSignalSet,
-): Promise<void> {
-  const actorJson = await readJsonFileOrNull<ActorJsonShape>(filePath);
+): void {
+  const actorJson = parseJsonOrNull<ActorJsonShape>(content);
 
   if (!actorJson) {
     return;
@@ -631,6 +641,44 @@ async function enrichActorJsonSignals(
     text: actorTextSignals,
   });
   addGenericTextSignals(matchedSignals, actorTextSignals);
+}
+
+function shouldReadFileContent(fileName: string, filePath: string): boolean {
+  return (
+    fileName === "package.json" ||
+    fileName === "requirements.txt" ||
+    fileName === "pyproject.toml" ||
+    isActorJsonFile(fileName, filePath) ||
+    shouldReadTextForTechnologySignals(fileName) ||
+    shouldReadTextForDependencySignals(fileName)
+  );
+}
+
+function shouldReadTextForDependencySignals(fileName: string): boolean {
+  return (
+    [
+      "Cargo.toml",
+      "go.mod",
+      "pom.xml",
+      "build.gradle",
+      "build.gradle.kts",
+      "Gemfile",
+      "composer.json",
+      "Package.swift",
+    ].includes(fileName) || fileName.endsWith(".csproj")
+  );
+}
+
+function parseJsonOrNull<T>(content: string | null): T | null {
+  if (!content) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(content) as T;
+  } catch {
+    return null;
+  }
 }
 
 function addGenericTextSignals(

--- a/src/domains/discovery/detector-signatures.ts
+++ b/src/domains/discovery/detector-signatures.ts
@@ -1,13 +1,22 @@
 import type { DemandSignalSet } from "../../types.js";
 
+/**
+ * Defines the supported detector signal set values.
+ */
 export type DetectorSignalSet = Partial<DemandSignalSet>;
 
+/**
+ * Describes detector conditional signals data exchanged by the lifecycle pipeline.
+ */
 export interface DetectorConditionalSignals {
   fileNamePattern?: RegExp;
   filePathPattern?: RegExp;
   signals: DetectorSignalSet;
 }
 
+/**
+ * Describes detector signature data exchanged by the lifecycle pipeline.
+ */
 export interface DetectorSignature {
   id: string;
   extensions?: string[];
@@ -17,6 +26,9 @@ export interface DetectorSignature {
   conditionalSignals?: DetectorConditionalSignals[];
 }
 
+/**
+ * Defines detector signatures shared by the lifecycle pipeline.
+ */
 export const DETECTOR_SIGNATURES: DetectorSignature[] = [
   {
     id: "documentation",

--- a/src/domains/discovery/detectors.ts
+++ b/src/domains/discovery/detectors.ts
@@ -8,6 +8,9 @@ import {
 } from "./detector-signatures.js";
 import { addSignals } from "./signals.js";
 
+/**
+ * Describes file detector data exchanged by the lifecycle pipeline.
+ */
 export interface FileDetector {
   id: string;
   matches(fileName: string, filePath: string): boolean;
@@ -18,10 +21,16 @@ export interface FileDetector {
   ): void;
 }
 
+/**
+ * Defines file detectors shared by the lifecycle pipeline.
+ */
 export const FILE_DETECTORS: FileDetector[] = DETECTOR_SIGNATURES.map(
   createSignatureDetector,
 );
 
+/**
+ * Returns whether the provided value matches detector inspectable file.
+ */
 export function isDetectorInspectableFile(
   fileName: string,
   filePath: string,
@@ -31,6 +40,9 @@ export function isDetectorInspectableFile(
   );
 }
 
+/**
+ * Collects detector signals from the provided inputs.
+ */
 export function collectDetectorSignals(
   fileName: string,
   filePath: string,

--- a/src/domains/discovery/github-harvester.ts
+++ b/src/domains/discovery/github-harvester.ts
@@ -1,13 +1,11 @@
-import {
-  fetchGitHubRepoSnapshot,
-  type GitHubRepoSnapshot,
-} from "../../github.js";
+import { fetchGitHubRepoSnapshot } from "../../github.js";
 import type {
   AssetCatalogEntry,
   AssetKind,
   AssetRisk,
   CompatibilityMode,
   DemandProfile,
+  GitHubRepoSnapshot,
   HostTarget,
   SelectionRegistry,
   SourceDefinition,
@@ -28,6 +26,9 @@ import {
   uniqueStrings,
 } from "./catalog-utils.js";
 
+/**
+ * Provides harvest git hub repo source for the lifecycle pipeline.
+ */
 export async function harvestGitHubRepoSource(
   source: SourceDefinition,
   demandProfile: DemandProfile | null,
@@ -41,12 +42,20 @@ export async function harvestGitHubRepoSource(
       return [];
     }
 
+    if (snapshot.tree.truncated) {
+      console.warn(
+        `Skipping repo source ${source.id}: GitHub tree response was truncated.`,
+      );
+      return [];
+    }
+
     return snapshot.tree.entries
+      .filter((entry) => entry.type === "blob")
       .map((entry) =>
         buildGitHubCatalogEntry(
           snapshot,
           source,
-          entry.path,
+          entry,
           demandProfile,
           selectionRegistry,
         ),
@@ -62,10 +71,11 @@ export async function harvestGitHubRepoSource(
 function buildGitHubCatalogEntry(
   snapshot: GitHubRepoSnapshot,
   source: SourceDefinition,
-  relativePath: string,
+  treeEntry: GitHubRepoSnapshot["tree"]["entries"][number],
   demandProfile: DemandProfile | null,
   selectionRegistry: SelectionRegistry,
 ): AssetCatalogEntry | null {
+  const relativePath = treeEntry.path;
   const classification = classifyGitHubTreePath(relativePath, source);
 
   if (!classification) {
@@ -127,6 +137,7 @@ function buildGitHubCatalogEntry(
       adaptableHosts:
         classification.compatibilityMode === "adaptable" ? hosts : undefined,
       relativePath,
+      manifestEntry: treeEntry.sha,
     },
     evidence: {
       manifestFound: true,

--- a/src/domains/discovery/index.ts
+++ b/src/domains/discovery/index.ts
@@ -1,9 +1,30 @@
+/**
+ * Re-exports AI enrichment report writing for discovery callers.
+ */
 export { writeAiEnrichmentReport } from "./ai-enrichment.js";
+/**
+ * Re-exports catalog inspection helpers for discovery callers.
+ */
 export { inspectCatalog, printCatalogStats } from "./catalog-inspection.js";
+/**
+ * Re-exports demand profile construction for discovery callers.
+ */
 export { buildDemandProfile } from "./demand-profile.js";
+/**
+ * Re-exports source index generation for discovery callers.
+ */
 export { generateSourceIndex } from "./source-index.js";
+/**
+ * Re-exports source registry loading for discovery callers.
+ */
 export { loadSourceRegistry } from "./source-registry.js";
+/**
+ * Re-exports source utilization reporting for discovery callers.
+ */
 export { writeSourceUtilizationReport } from "./source-utilization.js";
+/**
+ * Re-exports remote harvest state helpers for discovery callers.
+ */
 export {
   loadRemoteHarvestState,
   writeRemoteHarvestState,

--- a/src/domains/discovery/local-harvesters.ts
+++ b/src/domains/discovery/local-harvesters.ts
@@ -57,6 +57,9 @@ interface ClassifiedLocalFile {
   hosts: HostTarget[];
 }
 
+/**
+ * Provides harvest local manifest source for the lifecycle pipeline.
+ */
 export async function harvestLocalManifestSource(
   source: SourceDefinition,
   demandProfile: DemandProfile | null,
@@ -165,6 +168,9 @@ export async function harvestLocalManifestSource(
   });
 }
 
+/**
+ * Provides harvest local directory source for the lifecycle pipeline.
+ */
 export async function harvestLocalDirectorySource(
   source: SourceDefinition,
   demandProfile: DemandProfile | null,
@@ -373,7 +379,7 @@ function classifyLocalDirectoryFile(
   }
 
   if (source.id === "local-opencode-config") {
-    if (/^skills\/[^/]+\/SKILL\.md$/iu.test(relativePath)) {
+    if (/^skills\/.+\/SKILL\.md$/iu.test(relativePath)) {
       return {
         assetKind: "skill",
         compatibilityMode: "native",

--- a/src/domains/discovery/local-sources.ts
+++ b/src/domains/discovery/local-sources.ts
@@ -3,6 +3,9 @@ import { join } from "node:path";
 import type { SourceDefinition } from "../../types.js";
 import { resolveDefaultOpenCodeConfigRoot } from "../../lib/paths.js";
 
+/**
+ * Builds generated local sources from the provided inputs.
+ */
 export function buildGeneratedLocalSources(): SourceDefinition[] {
   const openCodeRoot = resolveDefaultOpenCodeConfigRoot();
 

--- a/src/domains/discovery/markdown-metadata.ts
+++ b/src/domains/discovery/markdown-metadata.ts
@@ -1,6 +1,9 @@
 import type { AssetPrerequisite } from "../../types.js";
 import { buildAssetPrerequisitesFromMetadata } from "../../lib/asset-prerequisites.js";
 
+/**
+ * Describes parsed markdown metadata data exchanged by the lifecycle pipeline.
+ */
 export interface ParsedMarkdownMetadata {
   fields: Record<string, string | string[]>;
   heading: string | null;
@@ -15,6 +18,9 @@ export interface ParsedMarkdownMetadata {
   body: string;
 }
 
+/**
+ * Provides extract markdown metadata for the lifecycle pipeline.
+ */
 export function extractMarkdownMetadata(
   content: string,
 ): ParsedMarkdownMetadata {
@@ -27,11 +33,15 @@ export function extractMarkdownMetadata(
   const dependencies = getStringArrayField(fields.dependencies);
   const authProviders = getStringArrayField(fields.auth);
   const requiredEnvVars = getStringArrayField(fields.requiresEnv);
+  const requiredHostLogins = getStringArrayField(fields.requiresHostLogin);
+  const requiredOauthProviders = getStringArrayField(fields.requiresOAuth);
   const setupUrls = getStringArrayField(fields.setupUrl);
   const setupUrl = setupUrls[0];
   const prerequisites = buildAssetPrerequisitesFromMetadata({
     providers: authProviders,
     envVars: requiredEnvVars,
+    hostLogins: requiredHostLogins,
+    oauthProviders: requiredOauthProviders,
     setupUrl,
   });
   const lineCount = content.split(/\r?\n/u).length;
@@ -71,6 +81,8 @@ function parseFrontmatter(content: string): {
     "dependencies",
     "auth",
     "requiresEnv",
+    "requiresHostLogin",
+    "requiresOAuth",
     "setupUrl",
     "mode",
     "compatibility",
@@ -149,6 +161,9 @@ function stripWrappingQuotes(value: string): string {
   return value.replace(/^['"]|['"]$/gu, "");
 }
 
+/**
+ * Returns get first string field for the provided inputs.
+ */
 export function getFirstStringField(
   value: string | string[] | undefined,
 ): string | null {

--- a/src/domains/discovery/official-index-harvester.ts
+++ b/src/domains/discovery/official-index-harvester.ts
@@ -49,6 +49,9 @@ const OFFICIAL_INDEX_ALLOWED_ORIGINS = [
   "https://raw.githubusercontent.com",
 ] as const;
 
+/**
+ * Provides harvest official skill indexes for the lifecycle pipeline.
+ */
 export async function harvestOfficialSkillIndexes(
   projectRoot: string,
   demandProfile: DemandProfile | null,
@@ -300,6 +303,34 @@ function buildOfficialIndexDuplicateGroup(owner: string, slug: string): string {
   return `official-index:${owner}:${slug}`;
 }
 
+function normalizeGitHubRepoIdentity(
+  repoUrl: string | undefined,
+): string | null {
+  if (!repoUrl) {
+    return null;
+  }
+
+  const normalizedRepoUrl = repoUrl.trim().replace(/^git\+/iu, "");
+  const httpsMatch =
+    /^https:\/\/github\.com\/([^/]+)\/(.+?)(?:\.git)?\/?$/iu.exec(
+      normalizedRepoUrl,
+    );
+  const scpMatch = /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/iu.exec(
+    normalizedRepoUrl,
+  );
+  const sshMatch =
+    /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?\/?$/iu.exec(
+      normalizedRepoUrl,
+    );
+  const match = httpsMatch ?? scpMatch ?? sshMatch;
+
+  if (!match?.[1] || !match[2]) {
+    return null;
+  }
+
+  return `${match[1]}/${match[2].replace(/\.git$/iu, "")}`.toLowerCase();
+}
+
 function isOfficialIndexOwner(owner: string): boolean {
   return [
     "anthropics",
@@ -344,14 +375,24 @@ async function resolveOfficialIndexEntryToRepoSource(
   officialRepoUrl?: string,
 ): Promise<AssetCatalogEntry | null> {
   const sourceRegistry = await loadSourceRegistry(projectRoot);
+  const officialRepoIdentity = normalizeGitHubRepoIdentity(officialRepoUrl);
+  const expectedFallbackIdentity = normalizeGitHubRepoIdentity(
+    `https://github.com/${owner}/${slug}`,
+  );
   const matchingSource = sourceRegistry.sources.find((source) => {
-    const repoUrl = source.endpoints.repo?.toLowerCase();
-    if (officialRepoUrl && repoUrl === officialRepoUrl.toLowerCase()) {
-      return true;
+    const sourceRepoIdentity = normalizeGitHubRepoIdentity(
+      source.endpoints.repo,
+    );
+    if (!sourceRepoIdentity) {
+      return false;
+    }
+
+    if (officialRepoIdentity) {
+      return sourceRepoIdentity === officialRepoIdentity;
     }
 
     return (
-      repoUrl?.includes(`/${owner.toLowerCase()}/`) &&
+      sourceRepoIdentity === expectedFallbackIdentity &&
       source.authorityTier === entry.source.authorityTier
     );
   });

--- a/src/domains/discovery/output-paths.ts
+++ b/src/domains/discovery/output-paths.ts
@@ -1,47 +1,74 @@
+/**
+ * Defines the demand profile output path location used by persisted project state.
+ */
 export const DEMAND_PROFILE_OUTPUT_PATH = [
   "discover",
   "output",
   "demand-profile.json",
 ];
 
+/**
+ * Defines the source index output path location used by persisted project state.
+ */
 export const SOURCE_INDEX_OUTPUT_PATH = [
   "discover",
   "output",
   "source-index.json",
 ];
 
+/**
+ * Defines the catalog output path location used by persisted project state.
+ */
 export const CATALOG_OUTPUT_PATH = ["discover", "catalog.assets.jsonl"];
 
+/**
+ * Defines the selected catalog output path location used by persisted project state.
+ */
 export const SELECTED_CATALOG_OUTPUT_PATH = [
   "discover",
   "output",
   "catalog.selected.jsonl",
 ];
 
+/**
+ * Defines the rejected catalog output path location used by persisted project state.
+ */
 export const REJECTED_CATALOG_OUTPUT_PATH = [
   "discover",
   "output",
   "catalog.rejected.jsonl",
 ];
 
+/**
+ * Defines the selection report output path location used by persisted project state.
+ */
 export const SELECTION_REPORT_OUTPUT_PATH = [
   "discover",
   "output",
   "selection-report.json",
 ];
 
+/**
+ * Defines the source utilization output path location used by persisted project state.
+ */
 export const SOURCE_UTILIZATION_OUTPUT_PATH = [
   "discover",
   "output",
   "source-utilization.json",
 ];
 
+/**
+ * Defines the remote harvest state output path location used by persisted project state.
+ */
 export const REMOTE_HARVEST_STATE_OUTPUT_PATH = [
   "state",
   "discover",
   "remote-harvest.json",
 ];
 
+/**
+ * Defines the remote catalog state output path location used by persisted project state.
+ */
 export const REMOTE_CATALOG_STATE_OUTPUT_PATH = [
   "state",
   "discover",

--- a/src/domains/discovery/package-candidates.ts
+++ b/src/domains/discovery/package-candidates.ts
@@ -1,5 +1,8 @@
 import type { DemandProfile } from "../../types.js";
 
+/**
+ * Defines the supported package registry kind values.
+ */
 export type PackageRegistryKind =
   | "npm"
   | "pypi"
@@ -11,6 +14,9 @@ export type PackageRegistryKind =
   | "packagist"
   | "swift";
 
+/**
+ * Collects package candidates from demand profile from the provided inputs.
+ */
 export function collectPackageCandidatesFromDemandProfile(
   demandProfile: DemandProfile | null,
   registryKind: PackageRegistryKind,

--- a/src/domains/discovery/package-registry-harvester.ts
+++ b/src/domains/discovery/package-registry-harvester.ts
@@ -31,6 +31,9 @@ import {
   type PackageRegistryKind,
 } from "./package-candidates.js";
 
+/**
+ * Provides harvest package registry source for the lifecycle pipeline.
+ */
 export async function harvestPackageRegistrySource(
   source: SourceDefinition,
   demandProfile: DemandProfile | null,

--- a/src/domains/discovery/reference-harvesters.ts
+++ b/src/domains/discovery/reference-harvesters.ts
@@ -6,6 +6,9 @@ import type {
   SourceDefinition,
 } from "../../types.js";
 
+/**
+ * Describes harvested reference item data exchanged by the lifecycle pipeline.
+ */
 export interface HarvestedReferenceItem {
   displayName: string;
   originUrl: string;
@@ -32,6 +35,9 @@ const VSCODE_MARKETPLACE_ORIGINS = [
   "https://marketplace.visualstudio.com",
 ] as const;
 
+/**
+ * Provides harvest reference items for the lifecycle pipeline.
+ */
 export async function harvestReferenceItems(
   source: SourceDefinition,
   demandProfile: DemandProfile | null,

--- a/src/domains/discovery/reference-source-harvester.ts
+++ b/src/domains/discovery/reference-source-harvester.ts
@@ -2,6 +2,7 @@ import { fetchOfficialIndexPageContent } from "../../official-index.js";
 import type {
   AssetCatalogEntry,
   AssetKind,
+  AssetStatus,
   CompatibilityMode,
   DemandProfile,
   SelectionRegistry,
@@ -25,6 +26,9 @@ import {
   type HarvestedReferenceItem,
 } from "./reference-harvesters.js";
 
+/**
+ * Provides harvest reference source for the lifecycle pipeline.
+ */
 export async function harvestReferenceSource(
   source: SourceDefinition,
   demandProfile: DemandProfile | null,
@@ -161,12 +165,24 @@ function buildReferenceSourceCatalogEntry(
       duplicateGroup: findDuplicateGroup(capabilities, selectionRegistry),
       candidateRankHint: buildCandidateRankHint(source.authorityTier),
     },
-    status: {
-      cataloged: true,
-      mirrorEligible: wasHarvested && source.rules.allowMirror,
-      installEligible: compatibilityMode === "native",
-      activationEligible: compatibilityMode === "native",
-    },
+    status: buildReferenceAssetStatus(source, compatibilityMode, wasHarvested),
+  };
+}
+
+function buildReferenceAssetStatus(
+  source: SourceDefinition,
+  compatibilityMode: CompatibilityMode,
+  wasHarvested: boolean,
+): AssetStatus {
+  const policyAllowsInstall =
+    wasHarvested && source.rules.allowMirror && source.rules.allowInstall;
+  const installEligible = compatibilityMode === "native" && policyAllowsInstall;
+
+  return {
+    cataloged: true,
+    mirrorEligible: wasHarvested && source.rules.allowMirror,
+    installEligible,
+    activationEligible: installEligible,
   };
 }
 

--- a/src/domains/discovery/remote-state.ts
+++ b/src/domains/discovery/remote-state.ts
@@ -3,6 +3,9 @@ import { join } from "node:path";
 import { readJsonFileOrNull, writeJsonFile } from "../../files.js";
 import { REMOTE_HARVEST_STATE_OUTPUT_PATH } from "./output-paths.js";
 
+/**
+ * Describes remote harvest state data exchanged by the lifecycle pipeline.
+ */
 export interface RemoteHarvestState {
   schemaVersion: number;
   generatedAt: string;
@@ -10,6 +13,9 @@ export interface RemoteHarvestState {
   completedSourceIds: string[];
 }
 
+/**
+ * Loads remote harvest state from project state.
+ */
 export async function loadRemoteHarvestState(
   projectRoot: string,
 ): Promise<RemoteHarvestState> {
@@ -66,6 +72,9 @@ function assertRemoteHarvestState(
   });
 }
 
+/**
+ * Writes remote harvest state to project state.
+ */
 export async function writeRemoteHarvestState(
   projectRoot: string,
   state: RemoteHarvestState,

--- a/src/domains/discovery/signals.ts
+++ b/src/domains/discovery/signals.ts
@@ -1,5 +1,8 @@
 import type { DemandSignalSet } from "../../types.js";
 
+/**
+ * Provides add signals for the lifecycle pipeline.
+ */
 export function addSignals(target: string[], values: string[]): void {
   for (const value of values) {
     if (!target.includes(value)) {
@@ -8,6 +11,9 @@ export function addSignals(target: string[], values: string[]): void {
   }
 }
 
+/**
+ * Provides merge signals for the lifecycle pipeline.
+ */
 export function mergeSignals(
   target: DemandSignalSet,
   source: DemandSignalSet,
@@ -19,6 +25,9 @@ export function mergeSignals(
   addSignals(target.tooling, source.tooling);
 }
 
+/**
+ * Provides sort signal set for the lifecycle pipeline.
+ */
 export function sortSignalSet(signalSet: DemandSignalSet): DemandSignalSet {
   return {
     languages: [...signalSet.languages].sort(),
@@ -29,6 +38,9 @@ export function sortSignalSet(signalSet: DemandSignalSet): DemandSignalSet {
   };
 }
 
+/**
+ * Creates empty signal set for use by the lifecycle pipeline.
+ */
 export function createEmptySignalSet(): DemandSignalSet {
   return {
     languages: [],
@@ -39,6 +51,9 @@ export function createEmptySignalSet(): DemandSignalSet {
   };
 }
 
+/**
+ * Provides has any signals for the lifecycle pipeline.
+ */
 export function hasAnySignals(signalSet: DemandSignalSet): boolean {
   return [
     signalSet.languages,

--- a/src/domains/discovery/source-index.ts
+++ b/src/domains/discovery/source-index.ts
@@ -11,6 +11,9 @@ import { countBy } from "./catalog-utils.js";
 import { SOURCE_INDEX_OUTPUT_PATH } from "./output-paths.js";
 import { loadSourceRegistry } from "./source-registry.js";
 
+/**
+ * Generates source index artifacts for the lifecycle pipeline.
+ */
 export async function generateSourceIndex(projectRoot: string): Promise<void> {
   const sourceRegistry = await loadSourceRegistry(projectRoot);
   const selectionRegistry = await readJsonFile<SelectionRegistry>(

--- a/src/domains/discovery/source-registry.ts
+++ b/src/domains/discovery/source-registry.ts
@@ -31,6 +31,9 @@ interface SourcePackShape {
   }>;
 }
 
+/**
+ * Loads source registry from project state.
+ */
 export async function loadSourceRegistry(
   projectRoot: string,
 ): Promise<SourceRegistry> {

--- a/src/domains/discovery/source-utilization.ts
+++ b/src/domains/discovery/source-utilization.ts
@@ -5,6 +5,9 @@ import type { AssetCatalogEntry, SourceDefinition } from "../../types.js";
 import { countBy } from "./catalog-utils.js";
 import { SOURCE_UTILIZATION_OUTPUT_PATH } from "./output-paths.js";
 
+/**
+ * Writes source utilization report to project state.
+ */
 export async function writeSourceUtilizationReport(
   projectRoot: string,
   enabledSources: SourceDefinition[],

--- a/src/domains/discovery/technology-signatures.ts
+++ b/src/domains/discovery/technology-signatures.ts
@@ -1,8 +1,14 @@
 import type { DemandSignalSet } from "../../types.js";
 import { addSignals } from "./signals.js";
 
+/**
+ * Defines the supported package ecosystem values.
+ */
 export type PackageEcosystem = "npm" | "pypi";
 
+/**
+ * Describes technology signature data exchanged by the lifecycle pipeline.
+ */
 export interface TechnologySignature {
   id: string;
   packages?: Partial<Record<PackageEcosystem, string[]>>;
@@ -11,12 +17,18 @@ export interface TechnologySignature {
   signals: Partial<DemandSignalSet>;
 }
 
+/**
+ * Describes technology signal context data exchanged by the lifecycle pipeline.
+ */
 export interface TechnologySignalContext {
   dependencyNames?: string[];
   ecosystem?: PackageEcosystem;
   text?: string;
 }
 
+/**
+ * Defines technology signatures shared by the lifecycle pipeline.
+ */
 export const TECHNOLOGY_SIGNATURES: TechnologySignature[] = [
   {
     id: "react",
@@ -507,6 +519,9 @@ export const TECHNOLOGY_SIGNATURES: TechnologySignature[] = [
   },
 ];
 
+/**
+ * Provides apply technology signatures for the lifecycle pipeline.
+ */
 export function applyTechnologySignatures(
   target: DemandSignalSet,
   context: TechnologySignalContext,

--- a/src/files.ts
+++ b/src/files.ts
@@ -15,6 +15,11 @@ import { createHash } from "node:crypto";
 
 import { getRuntimeConfig } from "./config/runtime.js";
 
+const FILE_STAT_CONCURRENCY = 16;
+
+/**
+ * Defines default ignored directory names shared by the lifecycle pipeline.
+ */
 export const DEFAULT_IGNORED_DIRECTORY_NAMES = new Set([
   ".git",
   ".idea",
@@ -51,11 +56,17 @@ export const DEFAULT_IGNORED_DIRECTORY_NAMES = new Set([
   "venv",
 ]);
 
+/**
+ * Defines the supported json validator values.
+ */
 export type JsonValidator<T> = (
   value: unknown,
   context: string,
 ) => asserts value is T;
 
+/**
+ * Resolves project root from the provided inputs.
+ */
 export function resolveProjectRoot(scriptFilePath: string): string {
   const scriptDirectory = dirname(scriptFilePath);
   const directoryName = basename(scriptDirectory);
@@ -67,6 +78,9 @@ export function resolveProjectRoot(scriptFilePath: string): string {
   return scriptDirectory;
 }
 
+/**
+ * Provides path exists for the lifecycle pipeline.
+ */
 export async function pathExists(filePath: string): Promise<boolean> {
   try {
     await access(filePath);
@@ -76,6 +90,9 @@ export async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Provides path entry exists for the lifecycle pipeline.
+ */
 export async function pathEntryExists(filePath: string): Promise<boolean> {
   try {
     await lstat(filePath);
@@ -85,10 +102,16 @@ export async function pathEntryExists(filePath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Ensures ensure directory exists or is ready for use.
+ */
 export async function ensureDirectory(directoryPath: string): Promise<void> {
   await mkdir(directoryPath, { recursive: true });
 }
 
+/**
+ * Reads json file from project state.
+ */
 export async function readJsonFile<T>(
   filePath: string,
   validator?: JsonValidator<T>,
@@ -113,27 +136,61 @@ export async function readJsonFile<T>(
   return parsedContent as T;
 }
 
+/**
+ * Reads json file or null from project state.
+ */
 export async function readJsonFileOrNull<T>(
   filePath: string,
   validator?: JsonValidator<T>,
 ): Promise<T | null> {
-  if (!(await pathExists(filePath))) {
-    return null;
-  }
+  try {
+    return await readJsonFile<T>(filePath, validator);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
 
-  return readJsonFile<T>(filePath, validator);
+    throw error;
+  }
 }
 
+/**
+ * Reads text file or null from project state.
+ */
 export async function readTextFileOrNull(
   filePath: string,
 ): Promise<string | null> {
-  if (!(await pathExists(filePath))) {
-    return null;
-  }
+  try {
+    return await readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
 
-  return readFile(filePath, "utf8");
+    throw error;
+  }
 }
 
+/**
+ * Reads binary file bytes or null from project state.
+ */
+export async function readBinaryFileOrNull(
+  filePath: string,
+): Promise<Buffer | null> {
+  try {
+    return await readFile(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Writes json file to project state.
+ */
 export async function writeJsonFile(
   filePath: string,
   value: unknown,
@@ -143,6 +200,9 @@ export async function writeJsonFile(
   await writeFile(filePath, json, "utf8");
 }
 
+/**
+ * Writes text file to project state.
+ */
 export async function writeTextFile(
   filePath: string,
   value: string,
@@ -151,6 +211,20 @@ export async function writeTextFile(
   await writeFile(filePath, value, "utf8");
 }
 
+/**
+ * Writes binary file bytes to project state.
+ */
+export async function writeBinaryFile(
+  filePath: string,
+  value: Buffer,
+): Promise<void> {
+  await ensureDirectory(dirname(filePath));
+  await writeFile(filePath, value);
+}
+
+/**
+ * Snapshots file if exists from the provided inputs.
+ */
 export async function snapshotFileIfExists(
   sourcePath: string,
   snapshotPath: string,
@@ -164,6 +238,9 @@ export async function snapshotFileIfExists(
   await writeTextFile(snapshotPath, content);
 }
 
+/**
+ * Writes json file with snapshot to project state.
+ */
 export async function writeJsonFileWithSnapshot(
   filePath: string,
   snapshotPath: string,
@@ -173,6 +250,9 @@ export async function writeJsonFileWithSnapshot(
   await writeJsonFile(filePath, value);
 }
 
+/**
+ * Writes json lines file with snapshot to project state.
+ */
 export async function writeJsonLinesFileWithSnapshot(
   filePath: string,
   snapshotPath: string,
@@ -182,6 +262,9 @@ export async function writeJsonLinesFileWithSnapshot(
   await writeJsonLinesFile(filePath, values);
 }
 
+/**
+ * Reads json lines file from project state.
+ */
 export async function readJsonLinesFile<T>(
   filePath: string,
   validator?: JsonValidator<T>,
@@ -217,6 +300,9 @@ export async function readJsonLinesFile<T>(
     });
 }
 
+/**
+ * Writes json lines file to project state.
+ */
 export async function writeJsonLinesFile(
   filePath: string,
   values: unknown[],
@@ -230,6 +316,9 @@ export async function writeJsonLinesFile(
   );
 }
 
+/**
+ * Provides copy path for the lifecycle pipeline.
+ */
 export async function copyPath(
   sourcePath: string,
   destinationPath: string,
@@ -238,6 +327,9 @@ export async function copyPath(
   await cp(sourcePath, destinationPath, { recursive: true, force: true });
 }
 
+/**
+ * Creates directory link for use by the lifecycle pipeline.
+ */
 export async function createDirectoryLink(
   linkPath: string,
   targetPath: string,
@@ -262,6 +354,9 @@ export async function createDirectoryLink(
   );
 }
 
+/**
+ * Provides replace directory link for the lifecycle pipeline.
+ */
 export async function replaceDirectoryLink(
   linkPath: string,
   targetPath: string,
@@ -282,10 +377,16 @@ export async function replaceDirectoryLink(
   await rename(temporaryLinkPath, linkPath);
 }
 
+/**
+ * Provides remove path for the lifecycle pipeline.
+ */
 export async function removePath(targetPath: string): Promise<void> {
   await rm(targetPath, { recursive: true, force: true });
 }
 
+/**
+ * Ensures ensure clean directory exists or is ready for use.
+ */
 export async function ensureCleanDirectory(
   directoryPath: string,
 ): Promise<void> {
@@ -293,10 +394,18 @@ export async function ensureCleanDirectory(
   await ensureDirectory(directoryPath);
 }
 
-export function createContentHash(content: string): string {
-  return createHash("sha256").update(content, "utf8").digest("hex");
+/**
+ * Creates content hash for use by the lifecycle pipeline.
+ */
+export function createContentHash(content: string | Buffer): string {
+  return typeof content === "string"
+    ? createHash("sha256").update(content, "utf8").digest("hex")
+    : createHash("sha256").update(content).digest("hex");
 }
 
+/**
+ * Provides upsert managed section for the lifecycle pipeline.
+ */
 export function upsertManagedSection(options: {
   originalContent: string;
   markerId: string;
@@ -321,6 +430,9 @@ export function upsertManagedSection(options: {
     : `${sectionContent}\n`;
 }
 
+/**
+ * Provides remove managed section for the lifecycle pipeline.
+ */
 export function removeManagedSection(options: {
   originalContent: string;
   markerId: string;
@@ -347,10 +459,16 @@ function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
+/**
+ * Provides to posix path for the lifecycle pipeline.
+ */
 export function toPosixPath(filePath: string): string {
   return filePath.split(sep).join("/");
 }
 
+/**
+ * Provides to relative posix path for the lifecycle pipeline.
+ */
 export function toRelativePosixPath(
   rootPath: string,
   filePath: string,
@@ -358,6 +476,9 @@ export function toRelativePosixPath(
   return toPosixPath(relative(rootPath, filePath));
 }
 
+/**
+ * Provides count non empty lines for the lifecycle pipeline.
+ */
 export function countNonEmptyLines(content: string): number {
   return content
     .split(/\r?\n/u)
@@ -365,6 +486,9 @@ export function countNonEmptyLines(content: string): number {
     .filter((line) => line.length > 0).length;
 }
 
+/**
+ * Describes scan budget options data exchanged by the lifecycle pipeline.
+ */
 export interface ScanBudgetOptions {
   maxDepth?: number;
   maxFiles?: number;
@@ -380,6 +504,9 @@ interface IgnorePattern {
   regex: RegExp;
 }
 
+/**
+ * Describes scan budget telemetry data exchanged by the lifecycle pipeline.
+ */
 export interface ScanBudgetTelemetry {
   visitedFiles: number;
   visitedBytes: number;
@@ -387,6 +514,9 @@ export interface ScanBudgetTelemetry {
   truncationReason?: string;
 }
 
+/**
+ * Provides list files recursive for the lifecycle pipeline.
+ */
 export async function listFilesRecursive(
   rootPath: string,
   ignoredDirectoryNames: ReadonlySet<string> = DEFAULT_IGNORED_DIRECTORY_NAMES,
@@ -399,6 +529,9 @@ export async function listFilesRecursive(
   ).then((result) => result.files);
 }
 
+/**
+ * Provides list files recursive with telemetry for the lifecycle pipeline.
+ */
 export async function listFilesRecursiveWithTelemetry(
   rootPath: string,
   ignoredDirectoryNames: ReadonlySet<string> = DEFAULT_IGNORED_DIRECTORY_NAMES,
@@ -451,6 +584,8 @@ async function collectFilesFromDirectory(
 
   const entries = await readdir(directoryPath, { withFileTypes: true });
   const collectedFiles: string[] = [];
+  const fileEntries: Array<{ entryPath: string; relativeEntryPath: string }> =
+    [];
 
   for (const entry of entries) {
     if (telemetry.truncated) {
@@ -462,7 +597,11 @@ async function collectFilesFromDirectory(
 
     if (entry.isDirectory()) {
       if (
-        ignoredDirectoryNames.has(entry.name) ||
+        shouldSkipDefaultIgnoredDirectory(
+          relativeEntryPath,
+          entry.name,
+          ignoredDirectoryNames,
+        ) ||
         shouldSkipIgnoredDirectory(
           relativeEntryPath,
           entry.name,
@@ -497,33 +636,77 @@ async function collectFilesFromDirectory(
         continue;
       }
 
-      let fileSize: number;
-      try {
-        fileSize = (await lstat(entryPath)).size;
-      } catch {
-        continue;
-      }
-
-      telemetry.visitedFiles += 1;
-      telemetry.visitedBytes += fileSize;
-
-      if (telemetry.visitedFiles > budgetOptions.maxFiles) {
-        telemetry.truncated = true;
-        telemetry.truncationReason = "max-files";
-        break;
-      }
-
-      if (telemetry.visitedBytes > budgetOptions.maxBytes) {
-        telemetry.truncated = true;
-        telemetry.truncationReason = "max-bytes";
-        break;
-      }
-
-      collectedFiles.push(entryPath);
+      fileEntries.push({ entryPath, relativeEntryPath });
     }
   }
 
+  const fileStats = await mapWithConcurrency(
+    fileEntries,
+    FILE_STAT_CONCURRENCY,
+    async (fileEntry) => {
+      if (telemetry.truncated) {
+        return null;
+      }
+
+      const stats = await lstat(fileEntry.entryPath).catch(() => null);
+      return stats?.isFile() ? { ...fileEntry, size: stats.size } : null;
+    },
+  );
+
+  for (const fileStat of fileStats) {
+    if (telemetry.truncated) {
+      break;
+    }
+    if (fileStat === null) {
+      continue;
+    }
+
+    telemetry.visitedFiles += 1;
+    telemetry.visitedBytes += fileStat.size;
+
+    if (telemetry.visitedFiles > budgetOptions.maxFiles) {
+      telemetry.truncated = true;
+      telemetry.truncationReason = "max-files";
+      break;
+    }
+
+    if (telemetry.visitedBytes > budgetOptions.maxBytes) {
+      telemetry.truncated = true;
+      telemetry.truncationReason = "max-bytes";
+      break;
+    }
+
+    collectedFiles.push(fileStat.entryPath);
+  }
+
   return collectedFiles;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  task: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let index = 0; index < values.length; index += concurrency) {
+    results.push(
+      ...(await Promise.all(
+        values.slice(index, index + concurrency).map(task),
+      )),
+    );
+  }
+  return results;
+}
+
+function shouldSkipDefaultIgnoredDirectory(
+  relativeEntryPath: string,
+  entryName: string,
+  ignoredDirectoryNames: ReadonlySet<string>,
+): boolean {
+  return (
+    ignoredDirectoryNames.has(entryName) ||
+    ignoredDirectoryNames.has(relativeEntryPath)
+  );
 }
 
 async function loadIgnorePatterns(rootPath: string): Promise<IgnorePattern[]> {

--- a/src/github.ts
+++ b/src/github.ts
@@ -3,8 +3,8 @@ import { join } from "node:path";
 import { getRuntimeConfig } from "./config/runtime.js";
 import { readJsonFileOrNull, writeJsonFile } from "./files.js";
 import { readResponseTextWithLimit } from "./lib/http.js";
-import { assertGitHubRepoSnapshot } from "./manifest-validation.js";
-import type { SourceDefinition } from "./types.js";
+import { assertGitHubRepoSnapshot } from "./manifest-validation/discovery.js";
+import type { GitHubRepoSnapshot, SourceDefinition } from "./types.js";
 
 interface GitHubRepoResponse {
   name: string;
@@ -159,43 +159,6 @@ interface GitHubDegradedModeSummary {
   degradedSources: GitHubSourceHealthEntry[];
 }
 
-export interface GitHubRepoSnapshot {
-  owner: string;
-  repo: string;
-  sourceId: string;
-  fetchedAt: string;
-  repoSummary: {
-    name: string;
-    fullName: string;
-    description: string | null;
-    defaultBranch: string;
-    updatedAt: string | null;
-    pushedAt: string | null;
-    stars: number;
-    language: string | null;
-    topics: string[];
-    archived: boolean;
-    htmlUrl: string;
-  };
-  readme: {
-    path: string;
-    sha: string;
-    size: number;
-    htmlUrl: string | null;
-    downloadUrl: string | null;
-  } | null;
-  tree: {
-    sha: string;
-    truncated: boolean;
-    entries: Array<{
-      path: string;
-      type: string;
-      size: number | null;
-      sha: string;
-    }>;
-  };
-}
-
 const GITHUB_API_BASE_URL = "https://api.github.com";
 const GITHUB_FETCH_TIMEOUT_MS = 10000;
 const GITHUB_JSON_MAX_BYTES = 2_000_000;
@@ -211,8 +174,12 @@ const GITHUB_DEGRADED_SUMMARY_PATH = [
   "github",
   "degraded-summary.json",
 ];
-const GITHUB_REPO_URL_PATTERN =
+const GITHUB_HTTPS_REPO_URL_PATTERN =
   /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/iu;
+const GITHUB_SCP_REPO_URL_PATTERN =
+  /^git@github\.com:([^/]+)\/(.+?)(?:\.git)?$/iu;
+const GITHUB_SSH_REPO_URL_PATTERN =
+  /^ssh:\/\/git@github\.com\/([^/]+)\/(.+?)(?:\.git)?\/?$/iu;
 let githubRateLimitResetAt: number | null = null;
 let githubHealthUpdateLock: Promise<void> = Promise.resolve();
 
@@ -225,31 +192,44 @@ export function clearGitHubState(): void {
   githubHealthUpdateLock = Promise.resolve();
 }
 
+/**
+ * Returns whether the provided value matches git hub repo source.
+ */
 export function isGitHubRepoSource(source: SourceDefinition): boolean {
   const repoUrl = source.endpoints.repo;
   return (
     source.kind === "repo" &&
     typeof repoUrl === "string" &&
-    GITHUB_REPO_URL_PATTERN.test(repoUrl)
+    parseGitHubRepoCoordinates(repoUrl) !== null
   );
 }
 
+/**
+ * Provides parse git hub repo coordinates for the lifecycle pipeline.
+ */
 export function parseGitHubRepoCoordinates(repoUrl: string): {
   owner: string;
   repo: string;
 } | null {
-  const match = GITHUB_REPO_URL_PATTERN.exec(repoUrl);
+  const normalizedRepoUrl = repoUrl.trim().replace(/^git\+/iu, "");
+  const match =
+    GITHUB_HTTPS_REPO_URL_PATTERN.exec(normalizedRepoUrl) ??
+    GITHUB_SCP_REPO_URL_PATTERN.exec(normalizedRepoUrl) ??
+    GITHUB_SSH_REPO_URL_PATTERN.exec(normalizedRepoUrl);
 
-  if (!match) {
+  if (!match?.[1] || !match[2]) {
     return null;
   }
 
   return {
     owner: match[1],
-    repo: match[2],
+    repo: match[2].replace(/\.git$/iu, ""),
   };
 }
 
+/**
+ * Fetches git hub repo snapshot with the configured runtime safeguards.
+ */
 export async function fetchGitHubRepoSnapshot(
   source: SourceDefinition,
   projectRoot: string,
@@ -273,6 +253,9 @@ export async function fetchGitHubRepoSnapshot(
   });
 }
 
+/**
+ * Fetches git hub repo snapshot by repo url with the configured runtime safeguards.
+ */
 export async function fetchGitHubRepoSnapshotByRepoUrl(options: {
   repoUrl: string;
   projectRoot: string;
@@ -291,6 +274,9 @@ export async function fetchGitHubRepoSnapshotByRepoUrl(options: {
   });
 }
 
+/**
+ * Builds git hub raw file url from the provided inputs.
+ */
 export function buildGitHubRawFileUrl(options: {
   owner: string;
   repo: string;

--- a/src/host-adapters/extension-installer.ts
+++ b/src/host-adapters/extension-installer.ts
@@ -6,8 +6,14 @@ import type { AssetCatalogEntry } from "../types.js";
 
 const execFileAsync = promisify(execFile);
 
+/**
+ * Defines the supported extension install operation values.
+ */
 export type ExtensionInstallOperation = "install" | "verify" | "remove";
 
+/**
+ * Describes extension install action data exchanged by the lifecycle pipeline.
+ */
 export interface ExtensionInstallAction {
   host: string;
   extensionId: string;
@@ -20,6 +26,9 @@ export interface ExtensionInstallAction {
   removeCommand: string;
 }
 
+/**
+ * Describes native install result data exchanged by the lifecycle pipeline.
+ */
 export interface NativeInstallResult {
   host: string;
   extensionId: string;
@@ -32,12 +41,18 @@ export interface NativeInstallResult {
   message: string;
 }
 
+/**
+ * Describes native command result data exchanged by the lifecycle pipeline.
+ */
 export interface NativeCommandResult {
   exitCode: number;
   stdout: string;
   stderr: string;
 }
 
+/**
+ * Defines the supported native command executor values.
+ */
 export type NativeCommandExecutor = (
   executable: string,
   args: string[],
@@ -48,6 +63,9 @@ const VS_CODE_EXTENSION_ID_PATTERN =
 const NATIVE_COMMAND_TIMEOUT_MS = 30_000;
 const NATIVE_COMMAND_MAX_BUFFER_BYTES = 2_000_000;
 
+/**
+ * Builds vs code extension install actions from the provided inputs.
+ */
 export function buildVsCodeExtensionInstallActions(
   extensionIds: string[],
 ): ExtensionInstallAction[] {
@@ -58,6 +76,9 @@ export function buildVsCodeExtensionInstallActions(
   });
 }
 
+/**
+ * Builds extension install actions from the provided inputs.
+ */
 export function buildExtensionInstallActions(options: {
   extensionIds: string[];
   executable: string;
@@ -84,10 +105,16 @@ export function buildExtensionInstallActions(options: {
     });
 }
 
+/**
+ * Returns whether the provided value matches valid vs code extension id.
+ */
 export function isValidVsCodeExtensionId(extensionId: string): boolean {
   return VS_CODE_EXTENSION_ID_PATTERN.test(extensionId);
 }
 
+/**
+ * Resolves vs code extension id from the provided inputs.
+ */
 export function resolveVsCodeExtensionId(
   asset: AssetCatalogEntry,
 ): string | undefined {
@@ -98,6 +125,9 @@ export function resolveVsCodeExtensionId(
   );
 }
 
+/**
+ * Formats extension install actions for user-facing output.
+ */
 export function formatExtensionInstallActions(
   actions: ExtensionInstallAction[],
 ): string[] {
@@ -107,6 +137,9 @@ export function formatExtensionInstallActions(
   );
 }
 
+/**
+ * Executes execute extension install action through the configured runtime executor.
+ */
 export async function executeExtensionInstallAction(
   action: ExtensionInstallAction,
   operation: ExtensionInstallOperation,
@@ -149,6 +182,9 @@ export async function executeExtensionInstallAction(
   };
 }
 
+/**
+ * Verifies verify extension install action using host runtime output.
+ */
 export async function verifyExtensionInstallAction(
   action: ExtensionInstallAction,
   executor: NativeCommandExecutor = executeNativeCommand,
@@ -176,6 +212,9 @@ export async function verifyExtensionInstallAction(
   };
 }
 
+/**
+ * Verifies verify vs code extension installed using host runtime output.
+ */
 export function verifyVsCodeExtensionInstalled(
   listExtensionsOutput: string,
   extensionId: string,

--- a/src/host-adapters/native-wire.ts
+++ b/src/host-adapters/native-wire.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import {
@@ -12,6 +11,7 @@ import {
   writeJsonFile,
   writeTextFile,
 } from "../files.js";
+import { sanitizeAssetId } from "../lib/safe-paths.js";
 import { readSharedMcpAssetIds } from "../lib/shared-mcp.js";
 import type {
   ActivationManifest,
@@ -21,8 +21,11 @@ import type {
   WirePlanManifest,
   WirePreviewManifest,
 } from "../types.js";
-import type { WireMode } from "./registry.js";
+import type { WireMode } from "./types.js";
 
+/**
+ * Defines the supported native wire host values.
+ */
 export type NativeWireHost = "cursor" | "zed" | "claude-code" | "pi";
 
 type LifecycleActivationHost = "copilot-vscode" | "opencode";
@@ -131,6 +134,9 @@ const NATIVE_HOST_SPECS: Record<NativeWireHost, NativeHostSpec> = {
   },
 };
 
+/**
+ * Provides wire native host for the lifecycle pipeline.
+ */
 export async function wireNativeHost(
   host: NativeWireHost,
   options: {
@@ -164,7 +170,6 @@ export async function wireNativeHost(
   );
 
   if (options.mode === "preview") {
-    await removePath(join(hostActivationRoot, "wire-plan.json"));
     return;
   }
 
@@ -270,7 +275,7 @@ async function readNativeAssetFromActivation(
   activationRoot: string,
   assetId: string,
 ): Promise<NativeAsset | null> {
-  const assetRoot = join(activationRoot, sanitizeActivationAssetId(assetId));
+  const assetRoot = join(activationRoot, sanitizeAssetId(assetId));
   const asset = await readJsonFileOrNull<AssetCatalogEntry>(
     join(assetRoot, "asset.json"),
   );
@@ -915,17 +920,6 @@ function sortMaterializedAssets(
 
 function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)].sort((left, right) => left.localeCompare(right));
-}
-
-function sanitizeActivationAssetId(value: string): string {
-  return value.replace(/[^a-zA-Z0-9_-]+/gu, "-");
-}
-
-function sanitizeAssetId(value: string): string {
-  const base =
-    value.replace(/[^a-zA-Z0-9_-]+/gu, "-").replace(/^-+|-+$/gu, "") || "asset";
-  const suffix = createHash("sha256").update(value).digest("hex").slice(0, 12);
-  return `${base}-${suffix}`;
 }
 
 type JsonObject = Record<string, unknown>;

--- a/src/host-adapters/opencode.ts
+++ b/src/host-adapters/opencode.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { isAbsolute, join, relative, resolve } from "node:path";
 
 import {
@@ -16,6 +15,7 @@ import {
   writeTextFile,
 } from "../files.js";
 import { assertWirePlanManifest } from "../manifest-validation.js";
+import { sanitizeAssetId } from "../lib/safe-paths.js";
 import { readSharedMcpAssetIds } from "../lib/shared-mcp.js";
 import type {
   ActivationManifest,
@@ -46,6 +46,9 @@ interface OpenCodeLinkedAsset {
   linkPath: string;
 }
 
+/**
+ * Provides wire open code for the lifecycle pipeline.
+ */
 export async function wireOpenCode(options: {
   projectRoot: string;
   workspaceRoot: string;
@@ -375,13 +378,6 @@ function isPathWithinRoot(pathValue: string, rootPath: string): boolean {
     relativePath === "" ||
     (!relativePath.startsWith("..") && !isAbsolute(relativePath))
   );
-}
-
-function sanitizeAssetId(value: string): string {
-  const base =
-    value.replace(/[^a-zA-Z0-9_-]+/gu, "-").replace(/^-+|-+$/gu, "") || "asset";
-  const suffix = createHash("sha256").update(value).digest("hex").slice(0, 12);
-  return `${base}-${suffix}`;
 }
 
 function toLoggableErrorMessage(error: unknown): string {

--- a/src/host-adapters/registry.ts
+++ b/src/host-adapters/registry.ts
@@ -1,4 +1,5 @@
 import type { AssetCatalogEntry, AssetKind, HostTarget } from "../types.js";
+import type { WireMode } from "./types.js";
 import { wireOpenCode } from "./opencode.js";
 import { wireVsCode } from "./vscode.js";
 import { wireNativeHost } from "./native-wire.js";
@@ -9,8 +10,15 @@ import {
   type ExtensionInstallAction,
 } from "./extension-installer.js";
 
+export type { WireMode } from "./types.js";
+
+/**
+ * Defines the supported lifecycle host values.
+ */
 export type LifecycleHost = "copilot-vscode" | "opencode";
-export type WireMode = "preview" | "apply" | "reset";
+/**
+ * Defines the supported host behavior values.
+ */
 export type HostBehavior =
   | "stage"
   | "wire"
@@ -18,11 +26,17 @@ export type HostBehavior =
   | "auth-assist"
   | "runtime-validation";
 
+/**
+ * Describes host capability data exchanged by the lifecycle pipeline.
+ */
 export interface HostCapability {
   assetKind: AssetKind;
   behaviors: HostBehavior[];
 }
 
+/**
+ * Describes host runtime spec data exchanged by the lifecycle pipeline.
+ */
 export interface HostRuntimeSpec {
   executable: string;
   versionArgs?: string[];
@@ -31,11 +45,17 @@ export interface HostRuntimeSpec {
   requiredFor?: HostBehavior[];
 }
 
+/**
+ * Describes host native install provider data exchanged by the lifecycle pipeline.
+ */
 export interface HostNativeInstallProvider {
   assetKind: AssetKind;
   collectActions(assets: AssetCatalogEntry[]): ExtensionInstallAction[];
 }
 
+/**
+ * Describes host adapter data exchanged by the lifecycle pipeline.
+ */
 export interface HostAdapter {
   id: string;
   aliases: string[];
@@ -101,6 +121,7 @@ const DEFAULT_HOST_ADAPTERS: HostAdapter[] = [
     requiresLifecycleHostPaths: true,
     runtime: {
       executable: "code",
+      versionArgs: ["--version"],
       readinessArgs: ["--list-extensions", "--show-versions"],
       guidance:
         "Install the VS Code CLI and ensure the 'code' command is available on PATH for native extension install and verification.",
@@ -130,6 +151,7 @@ const DEFAULT_HOST_ADAPTERS: HostAdapter[] = [
     requiresLifecycleHostPaths: false,
     runtime: {
       executable: "opencode",
+      versionArgs: ["--version"],
       guidance:
         "Install the OpenCode CLI if you want runtime validation beyond project-local overlay wiring.",
     },
@@ -147,6 +169,7 @@ const DEFAULT_HOST_ADAPTERS: HostAdapter[] = [
     requiresLifecycleHostPaths: false,
     runtime: {
       executable: "cursor",
+      versionArgs: ["--version"],
       readinessArgs: ["--list-extensions", "--show-versions"],
       guidance:
         "Install the Cursor CLI if you want runtime validation and native extension install/verification beyond project-local file wiring.",
@@ -178,6 +201,7 @@ const DEFAULT_HOST_ADAPTERS: HostAdapter[] = [
     requiresLifecycleHostPaths: false,
     runtime: {
       executable: "zed",
+      versionArgs: ["--version"],
       guidance:
         "Install the Zed CLI if you want runtime validation beyond project-local file wiring.",
     },
@@ -195,6 +219,7 @@ const DEFAULT_HOST_ADAPTERS: HostAdapter[] = [
     requiresLifecycleHostPaths: false,
     runtime: {
       executable: "claude",
+      versionArgs: ["--version"],
       guidance:
         "Install the Claude Code CLI if you want runtime validation beyond project-local file wiring.",
     },
@@ -212,6 +237,7 @@ const DEFAULT_HOST_ADAPTERS: HostAdapter[] = [
     requiresLifecycleHostPaths: false,
     runtime: {
       executable: "pi",
+      versionArgs: ["--version"],
       guidance:
         "Install the Pi CLI if you want runtime validation beyond project-local file wiring.",
     },
@@ -224,6 +250,9 @@ const hostAdapters = [...DEFAULT_HOST_ADAPTERS];
 
 const HOST_TARGET_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
 
+/**
+ * Provides register host adapter for the lifecycle pipeline.
+ */
 export function registerHostAdapter(adapter: HostAdapter): void {
   const normalizedId = adapter.id.toLowerCase();
   const existingIndex = hostAdapters.findIndex(

--- a/src/host-adapters/types.ts
+++ b/src/host-adapters/types.ts
@@ -1,0 +1,4 @@
+/**
+ * Defines the supported wire mode values.
+ */
+export type WireMode = "preview" | "apply" | "reset";

--- a/src/host-adapters/vscode-settings.ts
+++ b/src/host-adapters/vscode-settings.ts
@@ -8,6 +8,9 @@ import {
   writeTextFile,
 } from "../files.js";
 
+/**
+ * Reads vs code settings from project state.
+ */
 export async function readVsCodeSettings(
   settingsPath: string,
 ): Promise<Record<string, unknown>> {
@@ -40,6 +43,9 @@ export async function readVsCodeSettings(
   return parsedSettings as Record<string, unknown>;
 }
 
+/**
+ * Provides patch vs code settings for the lifecycle pipeline.
+ */
 export async function patchVsCodeSettings(
   settingsPath: string,
   updates: Record<string, unknown>,

--- a/src/host-adapters/vscode.ts
+++ b/src/host-adapters/vscode.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { basename, extname, join } from "node:path";
 import { readdir, stat } from "node:fs/promises";
@@ -32,9 +31,13 @@ import {
   toHomeRelativePath,
   resolveVsCodeUserSettingsPath,
 } from "../lib/paths.js";
+import { sanitizeAssetId } from "../lib/safe-paths.js";
 import { readSharedMcpAssetIds } from "../lib/shared-mcp.js";
 import { patchVsCodeSettings, readVsCodeSettings } from "./vscode-settings.js";
 
+/**
+ * Provides wire vs code for the lifecycle pipeline.
+ */
 export async function wireVsCode(options: {
   projectRoot: string;
   workspaceRoot: string;
@@ -673,10 +676,6 @@ function buildVsCodeSkillLocationOverrides(
   curatedRoot: string,
 ): Record<string, boolean> {
   return {
-    "~/.copilot/skills": false,
-    "~/.agents/skills": false,
-    "~/.claude/skills": false,
-    "~/.config/opencode/skills": false,
     [toHomePath(join(curatedRoot, "skills"))]: true,
   };
 }
@@ -736,6 +735,9 @@ interface MaterializedVsCodePaths {
   extensionIds: string[];
 }
 
+/**
+ * Builds copilot workspace overlay manifest from the provided inputs.
+ */
 export function buildCopilotWorkspaceOverlayManifest(options: {
   workspaceRoot: string;
   overlayPlan: CopilotWorkspaceOverlayManifest;
@@ -744,13 +746,6 @@ export function buildCopilotWorkspaceOverlayManifest(options: {
     ...options.overlayPlan,
     workspaceRoot: toPosixPath(options.workspaceRoot),
   };
-}
-
-function sanitizeAssetId(value: string): string {
-  const base =
-    value.replace(/[^a-zA-Z0-9_-]+/gu, "-").replace(/^-+|-+$/gu, "") || "asset";
-  const suffix = createHash("sha256").update(value).digest("hex").slice(0, 12);
-  return `${base}-${suffix}`;
 }
 
 function toHomePath(pathValue: string): string {

--- a/src/install.ts
+++ b/src/install.ts
@@ -7,6 +7,9 @@ import {
 import { manageNativeInstall } from "./install/native.js";
 import { reconcileInstallState, resetInstallState } from "./install/state.js";
 
+/**
+ * Dispatches the install CLI command group.
+ */
 export async function runInstall(
   args: string[],
   _workingDirectory: string,

--- a/src/install/bundle.ts
+++ b/src/install/bundle.ts
@@ -7,10 +7,10 @@ import {
   ensureCleanDirectory,
   listFilesRecursive,
   pathExists,
+  readBinaryFileOrNull,
   readJsonFile,
   readJsonFileOrNull,
   readJsonLinesFile,
-  readTextFileOrNull,
   toPosixPath,
   toRelativePosixPath,
   writeJsonFile,
@@ -26,6 +26,7 @@ import {
   assertBundleLock,
   assertInstallProgressState,
   assertInstalledBundleManifest,
+  assertInstalledPackageManifest,
   assertMirrorIndexEntry,
 } from "../manifest-validation.js";
 import type {
@@ -43,6 +44,9 @@ import {
 } from "./state.js";
 import { getInstallableAssets, sanitizeAssetId } from "./utils.js";
 
+/**
+ * Provides install bundles for the lifecycle pipeline.
+ */
 export async function installBundles(
   projectRoot: string,
   args: string[],
@@ -168,6 +172,18 @@ export async function installBundles(
       await ensureCleanDirectory(filesRoot);
       await copyMirrorManifestFiles(sourceMaterialPath, filesRoot, mirrorManifest);
 
+      const manifestPath = join(packageRoot, "install-manifest.json");
+      const previousPackageManifest =
+        await readJsonFileOrNull<InstalledPackageManifest>(
+          manifestPath,
+          assertInstalledPackageManifest,
+        );
+      const bundleMembership = [
+        ...new Set([
+          ...(previousPackageManifest?.bundleMembership ?? []),
+          bundleLock.bundleId,
+        ]),
+      ].sort((left, right) => left.localeCompare(right));
       const packageManifest: InstalledPackageManifest = {
         schemaVersion: 1,
         assetId: asset.assetId,
@@ -180,12 +196,11 @@ export async function installBundles(
         contextCost: catalogEntry.contextCost,
         portfolioFit: catalogEntry.fit.portfolioFit,
         filesRoot: toPosixPath(filesRoot),
-        bundleMembership: [bundleLock.bundleId],
+        bundleMembership,
         activationEligible: asset.activationEligible,
         activeByDefault: false,
       };
 
-      const manifestPath = join(packageRoot, "install-manifest.json");
       await writeJsonFile(manifestPath, packageManifest);
       packageManifests.push({
         assetId: asset.assetId,
@@ -264,6 +279,7 @@ interface MirrorFileManifest {
     relativePath: string;
     sha256: string;
     sizeBytes: number;
+    upstreamBlobSha?: string;
   }>;
 }
 
@@ -292,22 +308,20 @@ async function verifyMirrorFileManifest(
       sourceMaterialPath,
       file.relativePath,
     );
-    const content = await readTextFileOrNull(filePath);
+    const content = await readBinaryFileOrNull(filePath);
     if (content === null) {
       throw new Error(`Mirror artifact file is missing: ${file.relativePath}`);
     }
 
     const actualHash = createContentHash(content);
-    const actualSize = Buffer.byteLength(content, "utf8");
+    const actualSize = content.byteLength;
     if (actualHash !== file.sha256 || actualSize !== file.sizeBytes) {
       throw new Error(`Mirror artifact hash mismatch: ${file.relativePath}`);
     }
   }
 
   const aggregateHash = createContentHash(
-    normalizedFiles
-      .map((file) => `${file.relativePath}\0${file.sha256}\0${file.sizeBytes}`)
-      .join("\n"),
+    normalizedFiles.map(serializeMirrorManifestFileHashInput).join("\n"),
   );
   if (aggregateHash !== manifest.aggregateHash) {
     throw new Error("Mirror artifact manifest aggregate hash mismatch");
@@ -355,7 +369,26 @@ function assertMirrorFileManifest(
     if (typeof fileRecord.sizeBytes !== "number") {
       throw new Error(`${context}.files[${index}].sizeBytes must be a number`);
     }
+    if (
+      fileRecord.upstreamBlobSha !== undefined &&
+      typeof fileRecord.upstreamBlobSha !== "string"
+    ) {
+      throw new Error(
+        `${context}.files[${index}].upstreamBlobSha must be a string`,
+      );
+    }
   });
+}
+
+function serializeMirrorManifestFileHashInput(
+  file: MirrorFileManifest["files"][number],
+): string {
+  return [
+    file.relativePath,
+    file.sha256,
+    String(file.sizeBytes),
+    file.upstreamBlobSha ?? "",
+  ].join("\0");
 }
 
 async function copyMirrorManifestFiles(

--- a/src/install/generations.ts
+++ b/src/install/generations.ts
@@ -50,6 +50,9 @@ function validateGenerationId(value: string | undefined): string | undefined {
   return value;
 }
 
+/**
+ * Provides diff install state for the lifecycle pipeline.
+ */
 export async function diffInstallState(
   projectRoot: string,
   args: string[],
@@ -96,6 +99,9 @@ export async function diffInstallState(
   }
 }
 
+/**
+ * Provides explain installed asset for the lifecycle pipeline.
+ */
 export async function explainInstalledAsset(
   projectRoot: string,
   args: string[],
@@ -152,6 +158,9 @@ export async function explainInstalledAsset(
   console.log(lines.join("\n"));
 }
 
+/**
+ * Provides manage install generations for the lifecycle pipeline.
+ */
 export async function manageInstallGenerations(
   projectRoot: string,
   args: string[],

--- a/src/install/native.ts
+++ b/src/install/native.ts
@@ -29,6 +29,9 @@ import { sanitizeAssetId } from "./utils.js";
 
 type NativeInstallCliOperation = "plan" | ExtensionInstallOperation;
 
+/**
+ * Provides native install management for the lifecycle pipeline.
+ */
 export async function manageNativeInstall(
   projectRoot: string,
   args: string[],

--- a/src/install/paths.ts
+++ b/src/install/paths.ts
@@ -1,17 +1,29 @@
+/**
+ * Defines the install progress state output path location used by persisted project state.
+ */
 export const INSTALL_PROGRESS_STATE_OUTPUT_PATH = [
   "state",
   "install",
   "progress.json",
 ];
 
+/**
+ * Defines install generations root shared by the lifecycle pipeline.
+ */
 export const INSTALL_GENERATIONS_ROOT = ["install", "generations"];
 
+/**
+ * Defines the install progress snapshot output path location used by persisted project state.
+ */
 export const INSTALL_PROGRESS_SNAPSHOT_OUTPUT_PATH = [
   "state",
   "install",
   "progress.previous.json",
 ];
 
+/**
+ * Defines the native install state output path location used by persisted project state.
+ */
 export const NATIVE_INSTALL_STATE_OUTPUT_PATH = [
   "state",
   "install",

--- a/src/install/state.ts
+++ b/src/install/state.ts
@@ -32,6 +32,9 @@ import {
 } from "./paths.js";
 import { getInstallableAssets, INSTALL_HOSTS } from "./utils.js";
 
+/**
+ * Updates update install progress state state with the provided inputs.
+ */
 export async function updateInstallProgressState(
   projectRoot: string,
   bundleId: string,
@@ -72,6 +75,9 @@ export async function updateInstallProgressState(
   );
 }
 
+/**
+ * Reconciles reconcile install state state from persisted manifests.
+ */
 export async function reconcileInstallState(projectRoot: string): Promise<void> {
   const mirrorIndexEntries = await readJsonLinesFile<MirrorIndexEntry>(
     join(projectRoot, "mirror", "index.jsonl"),
@@ -160,6 +166,9 @@ export async function reconcileInstallState(projectRoot: string): Promise<void> 
   );
 }
 
+/**
+ * Resets reset install state state and generated outputs.
+ */
 export async function resetInstallState(projectRoot: string): Promise<void> {
   await removePath(join(projectRoot, "install"));
   await removePath(join(projectRoot, "state", "install"));
@@ -168,6 +177,9 @@ export async function resetInstallState(projectRoot: string): Promise<void> {
   );
 }
 
+/**
+ * Writes install generations to project state.
+ */
 export async function writeInstallGenerations(
   projectRoot: string,
   progressState: InstallProgressState,

--- a/src/install/utils.ts
+++ b/src/install/utils.ts
@@ -5,15 +5,23 @@ import type { BundleLock, MirrorIndexEntry } from "../types.js";
 type InstallHost = LifecycleHost | "shared";
 
 // Install roots are the registered lifecycle hosts plus the shared MCP root.
+/**
+ * Defines install hosts shared by the lifecycle pipeline.
+ */
 export const INSTALL_HOSTS = [
   "opencode",
   "copilot-vscode",
   "shared",
 ] as const satisfies readonly InstallHost[];
 
+/**
+ * Re-exports package-safe asset identifier sanitization for install callers.
+ */
 export { sanitizeAssetId };
 
-
+/**
+ * Returns get installable assets for the provided inputs.
+ */
 export function getInstallableAssets(
   bundleAssets: BundleLock["assets"],
   mirrorIndexById: Map<string, MirrorIndexEntry>,

--- a/src/lib/asset-prerequisites.ts
+++ b/src/lib/asset-prerequisites.ts
@@ -3,7 +3,10 @@ import { join } from "node:path";
 import { getRuntimeConfig } from "../config/runtime.js";
 import { readJsonFileOrNull } from "../files.js";
 import { sanitizeAssetId } from "./safe-paths.js";
-import type { HostAdapter } from "../host-adapters/registry.js";
+import {
+  resolveHostAdapter,
+  type HostAdapter,
+} from "../host-adapters/registry.js";
 import type {
   ActivationManifest,
   AssetCatalogEntry,
@@ -19,9 +22,14 @@ const PROVIDER_ENV_VARS: Record<string, string[]> = {
   sentry: ["SENTRY_AUTH_TOKEN"],
 };
 
+/**
+ * Builds asset prerequisites from metadata from the provided inputs.
+ */
 export function buildAssetPrerequisitesFromMetadata(options: {
   providers: string[];
   envVars: string[];
+  hostLogins?: string[];
+  oauthProviders?: string[];
   setupUrl?: string;
 }): AssetPrerequisite[] {
   const prerequisites: AssetPrerequisite[] = [];
@@ -52,12 +60,44 @@ export function buildAssetPrerequisitesFromMetadata(options: {
     });
   }
 
+  for (const hostLogin of uniqueStrings(
+    (options.hostLogins ?? []).map(canonicalizeHostLogin),
+  )) {
+    prerequisites.push({
+      id: `host-login:${hostLogin}`,
+      kind: "host-login",
+      required: true,
+      host: hostLogin as AssetPrerequisite["host"],
+      setupUrl: options.setupUrl,
+      description: `Sign in to ${hostLogin}.`,
+    });
+  }
+
+  for (const oauthProvider of uniqueStrings(
+    (options.oauthProviders ?? []).map(normalizeToken),
+  )) {
+    prerequisites.push({
+      id: `oauth:${oauthProvider}`,
+      kind: "oauth",
+      required: true,
+      provider: oauthProvider,
+      setupUrl: options.setupUrl,
+      description: `Complete OAuth authorization for ${oauthProvider}.`,
+    });
+  }
+
   return dedupePrerequisites(prerequisites);
 }
 
+/**
+ * Builds prerequisite diagnostics from the provided inputs.
+ */
 export function buildPrerequisiteDiagnostics(
   asset: AssetCatalogEntry,
-  options: { missingEnvSeverity?: PreflightSeverity } = {},
+  options: {
+    adapter?: HostAdapter;
+    missingEnvSeverity?: PreflightSeverity;
+  } = {},
 ): PreflightDiagnostic[] {
   const prerequisites = asset.install.prerequisites ?? [];
   const missingEnvSeverity = options.missingEnvSeverity ?? "error";
@@ -95,6 +135,28 @@ export function buildPrerequisiteDiagnostics(
       continue;
     }
 
+    if (prerequisite.kind === "host-login") {
+      diagnostics.push(
+        buildHostLoginPrerequisiteDiagnostic(
+          asset,
+          prerequisite,
+          options.adapter,
+        ),
+      );
+      continue;
+    }
+
+    if (prerequisite.kind === "oauth") {
+      diagnostics.push(
+        buildOauthPrerequisiteDiagnostic(
+          asset,
+          prerequisite,
+          missingEnvSeverity,
+        ),
+      );
+      continue;
+    }
+
     diagnostics.push({
       severity: prerequisite.required ? missingEnvSeverity : "info",
       code: `asset-prerequisite-guidance:${asset.id}:${prerequisite.id}`,
@@ -106,6 +168,9 @@ export function buildPrerequisiteDiagnostics(
   return diagnostics;
 }
 
+/**
+ * Collects activated asset prerequisite diagnostics from the provided inputs.
+ */
 export async function collectActivatedAssetPrerequisiteDiagnostics(
   projectRoot: string,
   adapter: HostAdapter,
@@ -113,7 +178,7 @@ export async function collectActivatedAssetPrerequisiteDiagnostics(
 ): Promise<PreflightDiagnostic[]> {
   const assets = await collectActivatedAssets(projectRoot, adapter);
   return assets.flatMap((asset) =>
-    buildPrerequisiteDiagnostics(asset, options),
+    buildPrerequisiteDiagnostics(asset, { ...options, adapter }),
   );
 }
 
@@ -175,10 +240,69 @@ function addAssetId(
   assetMap.set(activationHost, assetIds);
 }
 
+function buildHostLoginPrerequisiteDiagnostic(
+  asset: AssetCatalogEntry,
+  prerequisite: AssetPrerequisite,
+  adapter: HostAdapter | undefined,
+): PreflightDiagnostic {
+  const hostMatches =
+    !prerequisite.host ||
+    !adapter ||
+    [adapter.id, adapter.lifecycleHost, adapter.recommendationHost].includes(
+      prerequisite.host,
+    );
+  return {
+    severity: hostMatches && prerequisite.required ? "warning" : "info",
+    code: `asset-prerequisite-host-login:${asset.id}:${prerequisite.id}`,
+    message: hostMatches
+      ? `${asset.displayName} requires a signed-in ${prerequisite.host ?? "host"} session.`
+      : `${asset.displayName} declares a host login prerequisite for ${prerequisite.host}; current host is ${adapter?.id ?? "unknown"}.`,
+    action: buildPrerequisiteAction(prerequisite),
+  };
+}
+
+function buildOauthPrerequisiteDiagnostic(
+  asset: AssetCatalogEntry,
+  prerequisite: AssetPrerequisite,
+  missingSeverity: PreflightSeverity,
+): PreflightDiagnostic {
+  const envVars = prerequisite.provider
+    ? (PROVIDER_ENV_VARS[prerequisite.provider] ?? [])
+    : [];
+  const canValidateWithEnv = envVars.length > 0;
+  const env = getRuntimeConfig().env;
+  const hasProviderToken = envVars.some(
+    (envVar) => (env[envVar]?.trim().length ?? 0) > 0,
+  );
+
+  return {
+    severity: hasProviderToken
+      ? "info"
+      : prerequisite.required && canValidateWithEnv
+        ? missingSeverity
+        : "warning",
+    code: hasProviderToken
+      ? `asset-prerequisite-oauth-ready:${asset.id}:${prerequisite.id}`
+      : `asset-prerequisite-oauth:${asset.id}:${prerequisite.id}`,
+    message: hasProviderToken
+      ? `${asset.displayName} OAuth prerequisite has provider credentials configured.`
+      : `${asset.displayName} requires OAuth authorization for ${prerequisite.provider ?? "its provider"}.`,
+    action: hasProviderToken
+      ? undefined
+      : buildPrerequisiteAction(prerequisite),
+  };
+}
+
 function buildPrerequisiteAction(prerequisite: AssetPrerequisite): string {
   const actions: string[] = [];
   if ((prerequisite.envVars?.length ?? 0) > 0) {
     actions.push(`Set ${formatEnvChoices(prerequisite.envVars ?? [])}`);
+  }
+  if (prerequisite.kind === "host-login" && prerequisite.host) {
+    actions.push(`Run setup login --provider ${prerequisite.host}`);
+  }
+  if (prerequisite.kind === "oauth" && prerequisite.provider) {
+    actions.push(`Run setup login --provider ${prerequisite.provider}`);
   }
   if (prerequisite.setupUrl) {
     actions.push(`See ${prerequisite.setupUrl}`);
@@ -212,6 +336,10 @@ function dedupePrerequisites(
 
 function normalizeToken(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function canonicalizeHostLogin(value: string): string {
+  return resolveHostAdapter(value)?.id ?? normalizeToken(value);
 }
 
 function uniqueStrings(values: string[]): string[] {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,18 +1,54 @@
-import { isIP } from "node:net";
+import { lookup } from "node:dns/promises";
+import type { IncomingHttpHeaders } from "node:http";
+import { request } from "node:https";
+import { isIP, type LookupFunction } from "node:net";
+import { Readable } from "node:stream";
 import { TextDecoder } from "node:util";
 
+/**
+ * Describes resolved hostname address data exchanged by the lifecycle pipeline.
+ */
+export interface ResolvedHostnameAddress {
+  address: string;
+  family: 4 | 6;
+}
+
+/**
+ * Defines the supported hostname resolver values.
+ */
+export type HostnameResolver = (
+  hostname: string,
+) => Promise<ResolvedHostnameAddress[]>;
+
+/**
+ * Defines the supported guarded request body values.
+ */
+export type GuardedRequestBody =
+  | string
+  | Buffer
+  | URLSearchParams
+  | ArrayBuffer
+  | ArrayBufferView
+  | null
+  | undefined;
+
+/**
+ * Describes fetch with guards options data exchanged by the lifecycle pipeline.
+ */
 export interface FetchWithGuardsOptions {
   allowedOrigins?: readonly string[];
-  body?: BodyInit;
+  body?: GuardedRequestBody;
   headers?: HeadersInit;
   maxBytes?: number;
   method?: string;
+  resolveHostname?: HostnameResolver;
   signal?: AbortSignal;
   timeoutMs?: number;
 }
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 1_000_000;
+const DEFAULT_FETCH = globalThis.fetch;
 
 /**
  * Performs an HTTP(S) fetch with a timeout. Origin allowlists are enforced by
@@ -52,16 +88,16 @@ export async function fetchTextWithGuards(
   options: FetchWithGuardsOptions = {},
 ): Promise<string | null> {
   try {
-    const parsedUrl = assertAllowedHttpUrl(url, options.allowedOrigins ?? []);
-    const response = await fetchWithTimeout(
-      parsedUrl.toString(),
-      {
-        body: options.body,
-        headers: options.headers,
-        method: options.method,
-        redirect: "error",
-        signal: options.signal,
-      },
+    const { addresses, parsedUrl } =
+      await resolveAllowedPublicHttpUrlForRequest(
+        url,
+        options.allowedOrigins ?? [],
+        options.resolveHostname,
+      );
+    const response = await fetchResolvedUrl(
+      parsedUrl,
+      addresses,
+      options,
       options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     );
 
@@ -71,6 +107,41 @@ export async function fetchTextWithGuards(
     }
 
     return await readResponseTextWithLimit(
+      response,
+      options.maxBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetches bytes with guards with the configured runtime safeguards.
+ */
+export async function fetchBytesWithGuards(
+  url: string,
+  options: FetchWithGuardsOptions = {},
+): Promise<Buffer | null> {
+  try {
+    const { addresses, parsedUrl } =
+      await resolveAllowedPublicHttpUrlForRequest(
+        url,
+        options.allowedOrigins ?? [],
+        options.resolveHostname,
+      );
+    const response = await fetchResolvedUrl(
+      parsedUrl,
+      addresses,
+      options,
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      await response.body?.cancel();
+      return null;
+    }
+
+    return await readResponseBytesWithLimit(
       response,
       options.maxBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
     );
@@ -110,6 +181,25 @@ export function assertAllowedPublicHttpUrl(
   return parsedUrl;
 }
 
+/**
+ * Validates unknown data as allowed public http url with dns.
+ */
+export async function assertAllowedPublicHttpUrlWithDns(
+  url: string,
+  allowedOrigins: readonly string[],
+  resolveHostname: HostnameResolver = resolveHostnameWithDns,
+): Promise<URL> {
+  const { parsedUrl } = await resolveAllowedPublicHttpUrlForRequest(
+    url,
+    allowedOrigins,
+    resolveHostname,
+  );
+  return parsedUrl;
+}
+
+/**
+ * Validates unknown data as allowed http url.
+ */
 export function assertAllowedHttpUrl(
   url: string,
   allowedOrigins: readonly string[],
@@ -130,24 +220,290 @@ export function assertAllowedHttpUrl(
   return parsedUrl;
 }
 
+/**
+ * Validates unknown data as public internet hostname.
+ */
 export function assertPublicInternetHostname(parsedUrl: URL): void {
-  const hostname = parsedUrl.hostname
-    .replace(/^\[|\]$/gu, "")
-    .replace(/\.$/u, "")
-    .toLowerCase();
+  const hostname = normalizeHostname(parsedUrl);
 
   if (hostname === "localhost" || hostname.endsWith(".localhost")) {
     throw new Error(`URL hostname is not public: ${parsedUrl.hostname}`);
   }
 
-  const ipVersion = isIP(hostname);
-  if (ipVersion === 4 && isPrivateIpv4Address(hostname)) {
+  if (isNonPublicIpAddress(hostname)) {
     throw new Error(`URL hostname is not public: ${parsedUrl.hostname}`);
+  }
+}
+
+/**
+ * Validates unknown data as public internet resolution.
+ */
+export async function assertPublicInternetResolution(
+  parsedUrl: URL,
+  resolveHostname: HostnameResolver = resolveHostnameWithDns,
+): Promise<void> {
+  await resolvePublicInternetAddresses(parsedUrl, resolveHostname);
+}
+
+async function resolveAllowedPublicHttpUrlForRequest(
+  url: string,
+  allowedOrigins: readonly string[],
+  resolveHostname: HostnameResolver = resolveHostnameWithDns,
+): Promise<{ parsedUrl: URL; addresses: ResolvedHostnameAddress[] }> {
+  const parsedUrl = assertAllowedPublicHttpUrl(url, allowedOrigins);
+  const addresses = await resolvePublicInternetAddresses(
+    parsedUrl,
+    resolveHostname,
+  );
+  return { parsedUrl, addresses };
+}
+
+async function resolvePublicInternetAddresses(
+  parsedUrl: URL,
+  resolveHostname: HostnameResolver,
+): Promise<ResolvedHostnameAddress[]> {
+  const hostname = normalizeHostname(parsedUrl);
+  const ipVersion = isIP(hostname);
+  const addresses =
+    ipVersion === 4
+      ? [{ address: hostname, family: 4 as const }]
+      : ipVersion === 6
+        ? [{ address: hostname, family: 6 as const }]
+        : await resolveHostname(hostname);
+
+  if (addresses.length === 0) {
+    throw new Error(`URL hostname did not resolve: ${parsedUrl.hostname}`);
   }
 
-  if (ipVersion === 6 && isPrivateIpv6Address(hostname)) {
-    throw new Error(`URL hostname is not public: ${parsedUrl.hostname}`);
+  for (const address of addresses) {
+    if (isNonPublicIpAddress(address.address)) {
+      throw new Error(
+        `URL hostname resolves to a non-public address: ${parsedUrl.hostname}`,
+      );
+    }
   }
+
+  return addresses;
+}
+
+async function fetchResolvedUrl(
+  parsedUrl: URL,
+  addresses: readonly ResolvedHostnameAddress[],
+  options: FetchWithGuardsOptions,
+  timeoutMs: number,
+): Promise<Response> {
+  if (shouldUseTestFetchMock()) {
+    const body = serializeRequestBody(options.body);
+    return fetchWithTimeout(
+      parsedUrl.toString(),
+      {
+        body: toFetchBody(body),
+        headers: buildRequestHeaders(options.headers, body),
+        method: resolveRequestMethod(options.method, body),
+        redirect: "error",
+        signal: options.signal,
+      },
+      timeoutMs,
+    );
+  }
+
+  return fetchWithPinnedResolution(parsedUrl, addresses, options, timeoutMs);
+}
+
+function resolveRequestMethod(
+  requestedMethod: string | undefined,
+  body: string | Buffer | null,
+): string {
+  return requestedMethod ?? (body ? "POST" : "GET");
+}
+
+function toFetchBody(body: string | Buffer | null): BodyInit | null {
+  if (body === null || typeof body === "string") {
+    return body;
+  }
+
+  return body.buffer.slice(
+    body.byteOffset,
+    body.byteOffset + body.byteLength,
+  ) as ArrayBuffer;
+}
+
+function shouldUseTestFetchMock(): boolean {
+  return (
+    process.env.AGENT_HARNESS_TEST_FETCH_MOCKS === "1" &&
+    globalThis.fetch !== DEFAULT_FETCH
+  );
+}
+
+async function fetchWithPinnedResolution(
+  parsedUrl: URL,
+  addresses: readonly ResolvedHostnameAddress[],
+  options: FetchWithGuardsOptions,
+  timeoutMs: number,
+): Promise<Response> {
+  if (addresses.length === 0) {
+    throw new Error(`URL hostname did not resolve: ${parsedUrl.hostname}`);
+  }
+
+  const controller = new AbortController();
+  const abortFromCaller = (): void => {
+    controller.abort(options.signal?.reason);
+  };
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  if (options.signal?.aborted) {
+    abortFromCaller();
+  } else {
+    options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+
+  try {
+    let lastError: unknown = null;
+    for (const address of addresses) {
+      try {
+        return await requestWithPinnedAddress(
+          parsedUrl,
+          address,
+          options,
+          controller.signal,
+        );
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw error;
+        }
+        lastError = error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`All resolved addresses failed for ${parsedUrl.hostname}`);
+  } finally {
+    clearTimeout(timer);
+    options.signal?.removeEventListener("abort", abortFromCaller);
+  }
+}
+
+async function requestWithPinnedAddress(
+  parsedUrl: URL,
+  address: ResolvedHostnameAddress,
+  options: FetchWithGuardsOptions,
+  signal: AbortSignal,
+): Promise<Response> {
+  const body = serializeRequestBody(options.body);
+  const headers = buildRequestHeaders(options.headers, body);
+  const pinnedLookup: LookupFunction = (_hostname, _options, callback) => {
+    callback(null, address.address, address.family);
+  };
+
+  return new Promise((resolve, reject) => {
+    const requestMessage = request(
+      parsedUrl,
+      {
+        headers,
+        lookup: pinnedLookup,
+        method: resolveRequestMethod(options.method, body),
+        signal,
+      },
+      (responseMessage) => {
+        resolve(
+          new Response(Readable.toWeb(responseMessage) as ReadableStream, {
+            headers: buildResponseHeaders(responseMessage.headers),
+            status: responseMessage.statusCode ?? 0,
+            statusText: responseMessage.statusMessage,
+          }),
+        );
+      },
+    );
+    requestMessage.on("error", reject);
+    if (body) {
+      requestMessage.write(body);
+    }
+    requestMessage.end();
+  });
+}
+
+function serializeRequestBody(
+  body: GuardedRequestBody,
+): string | Buffer | null {
+  if (body === undefined || body === null) {
+    return null;
+  }
+
+  if (typeof body === "string" || Buffer.isBuffer(body)) {
+    return body;
+  }
+
+  if (body instanceof URLSearchParams) {
+    return body.toString();
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(body);
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  }
+
+  throw new Error("Unsupported guarded request body type.");
+}
+
+function buildRequestHeaders(
+  headers: HeadersInit | undefined,
+  body: string | Buffer | null,
+): Record<string, string> {
+  const requestHeaders = new Headers(headers);
+  if (body && !requestHeaders.has("content-length")) {
+    requestHeaders.set("content-length", String(Buffer.byteLength(body)));
+  }
+
+  return Object.fromEntries(requestHeaders.entries());
+}
+
+function buildResponseHeaders(headers: IncomingHttpHeaders): Headers {
+  const responseHeaders = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        responseHeaders.append(name, item);
+      }
+    } else if (value !== undefined) {
+      responseHeaders.set(name, String(value));
+    }
+  }
+  return responseHeaders;
+}
+
+function normalizeHostname(parsedUrl: URL): string {
+  return parsedUrl.hostname
+    .replace(/^\[|\]$/gu, "")
+    .replace(/\.$/u, "")
+    .toLowerCase();
+}
+
+async function resolveHostnameWithDns(
+  hostname: string,
+): Promise<ResolvedHostnameAddress[]> {
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.flatMap((address) =>
+    address.family === 4 || address.family === 6
+      ? [{ address: address.address, family: address.family }]
+      : [],
+  );
+}
+
+function isNonPublicIpAddress(hostname: string): boolean {
+  const ipVersion = isIP(hostname);
+  if (ipVersion === 4) {
+    return isPrivateIpv4Address(hostname);
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6Address(hostname);
+  }
+
+  return false;
 }
 
 function isPrivateIpv4Address(hostname: string): boolean {
@@ -167,8 +523,12 @@ function isPrivateIpv4Address(hostname: string): boolean {
     (first === 100 && second >= 64 && second <= 127) ||
     (first === 169 && second === 254) ||
     (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 0) ||
+    (first === 192 && second === 88 && octets[2] === 99) ||
     (first === 192 && second === 168) ||
     (first === 198 && (second === 18 || second === 19)) ||
+    (first === 198 && second === 51 && octets[2] === 100) ||
+    (first === 203 && second === 0 && octets[2] === 113) ||
     first >= 224
   );
 }
@@ -195,9 +555,11 @@ function isPrivateIpv6Address(hostname: string): boolean {
     normalizedHostname === "::" ||
     normalizedHostname === "::1" ||
     (Number.isFinite(firstGroupValue) &&
-      (firstGroupValue === 0x2002 ||
-        (firstGroupValue >= 0xfc00 && firstGroupValue <= 0xfdff) ||
-        (firstGroupValue >= 0xfe80 && firstGroupValue <= 0xfeff)))
+      firstGroupValue === 0x2001 &&
+      normalizedHostname.split(":")[1] === "db8") ||
+    firstGroupValue === 0x2002 ||
+    (firstGroupValue >= 0xfc00 && firstGroupValue <= 0xfdff) ||
+    (firstGroupValue >= 0xfe80 && firstGroupValue <= 0xfeff)
   );
 }
 
@@ -208,6 +570,17 @@ export async function readResponseTextWithLimit(
   response: Response,
   maxBytes: number,
 ): Promise<string> {
+  const bytes = await readResponseBytesWithLimit(response, maxBytes);
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Reads response bytes with limit from project state.
+ */
+export async function readResponseBytesWithLimit(
+  response: Response,
+  maxBytes: number,
+): Promise<Buffer> {
   const contentLength = response.headers.get("content-length");
   if (contentLength) {
     const parsedContentLength = Number(contentLength);
@@ -223,9 +596,9 @@ export async function readResponseTextWithLimit(
   }
 
   if (!response.body) {
-    const text = await response.text();
-    ensureTextWithinLimit(text, maxBytes);
-    return text;
+    const bytes = Buffer.from(await response.arrayBuffer());
+    ensureBytesWithinLimit(bytes.byteLength, maxBytes);
+    return bytes;
   }
 
   const reader = response.body.getReader();
@@ -245,22 +618,19 @@ export async function readResponseTextWithLimit(
     totalBytes += value.byteLength;
     if (totalBytes > maxBytes) {
       await reader.cancel();
-      throw new Error(
-        `Response body exceeds the configured limit (${totalBytes} > ${maxBytes} bytes).`,
-      );
+      ensureBytesWithinLimit(totalBytes, maxBytes);
     }
 
     chunks.push(value);
   }
 
-  return new TextDecoder().decode(concatenateChunks(chunks, totalBytes));
+  return Buffer.from(concatenateChunks(chunks, totalBytes));
 }
 
-function ensureTextWithinLimit(text: string, maxBytes: number): void {
-  const byteLength = Buffer.byteLength(text, "utf8");
-  if (byteLength > maxBytes) {
+function ensureBytesWithinLimit(bytes: number, maxBytes: number): void {
+  if (bytes > maxBytes) {
     throw new Error(
-      `Response body exceeds the configured limit (${byteLength} > ${maxBytes} bytes).`,
+      `Response body exceeds the configured limit (${bytes} > ${maxBytes} bytes).`,
     );
   }
 }

--- a/src/lib/paths.ts
+++ b/src/lib/paths.ts
@@ -2,6 +2,9 @@ import { isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 
 import { getRuntimeConfig } from "../config/runtime.js";
 
+/**
+ * Resolves home relative path from the provided inputs.
+ */
 export function resolveHomeRelativePath(pathValue: string): string {
   if (pathValue === "~") {
     return getRuntimeConfig().paths.homeDirectory;
@@ -14,6 +17,9 @@ export function resolveHomeRelativePath(pathValue: string): string {
   return pathValue;
 }
 
+/**
+ * Resolves portable path from the provided inputs.
+ */
 export function resolvePortablePath(
   pathValue: string | undefined,
   projectRoot: string,
@@ -28,6 +34,9 @@ export function resolvePortablePath(
     : resolve(projectRoot, expandedValue);
 }
 
+/**
+ * Provides to home relative path for the lifecycle pipeline.
+ */
 export function toHomeRelativePath(pathValue: string): string {
   const homeDirectory = getRuntimeConfig().paths.homeDirectory;
   const normalizedPath = normalize(pathValue);
@@ -45,6 +54,9 @@ export function toHomeRelativePath(pathValue: string): string {
   return normalizedPath.split(sep).join("/");
 }
 
+/**
+ * Resolves vs code user settings path from the provided inputs.
+ */
 export function resolveVsCodeUserSettingsPath(): string {
   const config = getRuntimeConfig();
 
@@ -72,6 +84,9 @@ export function resolveVsCodeUserSettingsPath(): string {
   return join(config.paths.xdgConfigHome, "Code", "User", "settings.json");
 }
 
+/**
+ * Resolves default open code config root from the provided inputs.
+ */
 export function resolveDefaultOpenCodeConfigRoot(): string {
   const config = getRuntimeConfig();
 

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";
 import { delimiter, dirname, join } from "node:path";
@@ -12,8 +13,14 @@ import {
   resolveVsCodeUserSettingsPath,
 } from "./paths.js";
 
+/**
+ * Defines the supported preflight severity values.
+ */
 export type PreflightSeverity = "info" | "warning" | "error";
 
+/**
+ * Describes preflight diagnostic data exchanged by the lifecycle pipeline.
+ */
 export interface PreflightDiagnostic {
   severity: PreflightSeverity;
   code: string;
@@ -21,6 +28,9 @@ export interface PreflightDiagnostic {
   action?: string;
 }
 
+/**
+ * Dispatches the config preflight CLI command group.
+ */
 export async function runConfigPreflight(): Promise<PreflightDiagnostic[]> {
   const diagnostics: PreflightDiagnostic[] = [];
   const config = getRuntimeConfig();
@@ -45,18 +55,7 @@ export async function runConfigPreflight(): Promise<PreflightDiagnostic[]> {
 export async function runAdapterPreflight(
   adapter: HostAdapter,
 ): Promise<PreflightDiagnostic[]> {
-  if (!adapter.runtime) {
-    return [];
-  }
-
-  return [
-    await checkExecutableOnPath(
-      adapter.runtime.executable,
-      `${adapter.id}-cli`,
-      "warning",
-      adapter.runtime.guidance,
-    ),
-  ];
+  return runAdapterRuntimePreflight(adapter.runtime, adapter.id, false);
 }
 
 /**
@@ -100,14 +99,49 @@ async function runAdapterRuntimePreflight(
       : [];
   }
 
-  return [
-    await checkExecutableOnPath(
-      runtime.executable,
-      `${adapterId}-cli`,
-      required ? "error" : "warning",
-      runtime.guidance,
-    ),
-  ];
+  const executableDiagnostic = await checkExecutableOnPath(
+    runtime.executable,
+    `${adapterId}-cli`,
+    required ? "error" : "warning",
+    runtime.guidance,
+  );
+  const diagnostics = [executableDiagnostic];
+
+  if (executableDiagnostic.severity !== "info") {
+    return diagnostics;
+  }
+
+  if (runtime.versionArgs?.length) {
+    diagnostics.push(
+      await checkRuntimeCommand({
+        executable: runtime.executable,
+        args: runtime.versionArgs,
+        code: `${adapterId}-version`,
+        failureSeverity: required ? "error" : "warning",
+        successMessage: `${runtime.executable} version command completed successfully.`,
+        failureAction:
+          runtime.guidance ??
+          "Confirm the host CLI is installed correctly and can report its version.",
+      }),
+    );
+  }
+
+  if (runtime.readinessArgs?.length) {
+    diagnostics.push(
+      await checkRuntimeCommand({
+        executable: runtime.executable,
+        args: runtime.readinessArgs,
+        code: `${adapterId}-readiness`,
+        failureSeverity: required ? "error" : "warning",
+        successMessage: `${runtime.executable} readiness command completed successfully.`,
+        failureAction:
+          runtime.guidance ??
+          "Sign in to the host CLI and confirm marketplace/runtime access is available.",
+      }),
+    );
+  }
+
+  return diagnostics;
 }
 
 /**
@@ -181,6 +215,9 @@ function requireDiagnostic(
   return diagnostic;
 }
 
+/**
+ * Validates unknown data as no preflight errors.
+ */
 export function assertNoPreflightErrors(
   diagnostics: PreflightDiagnostic[],
 ): void {
@@ -194,6 +231,9 @@ export function assertNoPreflightErrors(
   throw new Error(formatPreflightDiagnostics(errors));
 }
 
+/**
+ * Formats preflight diagnostics for user-facing output.
+ */
 export function formatPreflightDiagnostics(
   diagnostics: PreflightDiagnostic[],
 ): string {
@@ -266,6 +306,77 @@ async function findExecutableOnPath(
 
 /**
  * Checks file-system accessibility for a path with the requested access mode.
+ */
+interface RuntimeCommandCheckOptions {
+  executable: string;
+  args: string[];
+  code: string;
+  failureSeverity: PreflightSeverity;
+  successMessage: string;
+  failureAction: string;
+}
+
+async function checkRuntimeCommand(
+  options: RuntimeCommandCheckOptions,
+): Promise<PreflightDiagnostic> {
+  const result = await runRuntimeCommand(options.executable, options.args);
+  if (result.exitCode === 0) {
+    return {
+      severity: "info",
+      code: options.code,
+      message: options.successMessage,
+    };
+  }
+
+  return {
+    severity: options.failureSeverity,
+    code: options.code,
+    message: `${options.executable} ${options.args.join(" ")} failed: ${result.message}`,
+    action: options.failureAction,
+  };
+}
+
+async function runRuntimeCommand(
+  executable: string,
+  args: string[],
+): Promise<{ exitCode: number | null; message: string }> {
+  const timeoutMs = 5_000;
+
+  return new Promise((resolve) => {
+    const child = spawn(executable, args, {
+      shell: false,
+      stdio: ["ignore", "ignore", "pipe"],
+      windowsHide: true,
+    });
+    let settled = false;
+    let stderr = "";
+    const finish = (exitCode: number | null, message: string): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode, message });
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(null, `timed out after ${timeoutMs}ms`);
+    }, timeoutMs);
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr = `${stderr}${chunk.toString("utf8")}`.slice(0, 2_000);
+    });
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      finish(null, error.code ?? error.message);
+    });
+    child.on("close", (exitCode) => {
+      finish(exitCode, stderr.trim() || `exit code ${String(exitCode)}`);
+    });
+  });
+}
+
+/**
+ * Provides check path exists for the lifecycle pipeline.
  */
 export async function checkPathExists(
   pathValue: string,

--- a/src/lib/safe-paths.ts
+++ b/src/lib/safe-paths.ts
@@ -1,10 +1,17 @@
 import { createHash } from "node:crypto";
+import { lstat, realpath } from "node:fs/promises";
 import { isAbsolute, relative, resolve, sep } from "node:path";
 
+/**
+ * Provides sanitize mirror id for the lifecycle pipeline.
+ */
 export function sanitizeMirrorId(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]+/gu, "-");
 }
 
+/**
+ * Provides sanitize asset id for the lifecycle pipeline.
+ */
 export function sanitizeAssetId(value: string): string {
   const base =
     value.replace(/[^a-zA-Z0-9_-]+/gu, "-").replace(/^-+|-+$/gu, "") || "asset";
@@ -12,6 +19,9 @@ export function sanitizeAssetId(value: string): string {
   return `${base}-${suffix}`;
 }
 
+/**
+ * Returns whether the provided value matches path within root.
+ */
 export function isPathWithinRoot(
   rootPath: string,
   targetPath: string,
@@ -28,6 +38,9 @@ export function isPathWithinRoot(
   );
 }
 
+/**
+ * Resolves safe mirror file path from the provided inputs.
+ */
 export function resolveSafeMirrorFilePath(
   rawRoot: string,
   relativePath: string,
@@ -51,6 +64,9 @@ export function resolveSafeMirrorFilePath(
   return resolvedTarget;
 }
 
+/**
+ * Resolves allowed absolute path from the provided inputs.
+ */
 export function resolveAllowedAbsolutePath(
   pathValue: string,
   allowedRoots: readonly string[],
@@ -65,5 +81,41 @@ export function resolveAllowedAbsolutePath(
     isPathWithinRoot(rootPath, resolvedPath),
   )
     ? resolvedPath
+    : null;
+}
+
+/**
+ * Resolves allowed real file path from the provided inputs.
+ */
+export async function resolveAllowedRealFilePath(
+  pathValue: string,
+  allowedRoots: readonly string[],
+): Promise<string | null> {
+  const resolvedPath = resolveAllowedAbsolutePath(pathValue, allowedRoots);
+  if (!resolvedPath) {
+    return null;
+  }
+
+  const pathStats = await lstat(resolvedPath).catch(() => null);
+  if (!pathStats?.isFile() || pathStats.isSymbolicLink()) {
+    return null;
+  }
+
+  const [realTargetPath, realRootPaths] = await Promise.all([
+    realpath(resolvedPath).catch(() => null),
+    Promise.all(
+      allowedRoots.map((rootPath) => realpath(rootPath).catch(() => null)),
+    ),
+  ]);
+
+  if (!realTargetPath) {
+    return null;
+  }
+
+  return realRootPaths.some(
+    (realRootPath) =>
+      realRootPath !== null && isPathWithinRoot(realRootPath, realTargetPath),
+  )
+    ? realTargetPath
     : null;
 }

--- a/src/lib/shared-mcp.ts
+++ b/src/lib/shared-mcp.ts
@@ -11,6 +11,9 @@ import type {
   InstalledPackageManifest,
 } from "../types.js";
 
+/**
+ * Reads shared mcp asset ids from project state.
+ */
 export async function readSharedMcpAssetIds(
   projectRoot: string,
 ): Promise<string[]> {

--- a/src/lib/state-root.ts
+++ b/src/lib/state-root.ts
@@ -11,6 +11,9 @@ import {
 import { getRuntimeConfig } from "../config/runtime.js";
 import { resolvePortablePath } from "./paths.js";
 
+/**
+ * Defines state root env var shared by the lifecycle pipeline.
+ */
 export const STATE_ROOT_ENV_VAR = "AGENT_HARNESS_STATE_ROOT";
 
 const STATE_ASSET_PATHS = [
@@ -27,18 +30,27 @@ const STATE_ASSET_PATHS = [
   ["mirror", "schema"],
 ] as const;
 
+/**
+ * Describes state root resolution options data exchanged by the lifecycle pipeline.
+ */
 export interface StateRootResolutionOptions {
   packageRoot: string;
   workingDirectory: string;
   explicitStateRoot?: string;
 }
 
+/**
+ * Describes prepared state root data exchanged by the lifecycle pipeline.
+ */
 export interface PreparedStateRoot {
   packageRoot: string;
   stateRoot: string;
   usesPackageRoot: boolean;
 }
 
+/**
+ * Resolves state root from the provided inputs.
+ */
 export function resolveStateRoot(
   options: StateRootResolutionOptions,
 ): PreparedStateRoot {
@@ -60,6 +72,9 @@ export function resolveStateRoot(
   };
 }
 
+/**
+ * Provides prepare state root for the lifecycle pipeline.
+ */
 export async function prepareStateRoot(
   preparedRoot: PreparedStateRoot,
 ): Promise<void> {

--- a/src/manifest-validation/discovery.ts
+++ b/src/manifest-validation/discovery.ts
@@ -1,7 +1,7 @@
-import type { GitHubRepoSnapshot } from "../github.js";
 import type {
   AssetCatalogEntry,
   DemandProfile,
+  GitHubRepoSnapshot,
   SelectionRegistry,
   SelectionReport,
   SourceIndex,
@@ -29,6 +29,9 @@ import {
   SOURCE_KINDS,
 } from "./primitives.js";
 
+/**
+ * Validates unknown data as source registry.
+ */
 export function assertSourceRegistry(
   value: unknown,
   context: string,
@@ -67,6 +70,9 @@ export function assertSourceRegistry(
   });
 }
 
+/**
+ * Validates unknown data as selection registry.
+ */
 export function assertSelectionRegistry(
   value: unknown,
   context: string,
@@ -125,6 +131,9 @@ export function assertSelectionRegistry(
   );
 }
 
+/**
+ * Validates unknown data as demand profile.
+ */
 export function assertDemandProfile(
   value: unknown,
   context: string,
@@ -153,6 +162,9 @@ export function assertDemandProfile(
   );
 }
 
+/**
+ * Validates unknown data as source index.
+ */
 export function assertSourceIndex(
   value: unknown,
   context: string,
@@ -170,6 +182,9 @@ export function assertSourceIndex(
   );
 }
 
+/**
+ * Validates unknown data as asset catalog entry.
+ */
 export function assertAssetCatalogEntry(
   value: unknown,
   context: string,
@@ -254,6 +269,9 @@ export function assertAssetCatalogEntry(
   );
 }
 
+/**
+ * Validates unknown data as selection report.
+ */
 export function assertSelectionReport(
   value: unknown,
   context: string,
@@ -266,6 +284,9 @@ export function assertSelectionReport(
   assertNumber(record.rejectedCount, `${context}.rejectedCount`);
 }
 
+/**
+ * Validates unknown data as git hub repo snapshot.
+ */
 export function assertGitHubRepoSnapshot(
   value: unknown,
   context: string,

--- a/src/manifest-validation/install.ts
+++ b/src/manifest-validation/install.ts
@@ -18,6 +18,9 @@ import {
   assertStringArray,
 } from "./primitives.js";
 
+/**
+ * Validates unknown data as installed package manifest.
+ */
 export function assertInstalledPackageManifest(
   value: unknown,
   context: string,
@@ -55,6 +58,9 @@ export function assertInstalledPackageManifest(
   assertBoolean(record.activeByDefault, `${context}.activeByDefault`);
 }
 
+/**
+ * Validates unknown data as installed bundle manifest.
+ */
 export function assertInstalledBundleManifest(
   value: unknown,
   context: string,
@@ -83,6 +89,9 @@ export function assertInstalledBundleManifest(
   );
 }
 
+/**
+ * Validates unknown data as install generation manifest.
+ */
 export function assertInstallGenerationManifest(
   value: unknown,
   context: string,
@@ -105,6 +114,9 @@ export function assertInstallGenerationManifest(
   }
 }
 
+/**
+ * Validates unknown data as install progress state.
+ */
 export function assertInstallProgressState(
   value: unknown,
   context: string,

--- a/src/manifest-validation/mirror.ts
+++ b/src/manifest-validation/mirror.ts
@@ -19,6 +19,9 @@ import {
   UPSTREAM_TYPES,
 } from "./primitives.js";
 
+/**
+ * Validates unknown data as mirror policy.
+ */
 export function assertMirrorPolicy(
   value: unknown,
   context: string,
@@ -61,6 +64,9 @@ export function assertMirrorPolicy(
   );
 }
 
+/**
+ * Validates unknown data as bundle lock.
+ */
 export function assertBundleLock(
   value: unknown,
   context: string,
@@ -85,6 +91,9 @@ export function assertBundleLock(
   });
 }
 
+/**
+ * Validates unknown data as mirror index entry.
+ */
 export function assertMirrorIndexEntry(
   value: unknown,
   context: string,
@@ -111,6 +120,9 @@ export function assertMirrorIndexEntry(
   assertLiteral(record.status, [...MIRROR_STATUSES], `${context}.status`);
 }
 
+/**
+ * Validates unknown data as mirror acquire state.
+ */
 export function assertMirrorAcquireState(
   value: unknown,
   context: string,

--- a/src/manifest-validation/primitives.ts
+++ b/src/manifest-validation/primitives.ts
@@ -8,8 +8,14 @@ import type {
   SourceKind,
 } from "../types.js";
 
+/**
+ * Defines the supported json record values.
+ */
 export type JsonRecord = Record<string, unknown>;
 
+/**
+ * Defines authority tiers shared by the lifecycle pipeline.
+ */
 export const AUTHORITY_TIERS: AuthorityTier[] = [
   "trusted-local",
   "official-first-party",
@@ -19,6 +25,9 @@ export const AUTHORITY_TIERS: AuthorityTier[] = [
   "unverified-community",
 ];
 
+/**
+ * Defines source kinds shared by the lifecycle pipeline.
+ */
 export const SOURCE_KINDS: SourceKind[] = [
   "repo",
   "docs",
@@ -29,6 +38,9 @@ export const SOURCE_KINDS: SourceKind[] = [
   "local-directory",
 ];
 
+/**
+ * Defines asset kinds shared by the lifecycle pipeline.
+ */
 export const ASSET_KINDS: AssetKind[] = [
   "skill",
   "plugin",
@@ -42,6 +54,9 @@ export const ASSET_KINDS: AssetKind[] = [
   "reference-pack",
 ];
 
+/**
+ * Defines asset prerequisite kinds shared by the lifecycle pipeline.
+ */
 export const ASSET_PREREQUISITE_KINDS: AssetPrerequisiteKind[] = [
   "env",
   "host-login",
@@ -49,6 +64,9 @@ export const ASSET_PREREQUISITE_KINDS: AssetPrerequisiteKind[] = [
   "manual",
 ];
 
+/**
+ * Defines host targets shared by the lifecycle pipeline.
+ */
 export const HOST_TARGETS: BuiltInHostTarget[] = [
   "copilot-vscode",
   "opencode",
@@ -59,6 +77,9 @@ export const HOST_TARGETS: BuiltInHostTarget[] = [
   "pi",
 ];
 
+/**
+ * Defines compatibility modes shared by the lifecycle pipeline.
+ */
 export const COMPATIBILITY_MODES: CompatibilityMode[] = [
   "native",
   "adaptable",
@@ -67,13 +88,22 @@ export const COMPATIBILITY_MODES: CompatibilityMode[] = [
   "incompatible",
 ];
 
+/**
+ * Defines risk levels shared by the lifecycle pipeline.
+ */
 export const RISK_LEVELS = ["low", "medium", "high"] as const;
+/**
+ * Defines context cost classes shared by the lifecycle pipeline.
+ */
 export const CONTEXT_COST_CLASSES = [
   "tiny",
   "small",
   "medium",
   "large",
 ] as const;
+/**
+ * Defines mirror statuses shared by the lifecycle pipeline.
+ */
 export const MIRROR_STATUSES = [
   "approved",
   "approved-with-warning",
@@ -81,6 +111,9 @@ export const MIRROR_STATUSES = [
   "metadata-only",
   "reference-only",
 ] as const;
+/**
+ * Defines upstream types shared by the lifecycle pipeline.
+ */
 export const UPSTREAM_TYPES = [
   "repo",
   "package",
@@ -88,6 +121,9 @@ export const UPSTREAM_TYPES = [
   "docs",
   "local",
 ] as const;
+/**
+ * Defines wire plan hosts shared by the lifecycle pipeline.
+ */
 export const WIRE_PLAN_HOSTS = [
   ...HOST_TARGETS,
   "vscode-user",
@@ -96,6 +132,9 @@ export const WIRE_PLAN_HOSTS = [
 
 const HOST_TARGET_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
 
+/**
+ * Validates unknown data as host target.
+ */
 export function assertHostTarget(value: unknown, context: string): HostTarget {
   const host = assertString(value, context);
   if (!HOST_TARGET_PATTERN.test(host)) {
@@ -105,24 +144,36 @@ export function assertHostTarget(value: unknown, context: string): HostTarget {
   return host;
 }
 
+/**
+ * Validates unknown data as host target array.
+ */
 export function assertHostTargetArray(value: unknown, context: string): void {
   assertArray(value, context).forEach((entry, index) => {
     assertHostTarget(entry, `${context}[${index}]`);
   });
 }
 
+/**
+ * Validates unknown data as asset kind array.
+ */
 export function assertAssetKindArray(value: unknown, context: string): void {
   assertArray(value, context).forEach((entry, index) => {
     assertLiteral(entry, ASSET_KINDS, `${context}[${index}]`);
   });
 }
 
+/**
+ * Validates unknown data as string array.
+ */
 export function assertStringArray(value: unknown, context: string): string[] {
   return assertArray(value, context).map((entry, index) =>
     assertString(entry, `${context}[${index}]`),
   );
 }
 
+/**
+ * Validates unknown data as string array record.
+ */
 export function assertStringArrayRecord(value: unknown, context: string): void {
   const record = assertRecord(value, context);
   Object.entries(record).forEach(([key, entryValue]) => {
@@ -130,6 +181,9 @@ export function assertStringArrayRecord(value: unknown, context: string): void {
   });
 }
 
+/**
+ * Validates unknown data as array.
+ */
 export function assertArray(value: unknown, context: string): unknown[] {
   if (!Array.isArray(value)) {
     fail(context, "expected an array");
@@ -138,6 +192,9 @@ export function assertArray(value: unknown, context: string): unknown[] {
   return value;
 }
 
+/**
+ * Validates unknown data as record.
+ */
 export function assertRecord(value: unknown, context: string): JsonRecord {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     fail(context, "expected an object");
@@ -146,6 +203,9 @@ export function assertRecord(value: unknown, context: string): JsonRecord {
   return value as JsonRecord;
 }
 
+/**
+ * Validates unknown data as string.
+ */
 export function assertString(value: unknown, context: string): string {
   if (typeof value !== "string") {
     fail(context, "expected a string");
@@ -154,6 +214,9 @@ export function assertString(value: unknown, context: string): string {
   return value;
 }
 
+/**
+ * Validates unknown data as number.
+ */
 export function assertNumber(value: unknown, context: string): number {
   if (typeof value !== "number" || Number.isNaN(value)) {
     fail(context, "expected a number");
@@ -162,6 +225,9 @@ export function assertNumber(value: unknown, context: string): number {
   return value;
 }
 
+/**
+ * Validates unknown data as maybe string.
+ */
 export function assertMaybeString(
   value: unknown,
   context: string,
@@ -177,6 +243,9 @@ export function assertMaybeString(
   assertString(value, context);
 }
 
+/**
+ * Validates unknown data as maybe number.
+ */
 export function assertMaybeNumber(
   value: unknown,
   context: string,
@@ -192,6 +261,9 @@ export function assertMaybeNumber(
   assertNumber(value, context);
 }
 
+/**
+ * Validates unknown data as maybe array.
+ */
 export function assertMaybeArray(
   value: unknown,
   context: string,
@@ -207,6 +279,9 @@ export function assertMaybeArray(
   return assertArray(value, context);
 }
 
+/**
+ * Validates unknown data as maybe record.
+ */
 export function assertMaybeRecord(
   value: unknown,
   context: string,
@@ -222,6 +297,9 @@ export function assertMaybeRecord(
   return assertRecord(value, context);
 }
 
+/**
+ * Validates unknown data as maybe string array.
+ */
 export function assertMaybeStringArray(
   value: unknown,
   context: string,
@@ -237,6 +315,9 @@ export function assertMaybeStringArray(
   return assertStringArray(value, context);
 }
 
+/**
+ * Validates unknown data as boolean.
+ */
 export function assertBoolean(value: unknown, context: string): boolean {
   if (typeof value !== "boolean") {
     fail(context, "expected a boolean");
@@ -245,6 +326,9 @@ export function assertBoolean(value: unknown, context: string): boolean {
   return value;
 }
 
+/**
+ * Validates unknown data as literal.
+ */
 export function assertLiteral<T extends string>(
   value: unknown,
   allowed: readonly T[],
@@ -257,6 +341,9 @@ export function assertLiteral<T extends string>(
   return value as T;
 }
 
+/**
+ * Provides fail for the lifecycle pipeline.
+ */
 export function fail(context: string, message: string): never {
   throw new Error(`Invalid manifest at ${context}: ${message}`);
 }

--- a/src/manifest-validation/recommendation.ts
+++ b/src/manifest-validation/recommendation.ts
@@ -25,6 +25,9 @@ import {
   type JsonRecord,
 } from "./primitives.js";
 
+/**
+ * Validates unknown data as recommendation report.
+ */
 export function assertRecommendationReport(
   value: unknown,
   context: string,
@@ -229,6 +232,9 @@ export function assertRecommendationReport(
   );
 }
 
+/**
+ * Validates unknown data as recommendation policy.
+ */
 export function assertRecommendationPolicy(
   value: unknown,
   context: string,
@@ -255,6 +261,9 @@ export function assertRecommendationPolicy(
   assertRecommendationKeywordMaps(record, context);
 }
 
+/**
+ * Validates unknown data as recommendation policy base.
+ */
 export function assertRecommendationPolicyBase(
   value: unknown,
   context: string,
@@ -276,6 +285,9 @@ export function assertRecommendationPolicyBase(
   assertRecommendationKeywordMaps(record, context);
 }
 
+/**
+ * Validates unknown data as recommendation host policy override.
+ */
 export function assertRecommendationHostPolicyOverride(
   value: unknown,
   context: string,

--- a/src/manifest-validation/workspace.ts
+++ b/src/manifest-validation/workspace.ts
@@ -13,6 +13,9 @@ import {
   WIRE_PLAN_HOSTS,
 } from "./primitives.js";
 
+/**
+ * Validates unknown data as activation manifest.
+ */
 export function assertActivationManifest(
   value: unknown,
   context: string,
@@ -30,6 +33,9 @@ export function assertActivationManifest(
   }
 }
 
+/**
+ * Validates unknown data as copilot workspace profile manifest.
+ */
 export function assertCopilotWorkspaceProfileManifest(
   value: unknown,
   context: string,
@@ -41,15 +47,46 @@ export function assertCopilotWorkspaceProfileManifest(
   assertString(record.workspaceRoot, `${context}.workspaceRoot`);
   assertStringArray(record.bundleIds, `${context}.bundleIds`);
   assertStringArray(record.selectedAssetIds, `${context}.selectedAssetIds`);
-  if (record.selectedExtensionIds !== undefined) {
-    assertStringArray(
-      record.selectedExtensionIds,
-      `${context}.selectedExtensionIds`,
-    );
-  }
+  assertStringArray(
+    record.selectedInstructionIds,
+    `${context}.selectedInstructionIds`,
+  );
+  assertStringArray(record.selectedAgentIds, `${context}.selectedAgentIds`);
+  assertStringArray(
+    record.selectedWorkflowIds,
+    `${context}.selectedWorkflowIds`,
+  );
+  assertOptionalStringArray(
+    record.selectedPluginIds,
+    `${context}.selectedPluginIds`,
+  );
+  assertOptionalStringArray(
+    record.selectedExtensionIds,
+    `${context}.selectedExtensionIds`,
+  );
+  assertOptionalStringArray(
+    record.selectedHookIds,
+    `${context}.selectedHookIds`,
+  );
+  assertOptionalStringArray(
+    record.selectedSkillIds,
+    `${context}.selectedSkillIds`,
+  );
   assertNumber(record.activationBudget, `${context}.activationBudget`);
+  if (record.sessionIntent !== undefined) {
+    assertString(record.sessionIntent, `${context}.sessionIntent`);
+  }
 }
 
+function assertOptionalStringArray(value: unknown, context: string): void {
+  if (value !== undefined) {
+    assertStringArray(value, context);
+  }
+}
+
+/**
+ * Validates unknown data as wire plan manifest.
+ */
 export function assertWirePlanManifest(
   value: unknown,
   context: string,

--- a/src/mirror.ts
+++ b/src/mirror.ts
@@ -3,9 +3,21 @@ import { generateBundleLocks } from "./mirror/bundles.js";
 import { diffMirrorIndex, explainMirrorArtifact } from "./mirror/inspect.js";
 import { generateMirrorPlan } from "./mirror/plan.js";
 
+/**
+ * Re-exports safe mirror path resolution for tests and mirror callers.
+ */
 export { resolveSafeMirrorFilePath } from "./lib/safe-paths.js";
-export { resolveAllowedMirrorEvidenceFilePath } from "./mirror/paths.js";
+/**
+ * Re-exports mirror evidence path guards for tests and mirror callers.
+ */
+export {
+  resolveAllowedMirrorEvidenceFilePath,
+  resolveAllowedMirrorEvidenceFilePathForRead,
+} from "./mirror/paths.js";
 
+/**
+ * Dispatches the mirror CLI command group.
+ */
 export async function runMirror(
   args: string[],
   workingDirectory: string,

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import { getRuntimeConfig } from "../config/runtime.js";
@@ -9,16 +10,16 @@ import {
   readJsonLinesFile,
   readTextFileOrNull,
   toPosixPath,
+  writeBinaryFile,
   writeJsonFile,
   writeJsonLinesFileWithSnapshot,
-  writeTextFile,
 } from "../files.js";
 import {
   buildGitHubRawFileUrl,
   fetchGitHubRepoSnapshotByRepoUrl,
 } from "../github.js";
 import { getOptionValue } from "../lib/cli-options.js";
-import { fetchJsonWithGuards, fetchTextWithGuards } from "../lib/http.js";
+import { fetchBytesWithGuards, fetchJsonWithGuards } from "../lib/http.js";
 import {
   isPathWithinRoot,
   resolveSafeMirrorFilePath,
@@ -48,18 +49,20 @@ import {
 } from "./constants.js";
 import {
   buildMirrorEvidenceAllowedRoots,
-  resolveAllowedMirrorEvidenceFilePath,
+  resolveAllowedMirrorEvidenceFilePathForRead,
   sanitizeMirrorId,
 } from "./paths.js";
 
 interface MaterializedMirrorArtifact {
-  content: string;
+  content: Buffer;
   files?: Array<{
     relativePath: string;
-    content: string;
+    content: Buffer;
+    upstreamBlobSha?: string;
   }>;
   upstreamRef?: string;
   upstreamCommit?: string;
+  upstreamBlobSha?: string;
 }
 
 interface MirrorFileManifest {
@@ -69,9 +72,13 @@ interface MirrorFileManifest {
     relativePath: string;
     sha256: string;
     sizeBytes: number;
+    upstreamBlobSha?: string;
   }>;
 }
 
+/**
+ * Provides acquire mirror artifacts for the lifecycle pipeline.
+ */
 export async function acquireMirrorArtifacts(
   projectRoot: string,
   workingDirectory: string,
@@ -86,7 +93,7 @@ export async function acquireMirrorArtifacts(
     assertAssetCatalogEntry,
   );
   const mirrorEligibleEntries = selectedEntries.filter(
-    (entry) => entry.status.mirrorEligible && entry.status.installEligible,
+    (entry) => entry.status.mirrorEligible,
   );
   const rawBatchSize = Number(
     getOptionValue(args, "--batch-size") ??
@@ -135,13 +142,13 @@ export async function acquireMirrorArtifacts(
       sanitizeMirrorId(mirrorId),
     );
     await ensureCleanDirectory(rawRoot);
-    await writeTextFile(
+    await writeBinaryFile(
       join(rawRoot, "content.txt"),
       materializedArtifact.content,
     );
 
     for (const file of materializedArtifact.files ?? []) {
-      await writeTextFile(
+      await writeBinaryFile(
         resolveSafeMirrorFilePath(rawRoot, file.relativePath),
         file.content,
       );
@@ -182,7 +189,7 @@ export async function acquireMirrorArtifacts(
         sanitizeMirrorId(mirrorId),
       );
       await ensureDirectory(quarantineRoot);
-      await writeTextFile(
+      await writeBinaryFile(
         join(quarantineRoot, "content.txt"),
         materializedArtifact.content,
       );
@@ -240,7 +247,7 @@ async function materializeMirrorArtifact(
     );
     if (referenceContent !== null) {
       return {
-        content: referenceContent,
+        content: Buffer.from(referenceContent, "utf8"),
       };
     }
   }
@@ -259,19 +266,12 @@ async function materializeMirrorArtifact(
       return officialIndexPackageArtifact;
     }
 
-    const officialIndexContent = await fetchOfficialIndexPageContent(
-      entry.source.originUrl,
-    );
-    if (officialIndexContent !== null) {
-      return {
-        content: officialIndexContent,
-      };
-    }
+    return null;
   }
 
   const filePath = entry.evidence.filePath;
   if (filePath) {
-    const safeFilePath = resolveAllowedMirrorEvidenceFilePath(
+    const safeFilePath = await resolveAllowedMirrorEvidenceFilePathForRead(
       filePath,
       evidenceAllowedRoots,
     );
@@ -284,7 +284,7 @@ async function materializeMirrorArtifact(
     const fileContent = await readTextFileOrNull(safeFilePath);
     if (fileContent !== null) {
       return {
-        content: fileContent,
+        content: Buffer.from(fileContent, "utf8"),
       };
     }
   }
@@ -298,13 +298,13 @@ async function materializeMirrorArtifact(
     const cacheContent = await readTextFileOrNull(cachePath);
     if (cacheContent !== null) {
       return {
-        content: cacheContent,
+        content: Buffer.from(cacheContent, "utf8"),
       };
     }
   }
 
   return {
-    content: JSON.stringify(entry, null, 2),
+    content: Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
   };
 }
 
@@ -316,7 +316,11 @@ async function materializeGitHubTreeArtifact(
   if (!repoInfo) {
     return requirePinnedProvenance
       ? null
-      : { content: JSON.stringify(entry, null, 2) };
+      : { content: Buffer.from(JSON.stringify(entry, null, 2), "utf8") };
+  }
+
+  if (!repoInfo.expectedBlobSha) {
+    return null;
   }
 
   const commitSha = await fetchGitHubBranchCommitSha(
@@ -329,12 +333,13 @@ async function materializeGitHubTreeArtifact(
   }
 
   const fetchRef = commitSha ?? repoInfo.ref;
-  const content = await fetchGitHubFileContent(
+  const content = await fetchVerifiedGitHubFileContent(
     repoInfo.owner,
     repoInfo.repo,
     fetchRef,
     repoInfo.filePath,
     MAX_GITHUB_MIRROR_FILE_SIZE_BYTES,
+    repoInfo.expectedBlobSha,
   );
   if (content === null) {
     return null;
@@ -344,6 +349,7 @@ async function materializeGitHubTreeArtifact(
     content,
     upstreamRef: repoInfo.ref,
     upstreamCommit: commitSha ?? undefined,
+    upstreamBlobSha: repoInfo.expectedBlobSha,
   };
 }
 
@@ -366,7 +372,7 @@ async function materializeOfficialIndexPackage(
       sourceId: entry.source.sourceId,
     });
 
-    if (!snapshot) {
+    if (!snapshot || snapshot.tree.truncated) {
       continue;
     }
 
@@ -378,18 +384,23 @@ async function materializeOfficialIndexPackage(
       continue;
     }
 
-    const packageFiles = snapshot.tree.entries
-      .filter(
+    const packageFileCandidates = snapshot.tree.entries.filter(
+      (treeEntry) =>
+        treeEntry.type === "blob" &&
+        treeEntry.path.startsWith(`${skillRootPath}/`),
+    );
+    if (
+      packageFileCandidates.length > MAX_OFFICIAL_INDEX_PACKAGE_FILES ||
+      packageFileCandidates.some(
         (treeEntry) =>
-          treeEntry.type === "blob" &&
-          treeEntry.path.startsWith(`${skillRootPath}/`),
+          treeEntry.size !== null &&
+          treeEntry.size > MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
       )
-      .filter(
-        (treeEntry) =>
-          treeEntry.size === null ||
-          treeEntry.size <= MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
-      )
-      .slice(0, MAX_OFFICIAL_INDEX_PACKAGE_FILES);
+    ) {
+      continue;
+    }
+
+    const packageFiles = packageFileCandidates;
 
     if (packageFiles.length === 0) {
       continue;
@@ -404,25 +415,31 @@ async function materializeOfficialIndexPackage(
       continue;
     }
 
-    const materializedFiles: Array<{ relativePath: string; content: string }> =
-      [];
+    const materializedFiles: Array<{
+      relativePath: string;
+      content: Buffer;
+      upstreamBlobSha?: string;
+    }> = [];
     const fetchRef = commitSha ?? snapshot.repoSummary.defaultBranch;
 
     for (const packageFile of packageFiles) {
-      const fileContent = await fetchGitHubFileContent(
+      const fileContent = await fetchVerifiedGitHubFileContent(
         snapshot.owner,
         snapshot.repo,
         fetchRef,
         packageFile.path,
         MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
+        packageFile.sha,
       );
       if (fileContent === null) {
-        continue;
+        materializedFiles.length = 0;
+        break;
       }
 
       materializedFiles.push({
         relativePath: packageFile.path.slice(skillRootPath.length + 1),
         content: fileContent,
+        upstreamBlobSha: packageFile.sha,
       });
     }
 
@@ -435,7 +452,9 @@ async function materializeOfficialIndexPackage(
     );
 
     return {
-      content: skillMarkdownFile?.content ?? JSON.stringify(entry, null, 2),
+      content:
+        skillMarkdownFile?.content ??
+        Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
       files: materializedFiles,
       upstreamRef: snapshot.repoSummary.defaultBranch,
       upstreamCommit: commitSha ?? undefined,
@@ -455,10 +474,35 @@ function buildOfficialIndexRepoUrlCandidates(
     `https://github.com/${owner}/skills`,
   ].filter(
     (value): value is string =>
-      typeof value === "string" && value.includes("github.com"),
+      typeof value === "string" && isGitHubHttpsRepositoryUrl(value),
   );
 
   return [...new Set(candidateRepoUrls)];
+}
+
+function isGitHubHttpsRepositoryUrl(value: string): boolean {
+  try {
+    const parsedUrl = new URL(value);
+    return (
+      parsedUrl.protocol === "https:" &&
+      parsedUrl.hostname.toLowerCase() === "github.com" &&
+      parsedUrl.pathname.split("/").filter(Boolean).length >= 2
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isGitHubHttpsUrl(value: string): boolean {
+  try {
+    const parsedUrl = new URL(value);
+    return (
+      parsedUrl.protocol === "https:" &&
+      parsedUrl.hostname.toLowerCase() === "github.com"
+    );
+  } catch {
+    return false;
+  }
 }
 
 function findOfficialIndexSkillRoot(
@@ -484,14 +528,15 @@ function findOfficialIndexSkillRoot(
     : null;
 }
 
-async function fetchGitHubFileContent(
+async function fetchVerifiedGitHubFileContent(
   owner: string,
   repo: string,
   branch: string,
   filePath: string,
   maxBytes: number,
-): Promise<string | null> {
-  return fetchTextWithGuards(
+  expectedBlobSha?: string,
+): Promise<Buffer | null> {
+  const content = await fetchBytesWithGuards(
     buildGitHubRawFileUrl({ owner, repo, branch, filePath }),
     {
       allowedOrigins: GITHUB_RAW_ALLOWED_ORIGINS,
@@ -499,6 +544,16 @@ async function fetchGitHubFileContent(
       maxBytes,
     },
   );
+
+  if (content === null) {
+    return null;
+  }
+
+  if (expectedBlobSha && createGitBlobSha(content) !== expectedBlobSha) {
+    return null;
+  }
+
+  return content;
 }
 
 async function fetchGitHubBranchCommitSha(
@@ -532,6 +587,7 @@ function parseGitHubBlobEntry(entry: AssetCatalogEntry): {
   repo: string;
   ref: string;
   filePath: string;
+  expectedBlobSha?: string;
 } | null {
   const filePath = entry.evidence.filePath;
   if (!filePath) {
@@ -561,7 +617,11 @@ function parseGitHubBlobEntry(entry: AssetCatalogEntry): {
       return null;
     }
 
-    return { owner, repo, ref, filePath };
+    const expectedBlobSha = isGitBlobSha(entry.install.manifestEntry)
+      ? entry.install.manifestEntry
+      : undefined;
+
+    return { owner, repo, ref, filePath, expectedBlobSha };
   } catch {
     return null;
   }
@@ -573,18 +633,29 @@ function buildMirrorFileManifest(
 ): MirrorFileManifest {
   const files = [
     { relativePath: "content.txt", content: materializedArtifact.content },
-    { relativePath: "asset.json", content: `${JSON.stringify(entry, null, 2)}\n` },
+    {
+      relativePath: "asset.json",
+      content: Buffer.from(`${JSON.stringify(entry, null, 2)}\n`, "utf8"),
+    },
     ...(materializedArtifact.files ?? []),
   ]
     .map((file) => ({
       relativePath: file.relativePath,
       sha256: createContentHash(file.content),
-      sizeBytes: Buffer.byteLength(file.content, "utf8"),
+      sizeBytes: file.content.byteLength,
+      upstreamBlobSha: file.upstreamBlobSha,
     }))
     .sort((left, right) => left.relativePath.localeCompare(right.relativePath));
   const aggregateHash = createContentHash(
     files
-      .map((file) => `${file.relativePath}\0${file.sha256}\0${file.sizeBytes}`)
+      .map((file) =>
+        [
+          file.relativePath,
+          file.sha256,
+          String(file.sizeBytes),
+          file.upstreamBlobSha ?? "",
+        ].join("\0"),
+      )
       .join("\n"),
   );
 
@@ -622,7 +693,7 @@ function buildUpstreamMetadata(
     };
   }
 
-  if (entry.source.originUrl.includes("github.com")) {
+  if (isGitHubHttpsUrl(entry.source.originUrl)) {
     return {
       type: "repo",
       url: entry.source.originUrl,
@@ -674,19 +745,45 @@ function hasPromptInjectionRisk(
   materializedArtifact: MaterializedMirrorArtifact,
 ): boolean {
   const combinedContent = [
-    materializedArtifact.content,
-    ...(materializedArtifact.files ?? []).map((file) => file.content),
-  ]
-    .join("\n")
-    .toLowerCase();
-  return [
-    "ignore previous instructions",
-    "ignore all previous instructions",
-    "exfiltrate secrets",
-    "send environment variables",
-    "disable security",
-    "reveal your system prompt",
-  ].some((pattern) => combinedContent.includes(pattern));
+    materializedArtifact.content.toString("utf8"),
+    ...(materializedArtifact.files ?? []).map((file) =>
+      file.content.toString("utf8"),
+    ),
+  ].join("\n");
+  const normalizedContent = normalizePromptInjectionText(combinedContent);
+  return PROMPT_INJECTION_PATTERNS.some((pattern) =>
+    pattern.test(normalizedContent),
+  );
+}
+
+const PROMPT_INJECTION_PATTERNS = [
+  /\bignore\s+(?:all\s+)?(?:previous|prior|above|earlier)\s+(?:system\s+)?(?:instructions?|messages?|prompts?|rules?)\b/u,
+  /\b(?:override|bypass|disable|discard)\s+(?:the\s+)?(?:system|developer|safety|security)\s+(?:instructions?|messages?|prompts?|rules?)\b/u,
+  /\b(?:reveal|print|show|dump|output|leak)\s+(?:the\s+)?(?:system\s+prompt|developer\s+message|hidden\s+instructions?)\b/u,
+  /\b(?:exfiltrate|steal|leak|dump|print|send|upload|post|output)\s+(?:secrets?|credentials?|tokens?|api\s*keys?|environment\s+variables|env(?:ironment)?\s*(?:vars?)?)\b/u,
+  /\b(?:send|upload|post)\s+(?:.*\s+)?(?:to\s+)?(?:an?\s+)?(?:external|remote|attacker|webhook)\s+(?:server|url|endpoint)\b/u,
+  /\b(?:do\s+not|don't)\s+(?:tell|mention|disclose)\s+(?:the\s+)?user\b/u,
+];
+
+function normalizePromptInjectionText(content: string): string {
+  return content
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[`*_~>#|[\]{}()\\-]+/gu, " ")
+    .replace(/[^a-z0-9]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function createGitBlobSha(content: Buffer): string {
+  return createHash("sha1")
+    .update(`blob ${content.byteLength}\0`)
+    .update(content)
+    .digest("hex");
+}
+
+function isGitBlobSha(value: string | undefined): value is string {
+  return Boolean(value && /^[a-f0-9]{40}$/iu.test(value));
 }
 
 async function writeMirrorAcquireState(
@@ -721,7 +818,7 @@ function buildGitHubCachePath(
 ): string | null {
   if (
     !entry.source.sourceId ||
-    !entry.source.originUrl.includes("github.com")
+    !isGitHubHttpsUrl(entry.source.originUrl)
   ) {
     return null;
   }

--- a/src/mirror/bundles.ts
+++ b/src/mirror/bundles.ts
@@ -18,6 +18,9 @@ import type {
   MirrorPolicy,
 } from "../types.js";
 
+/**
+ * Generates bundle locks artifacts for the lifecycle pipeline.
+ */
 export async function generateBundleLocks(projectRoot: string): Promise<void> {
   const policy = await readJsonFile<MirrorPolicy>(
     join(projectRoot, "mirror", "policy.json"),
@@ -28,7 +31,7 @@ export async function generateBundleLocks(projectRoot: string): Promise<void> {
     assertAssetCatalogEntry,
   );
   const mirrorEligibleEntries = selectedEntries.filter(
-    (entry) => entry.status.mirrorEligible && entry.status.installEligible,
+    (entry) => entry.status.mirrorEligible,
   );
 
   for (const bundleTemplate of policy.bundleTemplates) {
@@ -69,6 +72,9 @@ export async function generateBundleLocks(projectRoot: string): Promise<void> {
   );
 }
 
+/**
+ * Resolves bundle locks from the provided inputs.
+ */
 export async function resolveBundleLocks(
   projectRoot: string,
   mirrorIndexEntries: MirrorIndexEntry[],

--- a/src/mirror/constants.ts
+++ b/src/mirror/constants.ts
@@ -1,15 +1,42 @@
+/**
+ * Defines the mirror plan output path location used by persisted project state.
+ */
 export const MIRROR_PLAN_OUTPUT_PATH = ["mirror", "audit", "mirror-plan.json"];
+/**
+ * Defines the mirror index output path location used by persisted project state.
+ */
 export const MIRROR_INDEX_OUTPUT_PATH = ["mirror", "index.jsonl"];
+/**
+ * Defines the mirror index snapshot path location used by persisted project state.
+ */
 export const MIRROR_INDEX_SNAPSHOT_PATH = ["mirror", "index.previous.jsonl"];
+/**
+ * Defines the mirror acquire state output path location used by persisted project state.
+ */
 export const MIRROR_ACQUIRE_STATE_OUTPUT_PATH = [
   "state",
   "mirror",
   "acquire-state.json",
 ];
+/**
+ * Defines max official index package files shared by the lifecycle pipeline.
+ */
 export const MAX_OFFICIAL_INDEX_PACKAGE_FILES = 50;
+/**
+ * Defines max official index file size bytes shared by the lifecycle pipeline.
+ */
 export const MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES = 150_000;
+/**
+ * Defines max github mirror file size bytes shared by the lifecycle pipeline.
+ */
 export const MAX_GITHUB_MIRROR_FILE_SIZE_BYTES = 500_000;
+/**
+ * Defines the allowed github raw allowed origins used by guarded network requests.
+ */
 export const GITHUB_RAW_ALLOWED_ORIGINS = [
   "https://raw.githubusercontent.com",
 ] as const;
+/**
+ * Defines the allowed github api allowed origins used by guarded network requests.
+ */
 export const GITHUB_API_ALLOWED_ORIGINS = ["https://api.github.com"] as const;

--- a/src/mirror/inspect.ts
+++ b/src/mirror/inspect.ts
@@ -15,6 +15,9 @@ import {
 } from "./constants.js";
 import { sanitizeMirrorId } from "./paths.js";
 
+/**
+ * Provides diff mirror index for the lifecycle pipeline.
+ */
 export async function diffMirrorIndex(projectRoot: string): Promise<void> {
   const currentEntries = await readJsonLinesFile<MirrorIndexEntry>(
     join(projectRoot, ...MIRROR_INDEX_OUTPUT_PATH),
@@ -56,6 +59,9 @@ export async function diffMirrorIndex(projectRoot: string): Promise<void> {
   console.log(`  Changed assets: ${formatDiffList(changed)}`);
 }
 
+/**
+ * Provides explain mirror artifact for the lifecycle pipeline.
+ */
 export async function explainMirrorArtifact(
   projectRoot: string,
   args: string[],

--- a/src/mirror/paths.ts
+++ b/src/mirror/paths.ts
@@ -6,11 +6,18 @@ import {
 } from "../lib/paths.js";
 import {
   resolveAllowedAbsolutePath,
+  resolveAllowedRealFilePath,
   sanitizeMirrorId,
 } from "../lib/safe-paths.js";
 
+/**
+ * Re-exports mirror identifier sanitization for mirror path callers.
+ */
 export { sanitizeMirrorId };
 
+/**
+ * Builds mirror evidence allowed roots from the provided inputs.
+ */
 export function buildMirrorEvidenceAllowedRoots(
   projectRoot: string,
   workingDirectory: string,
@@ -23,9 +30,22 @@ export function buildMirrorEvidenceAllowedRoots(
   ].map((rootPath) => resolve(rootPath));
 }
 
+/**
+ * Resolves allowed mirror evidence file path from the provided inputs.
+ */
 export function resolveAllowedMirrorEvidenceFilePath(
   filePath: string,
   allowedRoots: readonly string[],
 ): string | null {
   return resolveAllowedAbsolutePath(filePath, allowedRoots);
+}
+
+/**
+ * Resolves allowed mirror evidence file path for read from the provided inputs.
+ */
+export async function resolveAllowedMirrorEvidenceFilePathForRead(
+  filePath: string,
+  allowedRoots: readonly string[],
+): Promise<string | null> {
+  return resolveAllowedRealFilePath(filePath, allowedRoots);
 }

--- a/src/mirror/plan.ts
+++ b/src/mirror/plan.ts
@@ -20,6 +20,9 @@ import type {
 } from "../types.js";
 import { MIRROR_PLAN_OUTPUT_PATH } from "./constants.js";
 
+/**
+ * Generates mirror plan artifacts for the lifecycle pipeline.
+ */
 export async function generateMirrorPlan(projectRoot: string): Promise<void> {
   const policy = await readJsonFile<MirrorPolicy>(
     join(projectRoot, "mirror", "policy.json"),

--- a/src/official-index.ts
+++ b/src/official-index.ts
@@ -16,6 +16,9 @@ const OFFICIAL_INDEX_ALLOWED_ORIGINS = [
   "https://pypi.org",
 ] as const;
 
+/**
+ * Fetches official index page content with the configured runtime safeguards.
+ */
 export async function fetchOfficialIndexPageContent(
   url: string,
 ): Promise<string | null> {
@@ -34,6 +37,9 @@ export async function fetchOfficialIndexPageContent(
   return extractedContent.length > 0 ? extractedContent : null;
 }
 
+/**
+ * Builds official index asset status from the provided inputs.
+ */
 export function buildOfficialIndexAssetStatus(
   authorityTier: AuthorityTier,
 ): AssetStatus {

--- a/src/package-registries.ts
+++ b/src/package-registries.ts
@@ -1,10 +1,16 @@
-import { fetchJsonWithGuards } from "./lib/http.js";
+import {
+  fetchJsonWithGuards,
+  type FetchWithGuardsOptions,
+} from "./lib/http.js";
 
 const NPM_REGISTRY_ORIGINS = ["https://registry.npmjs.org"] as const;
 const PYPI_REGISTRY_ORIGINS = ["https://pypi.org"] as const;
 const REGISTRY_METADATA_MAX_BYTES = 2_000_000;
 const REGISTRY_FETCH_TIMEOUT_MS = 5_000;
 
+/**
+ * Describes npm package metadata data exchanged by the lifecycle pipeline.
+ */
 export interface NpmPackageMetadata {
   name: string;
   description?: string;
@@ -21,6 +27,9 @@ export interface NpmPackageMetadata {
   lastUpdated?: string;
 }
 
+/**
+ * Describes pypi package metadata data exchanged by the lifecycle pipeline.
+ */
 export interface PypiPackageMetadata {
   info: {
     name: string;
@@ -34,8 +43,12 @@ export interface PypiPackageMetadata {
   lastUpdated?: string;
 }
 
+/**
+ * Fetches npm package metadata with the configured runtime safeguards.
+ */
 export async function fetchNpmPackageMetadata(
   packageName: string,
+  options: Pick<FetchWithGuardsOptions, "resolveHostname"> = {},
 ): Promise<NpmPackageMetadata | null> {
   try {
     const data = await fetchJsonWithGuards(
@@ -44,6 +57,7 @@ export async function fetchNpmPackageMetadata(
         allowedOrigins: NPM_REGISTRY_ORIGINS,
         headers: { Accept: "application/vnd.npm.install-v1+json" },
         maxBytes: REGISTRY_METADATA_MAX_BYTES,
+        resolveHostname: options.resolveHostname,
         timeoutMs: REGISTRY_FETCH_TIMEOUT_MS,
       },
     );
@@ -57,8 +71,12 @@ export async function fetchNpmPackageMetadata(
   }
 }
 
+/**
+ * Fetches pypi package metadata with the configured runtime safeguards.
+ */
 export async function fetchPypiPackageMetadata(
   packageName: string,
+  options: Pick<FetchWithGuardsOptions, "resolveHostname"> = {},
 ): Promise<PypiPackageMetadata | null> {
   try {
     const data = await fetchJsonWithGuards(
@@ -66,6 +84,7 @@ export async function fetchPypiPackageMetadata(
       {
         allowedOrigins: PYPI_REGISTRY_ORIGINS,
         maxBytes: REGISTRY_METADATA_MAX_BYTES,
+        resolveHostname: options.resolveHostname,
         timeoutMs: REGISTRY_FETCH_TIMEOUT_MS,
       },
     );
@@ -227,6 +246,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Provides extract repository url from npm metadata for the lifecycle pipeline.
+ */
 export function extractRepositoryUrlFromNpmMetadata(
   metadata: NpmPackageMetadata,
 ): string | undefined {
@@ -235,14 +257,17 @@ export function extractRepositoryUrlFromNpmMetadata(
   }
 
   if (typeof metadata.repository === "string") {
-    return sanitizeRepositoryUrl(metadata.repository);
+    return normalizeRepositoryHttpUrl(metadata.repository);
   }
 
   return metadata.repository.url
-    ? sanitizeRepositoryUrl(metadata.repository.url)
+    ? normalizeRepositoryHttpUrl(metadata.repository.url)
     : undefined;
 }
 
+/**
+ * Provides extract repository url from pypi metadata for the lifecycle pipeline.
+ */
 export function extractRepositoryUrlFromPypiMetadata(
   metadata: PypiPackageMetadata,
 ): string | undefined {
@@ -273,8 +298,54 @@ function isGitHubRepositoryUrl(value: string): boolean {
 }
 
 function sanitizeRepositoryUrl(value: string): string {
-  return value
-    .replace(/^git\+/u, "")
-    .replace(/\.git$/u, "")
-    .replace(/^git:/u, "https:");
+  const trimmedValue = stripUrlSuffix(value.trim());
+  const githubShorthand = /^github:([^/\s]+)\/(.+)$/iu.exec(trimmedValue);
+  if (githubShorthand?.[1] && githubShorthand[2]) {
+    return buildGitHubRepositoryUrl(githubShorthand[1], githubShorthand[2]);
+  }
+
+  const scpLikeGithubUrl = /^git@github\.com:([^/\s]+)\/(.+)$/iu.exec(
+    trimmedValue,
+  );
+  if (scpLikeGithubUrl?.[1] && scpLikeGithubUrl[2]) {
+    return buildGitHubRepositoryUrl(scpLikeGithubUrl[1], scpLikeGithubUrl[2]);
+  }
+
+  const withoutGitPrefix = trimmedValue.replace(/^git\+/iu, "");
+  const sshGithubUrl = /^ssh:\/\/git@github\.com\/([^/\s]+)\/(.+)$/iu.exec(
+    withoutGitPrefix,
+  );
+  if (sshGithubUrl?.[1] && sshGithubUrl[2]) {
+    return buildGitHubRepositoryUrl(sshGithubUrl[1], sshGithubUrl[2]);
+  }
+
+  const normalizedUrl = withoutGitPrefix.replace(/^git:/iu, "https:");
+  try {
+    const parsedUrl = new URL(normalizedUrl);
+    if (parsedUrl.hostname.toLowerCase() === "github.com") {
+      const [owner, repo] = parsedUrl.pathname.split("/").filter(Boolean);
+      return owner && repo
+        ? buildGitHubRepositoryUrl(owner, repo)
+        : normalizedUrl;
+    }
+  } catch {
+    return normalizedUrl.replace(/\.git$/iu, "");
+  }
+
+  return normalizedUrl.replace(/\.git$/iu, "");
+}
+
+function buildGitHubRepositoryUrl(owner: string, repo: string): string {
+  const cleanOwner = stripUrlSuffix(owner).split("/").filter(Boolean)[0];
+  const cleanRepo = stripUrlSuffix(repo)
+    .split("/")
+    .filter(Boolean)[0]
+    ?.replace(/\.git$/iu, "");
+  return cleanOwner && cleanRepo
+    ? `https://github.com/${cleanOwner}/${cleanRepo}`
+    : `https://github.com/${owner}/${repo.replace(/\.git$/iu, "")}`;
+}
+
+function stripUrlSuffix(value: string): string {
+  return value.split(/[?#]/u)[0] ?? value;
 }

--- a/src/quarantine.ts
+++ b/src/quarantine.ts
@@ -27,6 +27,9 @@ interface QuarantineReviewDecision {
 const MIRROR_INDEX_PATH = ["mirror", "index.jsonl"] as const;
 const REVIEW_LOG_PATH = ["state", "quarantine", "reviews.jsonl"] as const;
 
+/**
+ * Dispatches the quarantine CLI command group.
+ */
 export async function runQuarantine(
   args: string[],
   projectRoot: string,

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -22,9 +22,12 @@ const BUNDLE_LOCK_FILE_NAMES = [
   "community-stable.lock.json",
 ];
 
+/**
+ * Dispatches the rebuild CLI command group.
+ */
 export async function runRebuild(
   args: string[],
-  _workingDirectory: string,
+  workingDirectory: string,
   projectRoot: string,
 ): Promise<number> {
   const [command = "help"] = args;
@@ -35,17 +38,17 @@ export async function runRebuild(
       return 0;
     case "full":
       await cleanState(projectRoot);
-      await runDiscover(["demand-profile"], projectRoot, projectRoot);
-      await runDiscover(["sources"], projectRoot, projectRoot);
-      await runDiscover(["catalog"], projectRoot, projectRoot);
-      await runDiscover(["select"], projectRoot, projectRoot);
-      await runRecommend(["report"], projectRoot, projectRoot);
-      await runMirror(["plan"], projectRoot, projectRoot);
-      await runMirror(["locks"], projectRoot, projectRoot);
-      await acquireAllMirrorBatches(projectRoot);
-      await installAllBundleBatches(projectRoot);
-      await runInstall(["reconcile"], projectRoot, projectRoot);
-      await runActivate(["host"], projectRoot, projectRoot);
+      await runDiscover(["demand-profile"], workingDirectory, projectRoot);
+      await runDiscover(["sources"], workingDirectory, projectRoot);
+      await runDiscover(["catalog"], workingDirectory, projectRoot);
+      await runDiscover(["select"], workingDirectory, projectRoot);
+      await runRecommend(["report"], workingDirectory, projectRoot);
+      await runMirror(["plan"], workingDirectory, projectRoot);
+      await runMirror(["locks"], workingDirectory, projectRoot);
+      await acquireAllMirrorBatches(projectRoot, workingDirectory);
+      await installAllBundleBatches(projectRoot, workingDirectory);
+      await runInstall(["reconcile"], workingDirectory, projectRoot);
+      await runActivate(["host"], workingDirectory, projectRoot);
       return 0;
     case "help":
       printRebuildHelp();
@@ -66,14 +69,17 @@ async function cleanState(projectRoot: string): Promise<void> {
   );
 }
 
-async function acquireAllMirrorBatches(projectRoot: string): Promise<void> {
+async function acquireAllMirrorBatches(
+  projectRoot: string,
+  workingDirectory: string,
+): Promise<void> {
   const batchSize = String(getRuntimeConfig().batches.mirrorAcquire);
   const maxBatches = 200;
 
   for (let batchIndex = 0; batchIndex < maxBatches; batchIndex += 1) {
     await runMirror(
       ["acquire", "--batch-size", batchSize],
-      projectRoot,
+      workingDirectory,
       projectRoot,
     );
     const state = await readJsonFileOrNull<MirrorAcquireState>(
@@ -89,7 +95,10 @@ async function acquireAllMirrorBatches(projectRoot: string): Promise<void> {
   );
 }
 
-async function installAllBundleBatches(projectRoot: string): Promise<void> {
+async function installAllBundleBatches(
+  projectRoot: string,
+  workingDirectory: string,
+): Promise<void> {
   const bundleIds = await discoverBundleIds(projectRoot);
   const batchSize = String(getRuntimeConfig().batches.installBundle);
   const maxBatchesPerBundle = 200;
@@ -102,7 +111,7 @@ async function installAllBundleBatches(projectRoot: string): Promise<void> {
     ) {
       await runInstall(
         ["bundle", "--bundle", bundleId, "--batch-size", batchSize],
-        projectRoot,
+        workingDirectory,
         projectRoot,
       );
       const progressState = await readJsonFileOrNull<InstallProgressState>(

--- a/src/recommend-fixtures.ts
+++ b/src/recommend-fixtures.ts
@@ -29,6 +29,9 @@ interface FixtureAssetOptions {
   trustScore?: number;
 }
 
+/**
+ * Builds recommendation fixtures from the provided inputs.
+ */
 export function buildRecommendationFixtures(): RecommendationEvaluationFixture[] {
   return [
     buildBackendIntegrationFixture(),

--- a/src/recommend.ts
+++ b/src/recommend.ts
@@ -1,4 +1,10 @@
+/**
+ * Re-exports recommendation command dispatch for CLI callers.
+ */
 export { runRecommend } from "./recommend/commands.js";
+/**
+ * Re-exports recommendation report helpers for programmatic callers.
+ */
 export {
   buildRecommendationReport,
   writeRecommendationReport,

--- a/src/recommend/candidates.ts
+++ b/src/recommend/candidates.ts
@@ -17,6 +17,9 @@ import type {
 import type { RecommendationHost } from "./hosts.js";
 import type { CandidateRecommendation, DemandContext } from "./model.js";
 
+/**
+ * Provides compute entry preselection score for the lifecycle pipeline.
+ */
 export function computeEntryPreselectionScore(
   entry: AssetCatalogEntry,
 ): number {
@@ -30,6 +33,9 @@ export function computeEntryPreselectionScore(
   );
 }
 
+/**
+ * Builds candidate recommendation from the provided inputs.
+ */
 export function buildCandidateRecommendation(
   entry: AssetCatalogEntry,
   host: RecommendationHost,

--- a/src/recommend/commands.ts
+++ b/src/recommend/commands.ts
@@ -23,6 +23,9 @@ import type {
   RecommendationSignalMatch,
 } from "../types.js";
 
+/**
+ * Dispatches the recommend CLI command group.
+ */
 export async function runRecommend(
   args: string[],
   _workingDirectory: string,

--- a/src/recommend/constants.ts
+++ b/src/recommend/constants.ts
@@ -1,29 +1,53 @@
 import type { HostTarget } from "../types.js";
 
+/**
+ * Defines the legacy policy file path location used by persisted project state.
+ */
 export const LEGACY_POLICY_FILE_PATH = [
   "discover",
   "recommendation-policy.json",
 ] as const;
+/**
+ * Defines the policy base file path location used by persisted project state.
+ */
 export const POLICY_BASE_FILE_PATH = [
   "discover",
   "recommendation-policy",
   "base.json",
 ] as const;
+/**
+ * Defines the policy host directory path location used by persisted project state.
+ */
 export const POLICY_HOST_DIRECTORY_PATH = [
   "discover",
   "recommendation-policy",
   "hosts",
 ] as const;
+/**
+ * Defines the report file path location used by persisted project state.
+ */
 export const REPORT_FILE_PATH = ["state", "recommendations.json"] as const;
+/**
+ * Defines the evaluation file path location used by persisted project state.
+ */
 export const EVALUATION_FILE_PATH = [
   "state",
   "recommendation-evaluation.json",
 ] as const;
+/**
+ * Defines shared recommendation host shared by the lifecycle pipeline.
+ */
 export const SHARED_RECOMMENDATION_HOST =
   "shared" as const satisfies HostTarget;
 // Cap each focused capability bucket so broad sources cannot crowd out
 // diversity-sensitive recommendations before host policy caps are applied.
+/**
+ * Defines focused bucket limit shared by the lifecycle pipeline.
+ */
 export const FOCUSED_BUCKET_LIMIT = 20;
+/**
+ * Defines generic capability terms shared by the lifecycle pipeline.
+ */
 export const GENERIC_CAPABILITY_TERMS = new Set([
   "agent",
   "agents",

--- a/src/recommend/counts.ts
+++ b/src/recommend/counts.ts
@@ -1,20 +1,26 @@
 import type { RecommendationEntry } from "../types.js";
 import type { CandidateRecommendation } from "./model.js";
 
+/**
+ * Provides count coverage tags for the lifecycle pipeline.
+ */
 export function countCoverageTags(
   entries: CandidateRecommendation[],
 ): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const entry of entries) {
-    for (const tag of entry.coverageTags) {
-      counts[tag] = (counts[tag] ?? 0) + 1;
-    }
-  }
-  return counts;
+  return countCoverageTagsForItems(entries);
 }
 
+/**
+ * Provides count coverage tags from entries for the lifecycle pipeline.
+ */
 export function countCoverageTagsFromEntries(
   entries: RecommendationEntry[],
+): Record<string, number> {
+  return countCoverageTagsForItems(entries);
+}
+
+function countCoverageTagsForItems<T extends { coverageTags: string[] }>(
+  entries: T[],
 ): Record<string, number> {
   const counts: Record<string, number> = {};
   for (const entry of entries) {
@@ -25,6 +31,9 @@ export function countCoverageTagsFromEntries(
   return counts;
 }
 
+/**
+ * Provides count by for the lifecycle pipeline.
+ */
 export function countBy<T>(
   values: T[],
   selector: (value: T) => string,

--- a/src/recommend/hosts.ts
+++ b/src/recommend/hosts.ts
@@ -2,8 +2,14 @@ import { listHostAdapters } from "../host-adapters/registry.js";
 import { SHARED_RECOMMENDATION_HOST } from "./constants.js";
 import type { HostTarget } from "../types.js";
 
+/**
+ * Defines the supported recommendation host values.
+ */
 export type RecommendationHost = HostTarget;
 
+/**
+ * Returns get recommendation hosts for the provided inputs.
+ */
 export function getRecommendationHosts(): RecommendationHost[] {
   return [
     ...new Set([
@@ -13,6 +19,9 @@ export function getRecommendationHosts(): RecommendationHost[] {
   ];
 }
 
+/**
+ * Returns whether the provided value matches recommendation host.
+ */
 export function isRecommendationHost(
   value: string,
 ): value is RecommendationHost {

--- a/src/recommend/model.ts
+++ b/src/recommend/model.ts
@@ -6,6 +6,9 @@ import type {
 } from "../types.js";
 import type { RecommendationHost } from "./hosts.js";
 
+/**
+ * Describes demand term context data exchanged by the lifecycle pipeline.
+ */
 export interface DemandTermContext {
   key: string;
   canonicalTerm: string;
@@ -14,12 +17,18 @@ export interface DemandTermContext {
   matchTerms: Set<string>;
 }
 
+/**
+ * Describes demand context data exchanged by the lifecycle pipeline.
+ */
 export interface DemandContext {
   terms: DemandTermContext[];
   hasSignals: boolean;
   activeDomainGroups: Set<string>;
 }
 
+/**
+ * Describes candidate recommendation data exchanged by the lifecycle pipeline.
+ */
 export interface CandidateRecommendation {
   entry: AssetCatalogEntry;
   host: RecommendationHost;
@@ -32,6 +41,9 @@ export interface CandidateRecommendation {
   breakdown: RecommendationScoreBreakdown;
 }
 
+/**
+ * Describes dynamic score data exchanged by the lifecycle pipeline.
+ */
 export interface DynamicScore {
   total: number;
   coverage: number;

--- a/src/recommend/policy.ts
+++ b/src/recommend/policy.ts
@@ -26,6 +26,9 @@ import type {
 } from "../types.js";
 import type { RecommendationHost } from "./hosts.js";
 
+/**
+ * Loads recommendation policy from project state.
+ */
 export async function loadRecommendationPolicy(
   projectRoot: string,
 ): Promise<RecommendationPolicy> {

--- a/src/recommend/report.ts
+++ b/src/recommend/report.ts
@@ -25,6 +25,9 @@ import type {
 } from "../types.js";
 import type { RecommendationHost } from "./hosts.js";
 
+/**
+ * Writes recommendation report to project state.
+ */
 export async function writeRecommendationReport(
   projectRoot: string,
 ): Promise<RecommendationReport> {
@@ -48,6 +51,9 @@ export async function writeRecommendationReport(
   return report;
 }
 
+/**
+ * Builds recommendation report from the provided inputs.
+ */
 export function buildRecommendationReport(
   entries: AssetCatalogEntry[],
   demandProfile: DemandProfile | null,

--- a/src/recommend/selection.ts
+++ b/src/recommend/selection.ts
@@ -3,7 +3,7 @@ import {
   buildCandidateRecommendation,
   computeEntryPreselectionScore,
 } from "./candidates.js";
-import { countBy, countCoverageTags } from "./counts.js";
+
 import type {
   AssetCatalogEntry,
   RecommendationEntry,
@@ -17,6 +17,9 @@ import type {
   DynamicScore,
 } from "./model.js";
 
+/**
+ * Builds top recommendations for host from the provided inputs.
+ */
 export function buildTopRecommendationsForHost(
   host: RecommendationHost,
   entries: AssetCatalogEntry[],
@@ -111,32 +114,27 @@ function preserveRequiredCoverageCandidates(
   >();
 
   for (const target of hostPolicy.targetAssetKinds) {
-    if (target.minimum <= 0) {
-      continue;
-    }
-    const match = scoredCandidates.find(
+    preserveMinimumCandidates(
+      scoredCandidates,
+      preserved,
+      target.minimum,
       (entry) => entry.candidate.entry.assetKind === target.assetKind,
     );
-    if (match) {
-      preserved.set(match.candidate.entry.id, match);
-    }
   }
 
   for (const target of hostPolicy.targetConcerns) {
-    if (target.minimum <= 0) {
-      continue;
-    }
-    const match = scoredCandidates.find((entry) =>
-      entry.candidate.coverageTags.includes(target.concern),
+    preserveMinimumCandidates(
+      scoredCandidates,
+      preserved,
+      target.minimum,
+      (entry) => entry.candidate.coverageTags.includes(target.concern),
     );
-    if (match) {
-      preserved.set(match.candidate.entry.id, match);
-    }
   }
 
   const selected = [...preserved.values()];
+  const effectiveLimit = Math.max(limit, preserved.size);
   for (const entry of scoredCandidates) {
-    if (selected.length >= limit) {
+    if (selected.length >= effectiveLimit) {
       break;
     }
     if (!preserved.has(entry.candidate.entry.id)) {
@@ -144,7 +142,41 @@ function preserveRequiredCoverageCandidates(
     }
   }
 
-  return selected.slice(0, limit).sort(compareScoredCandidates);
+  return selected.slice(0, effectiveLimit).sort(compareScoredCandidates);
+}
+
+function preserveMinimumCandidates(
+  scoredCandidates: Array<{
+    candidate: CandidateRecommendation;
+    preselectionScore: number;
+  }>,
+  preserved: Map<
+    string,
+    { candidate: CandidateRecommendation; preselectionScore: number }
+  >,
+  minimum: number,
+  matchesTarget: (entry: {
+    candidate: CandidateRecommendation;
+    preselectionScore: number;
+  }) => boolean,
+): void {
+  if (minimum <= 0) {
+    return;
+  }
+
+  let preservedCount = [...preserved.values()].filter(matchesTarget).length;
+  for (const entry of scoredCandidates) {
+    if (preservedCount >= minimum) {
+      return;
+    }
+    if (!matchesTarget(entry)) {
+      continue;
+    }
+    if (!preserved.has(entry.candidate.entry.id)) {
+      preserved.set(entry.candidate.entry.id, entry);
+      preservedCount += 1;
+    }
+  }
 }
 
 function computeCandidatePreselectionScore(
@@ -186,11 +218,11 @@ function selectCandidatesForHost(
   policy: RecommendationPolicy,
 ): CandidateRecommendation[] {
   const hostPolicy = policy.hosts[host];
-  const selected: CandidateRecommendation[] = [];
+  const selectionState = createSelectionState();
   const remaining = [...candidates];
 
   while (
-    selected.length < hostPolicy.recommendationLimit &&
+    selectionState.selected.length < hostPolicy.recommendationLimit &&
     remaining.length > 0
   ) {
     let bestIndex = -1;
@@ -198,13 +230,13 @@ function selectCandidatesForHost(
 
     for (let index = 0; index < remaining.length; index += 1) {
       const candidate = remaining[index];
-      if (exceedsHostCaps(candidate, selected, hostPolicy, false)) {
+      if (exceedsHostCaps(candidate, selectionState, hostPolicy)) {
         continue;
       }
 
       const candidateScore = scoreCandidateAgainstSelection(
         candidate,
-        selected,
+        selectionState,
         hostPolicy,
         policy,
         false,
@@ -229,50 +261,60 @@ function selectCandidatesForHost(
     }
 
     const [chosenCandidate] = remaining.splice(bestIndex, 1);
-    selected.push(applyDynamicScore(chosenCandidate, bestScore));
+    addCandidateToSelectionState(
+      selectionState,
+      applyDynamicScore(chosenCandidate, bestScore),
+    );
   }
 
-  if (selected.length >= hostPolicy.recommendationLimit) {
-    return selected;
+  if (selectionState.selected.length >= hostPolicy.recommendationLimit) {
+    return selectionState.selected;
   }
 
   for (const candidate of remaining) {
-    if (selected.length >= hostPolicy.recommendationLimit) {
+    if (selectionState.selected.length >= hostPolicy.recommendationLimit) {
       break;
     }
-    if (exceedsHostCaps(candidate, selected, hostPolicy, true)) {
+    if (exceedsHostCaps(candidate, selectionState, hostPolicy)) {
       continue;
     }
 
     const fallbackScore = scoreCandidateAgainstSelection(
       candidate,
-      selected,
+      selectionState,
       hostPolicy,
       policy,
       true,
     );
-    selected.push(applyDynamicScore(candidate, fallbackScore));
+    addCandidateToSelectionState(
+      selectionState,
+      applyDynamicScore(candidate, fallbackScore),
+    );
   }
 
-  return selected;
+  return selectionState.selected;
 }
 
 function scoreCandidateAgainstSelection(
   candidate: CandidateRecommendation,
-  selected: CandidateRecommendation[],
+  selectionState: SelectionState,
   hostPolicy: RecommendationPolicy["hosts"][RecommendationHost],
   policy: RecommendationPolicy,
   relaxed: boolean,
 ): DynamicScore {
-  const coverage = computeCoverageGain(candidate, selected, hostPolicy, policy);
-  const diversity = selected.some(
-    (entry) => entry.sourceFamily === candidate.sourceFamily,
-  )
-    ? 0
-    : policy.scoring.sourceDiversityBonus;
+  const coverage = computeCoverageGain(
+    candidate,
+    selectionState,
+    hostPolicy,
+    policy,
+  );
+  const diversity =
+    (selectionState.sourceFamilyCounts[candidate.sourceFamily] ?? 0) > 0
+      ? 0
+      : policy.scoring.sourceDiversityBonus;
   const redundancyPenalty = computeRedundancyPenalty(
     candidate,
-    selected,
+    selectionState,
     hostPolicy,
     policy,
   );
@@ -301,18 +343,16 @@ function scoreCandidateAgainstSelection(
 
 function computeCoverageGain(
   candidate: CandidateRecommendation,
-  selected: CandidateRecommendation[],
+  selectionState: SelectionState,
   hostPolicy: RecommendationPolicy["hosts"][RecommendationHost],
   policy: RecommendationPolicy,
 ): number {
   let score = 0;
-  const selectedKinds = countBy(selected, (entry) => entry.entry.assetKind);
-  const selectedConcerns = countCoverageTags(selected);
 
   for (const target of hostPolicy.targetAssetKinds) {
     if (
       target.assetKind === candidate.entry.assetKind &&
-      (selectedKinds[target.assetKind] ?? 0) < target.minimum
+      (selectionState.kindCounts[target.assetKind] ?? 0) < target.minimum
     ) {
       score += target.weight * policy.scoring.coverageGainWeight;
     }
@@ -321,7 +361,7 @@ function computeCoverageGain(
   for (const target of hostPolicy.targetConcerns) {
     if (
       candidate.coverageTags.includes(target.concern) &&
-      (selectedConcerns[target.concern] ?? 0) < target.minimum
+      (selectionState.coverageTagCounts[target.concern] ?? 0) < target.minimum
     ) {
       score += target.weight * policy.scoring.coverageGainWeight;
     }
@@ -332,16 +372,15 @@ function computeCoverageGain(
 
 function computeRedundancyPenalty(
   candidate: CandidateRecommendation,
-  selected: CandidateRecommendation[],
+  selectionState: SelectionState,
   hostPolicy: RecommendationPolicy["hosts"][RecommendationHost],
   policy: RecommendationPolicy,
 ): number {
   let overlapCount = 0;
-  const sameSourceFamilyCount = selected.filter(
-    (entry) => entry.sourceFamily === candidate.sourceFamily,
-  ).length;
+  const sameSourceFamilyCount =
+    selectionState.sourceFamilyCounts[candidate.sourceFamily] ?? 0;
 
-  for (const entry of selected) {
+  for (const entry of selectionState.selected) {
     if (entry.sourceFamily === candidate.sourceFamily) {
       overlapCount += 1;
     }
@@ -383,40 +422,73 @@ function computeSourceSaturationPenalty(
 
 function exceedsHostCaps(
   candidate: CandidateRecommendation,
-  selected: CandidateRecommendation[],
+  selectionState: SelectionState,
   hostPolicy: RecommendationPolicy["hosts"][RecommendationHost],
-  relaxed: boolean,
 ): boolean {
-  const selectedKinds = countBy(selected, (entry) => entry.entry.assetKind);
   const assetKindCap = hostPolicy.maxPerAssetKind[candidate.entry.assetKind];
   if (
     assetKindCap !== undefined &&
-    (selectedKinds[candidate.entry.assetKind] ?? 0) >= assetKindCap
+    (selectionState.kindCounts[candidate.entry.assetKind] ?? 0) >= assetKindCap
   ) {
     return true;
   }
 
-  if (relaxed) {
-    return false;
-  }
-
   if (
-    selected.filter((entry) => entry.sourceFamily === candidate.sourceFamily)
-      .length >= hostPolicy.maxPerSourceFamily
+    (selectionState.sourceFamilyCounts[candidate.sourceFamily] ?? 0) >=
+    hostPolicy.maxPerSourceFamily
   ) {
     return true;
   }
 
   if (
     candidate.duplicateGroup &&
-    selected.filter(
-      (entry) => entry.duplicateGroup === candidate.duplicateGroup,
-    ).length >= hostPolicy.maxPerDuplicateGroup
+    (selectionState.duplicateGroupCounts[candidate.duplicateGroup] ?? 0) >=
+      hostPolicy.maxPerDuplicateGroup
   ) {
     return true;
   }
 
   return false;
+}
+
+interface SelectionState {
+  selected: CandidateRecommendation[];
+  kindCounts: Record<string, number>;
+  sourceFamilyCounts: Record<string, number>;
+  duplicateGroupCounts: Record<string, number>;
+  coverageTagCounts: Record<string, number>;
+}
+
+function createSelectionState(): SelectionState {
+  return {
+    selected: [],
+    kindCounts: {},
+    sourceFamilyCounts: {},
+    duplicateGroupCounts: {},
+    coverageTagCounts: {},
+  };
+}
+
+function addCandidateToSelectionState(
+  selectionState: SelectionState,
+  candidate: CandidateRecommendation,
+): void {
+  selectionState.selected.push(candidate);
+  incrementCount(selectionState.kindCounts, candidate.entry.assetKind);
+  incrementCount(selectionState.sourceFamilyCounts, candidate.sourceFamily);
+  if (candidate.duplicateGroup) {
+    incrementCount(
+      selectionState.duplicateGroupCounts,
+      candidate.duplicateGroup,
+    );
+  }
+  for (const coverageTag of candidate.coverageTags) {
+    incrementCount(selectionState.coverageTagCounts, coverageTag);
+  }
+}
+
+function incrementCount(counts: Record<string, number>, key: string): void {
+  counts[key] = (counts[key] ?? 0) + 1;
 }
 
 function applyDynamicScore(

--- a/src/recommend/signals.ts
+++ b/src/recommend/signals.ts
@@ -8,6 +8,9 @@ import type {
 } from "../types.js";
 import type { DemandContext, DemandTermContext } from "./model.js";
 
+/**
+ * Collects matched signals from the provided inputs.
+ */
 export function collectMatchedSignals(
   searchTerms: Set<string>,
   demandContext: DemandContext,
@@ -35,6 +38,9 @@ export function collectMatchedSignals(
     );
 }
 
+/**
+ * Builds demand context from the provided inputs.
+ */
 export function buildDemandContext(
   demandProfile: DemandProfile | null,
   policy: RecommendationPolicy,
@@ -117,6 +123,9 @@ function buildActiveDomainGroups(
   return activeGroups;
 }
 
+/**
+ * Provides compute out of domain penalty for the lifecycle pipeline.
+ */
 export function computeOutOfDomainPenalty(
   searchTerms: Set<string>,
   demandContext: DemandContext,
@@ -139,6 +148,9 @@ export function computeOutOfDomainPenalty(
   return penalty;
 }
 
+/**
+ * Builds coverage tags from the provided inputs.
+ */
 export function buildCoverageTags(
   searchTerms: Set<string>,
   matchedSignals: RecommendationSignalMatch[],
@@ -161,6 +173,9 @@ export function buildCoverageTags(
   return [...tags].sort();
 }
 
+/**
+ * Builds task modes from the provided inputs.
+ */
 export function buildTaskModes(
   searchTerms: Set<string>,
   coverageTags: string[],
@@ -204,6 +219,9 @@ export function buildTaskModes(
   return [...modes].sort();
 }
 
+/**
+ * Builds duplicate group from the provided inputs.
+ */
 export function buildDuplicateGroup(
   assetKind: AssetKind,
   matchedSignals: RecommendationSignalMatch[],
@@ -224,6 +242,9 @@ export function buildDuplicateGroup(
   return `${assetKind}:${terms.join("+")}`;
 }
 
+/**
+ * Builds search terms from the provided inputs.
+ */
 export function buildSearchTerms(
   values: string[],
   policy: RecommendationPolicy,
@@ -266,6 +287,9 @@ function canonicalizePhrase(
   return normalizedValue;
 }
 
+/**
+ * Provides normalize phrase for the lifecycle pipeline.
+ */
 export function normalizePhrase(value: string): string {
   return value
     .toLowerCase()

--- a/src/recommend/summary.ts
+++ b/src/recommend/summary.ts
@@ -8,6 +8,9 @@ import type {
 } from "../types.js";
 import type { RecommendationHost } from "./hosts.js";
 
+/**
+ * Builds host summary from the provided inputs.
+ */
 export function buildHostSummary(
   host: RecommendationHost,
   entries: RecommendationEntry[],
@@ -31,6 +34,9 @@ export function buildHostSummary(
   };
 }
 
+/**
+ * Builds suggested bundle from the provided inputs.
+ */
 export function buildSuggestedBundle(
   host: RecommendationHost,
   entries: RecommendationEntry[],
@@ -63,10 +69,7 @@ function selectEntriesWithinBudget(
   let remainingBudget = budget;
 
   for (const entry of entries) {
-    if (
-      entry.estimatedPromptWeight <= remainingBudget ||
-      selected.length === 0
-    ) {
+    if (entry.estimatedPromptWeight <= remainingBudget) {
       selected.push(entry);
       remainingBudget -= entry.estimatedPromptWeight;
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -109,7 +109,27 @@ async function runDoctor(
 
 function printLoginGuidance(args: string[]): void {
   const provider = getOptionValue(args, "--provider") ?? args[0] ?? "github";
-  const guidanceByProvider: Record<string, string[]> = {
+  const normalizedProvider = provider.toLowerCase();
+  const guidanceByProvider = buildLoginGuidanceByProvider();
+  const adapter = resolveHostAdapter(normalizedProvider);
+  const guidance =
+    guidanceByProvider[normalizedProvider] ??
+    (adapter ? buildAdapterLoginGuidance(adapter) : undefined);
+  if (!guidance) {
+    console.log(
+      `Unknown login provider '${provider}'. Known providers: ${getLoginProviderNames(guidanceByProvider).join(", ")}`,
+    );
+    return;
+  }
+
+  console.log(`# ${normalizedProvider} login guidance`);
+  for (const line of guidance) {
+    console.log(`- ${line}`);
+  }
+}
+
+function buildLoginGuidanceByProvider(): Record<string, string[]> {
+  return {
     github: [
       "GitHub authentication improves discovery throughput for public and private repository sources.",
       "Create a least-privileged token at https://github.com/settings/tokens?type=beta or https://github.com/settings/tokens.",
@@ -117,25 +137,69 @@ function printLoginGuidance(args: string[]): void {
     ],
     npm: [
       "npm authentication is required only for package publication.",
-      "Run npm login locally or configure NPM_TOKEN as a GitHub Actions secret for release publishing.",
+      "Use npm trusted publishing from GitHub Actions for releases, or run npm login locally for manual package management.",
+    ],
+    "copilot-vscode": [
+      "VS Code/Copilot host-login prerequisites require a signed-in GitHub Copilot session in VS Code.",
+      "Run code --version and code --list-extensions --show-versions to verify CLI and marketplace access.",
+      "Use the VS Code Accounts menu to sign in to GitHub if Copilot or extension access is unavailable.",
+    ],
+    vscode: [
+      "VS Code/Copilot host-login prerequisites require a signed-in GitHub Copilot session in VS Code.",
+      "Run code --version and code --list-extensions --show-versions to verify CLI and marketplace access.",
+      "Use the VS Code Accounts menu to sign in to GitHub if Copilot or extension access is unavailable.",
+    ],
+    cursor: [
+      "Cursor host-login prerequisites require a signed-in Cursor session.",
+      "Run cursor --version and cursor --list-extensions --show-versions to verify CLI and marketplace access.",
+      "Use Cursor account settings to sign in before applying host wire-in that depends on account state.",
+    ],
+    opencode: [
+      "OpenCode host-login prerequisites require a working OpenCode CLI session for runtime validation.",
+      "Run opencode --version to verify CLI availability.",
+    ],
+    anthropic: [
+      "Anthropic OAuth or token prerequisites require an Anthropic account or API key.",
+      "Set ANTHROPIC_API_KEY for token-based assets, or complete the OAuth flow described by the asset setup URL.",
+    ],
+    openai: [
+      "OpenAI OAuth or token prerequisites require an OpenAI account or API key.",
+      "Set OPENAI_API_KEY for token-based assets, or complete the OAuth flow described by the asset setup URL.",
+    ],
+    sentry: [
+      "Sentry OAuth or token prerequisites require access to the target Sentry organization.",
+      "Set SENTRY_AUTH_TOKEN for token-based assets, or complete the OAuth flow described by the asset setup URL.",
     ],
     ai: [
       "Optional AI enrichment uses an OpenAI-compatible chat completions endpoint.",
       "Set AGENT_HARNESS_AI_ENRICHMENT_URL, AGENT_HARNESS_AI_ENRICHMENT_API_KEY, and optionally AGENT_HARNESS_AI_ENRICHMENT_MODEL.",
     ],
   };
-  const guidance = guidanceByProvider[provider.toLowerCase()];
-  if (!guidance) {
-    console.log(
-      `Unknown login provider '${provider}'. Known providers: ${Object.keys(guidanceByProvider).join(", ")}`,
-    );
-    return;
-  }
+}
 
-  console.log(`# ${provider} login guidance`);
-  for (const line of guidance) {
-    console.log(`- ${line}`);
-  }
+function buildAdapterLoginGuidance(adapter: HostAdapter): string[] {
+  const runtimeGuidance = adapter.runtime?.guidance
+    ? [adapter.runtime.guidance]
+    : [];
+  return [
+    `${adapter.displayName} host-login prerequisites require a signed-in and usable host runtime when assets depend on account state.`,
+    ...runtimeGuidance,
+    `Run setup doctor --host ${adapter.id} to check CLI, version, and readiness diagnostics for this adapter.`,
+  ];
+}
+
+function getLoginProviderNames(
+  guidanceByProvider: Record<string, string[]>,
+): string[] {
+  return [
+    ...new Set([
+      ...Object.keys(guidanceByProvider),
+      ...listHostAdapters().flatMap((adapter) => [
+        adapter.id,
+        ...adapter.aliases,
+      ]),
+    ]),
+  ].sort((left, right) => left.localeCompare(right));
 }
 
 function printHosts(): void {
@@ -151,6 +215,9 @@ function printSetupHelp(): void {
     .flatMap((adapter) => [adapter.id, ...adapter.aliases])
     .sort((left, right) => left.localeCompare(right))
     .join("|");
+  const providerNames = getLoginProviderNames(
+    buildLoginGuidanceByProvider(),
+  ).join("|");
   console.log(`setup commands:
   doctor        Check config, host readiness, capabilities, and guided setup notes
   hosts         List registered host adapters
@@ -158,5 +225,5 @@ function printSetupHelp(): void {
 
 Options:
   --host <${hostNames}>
-  --provider <github|npm|ai>`);
+  --provider <${providerNames}>`);
 }

--- a/src/tests/asset-prerequisites.test.ts
+++ b/src/tests/asset-prerequisites.test.ts
@@ -19,18 +19,28 @@ void test("metadata prerequisites map known auth providers and explicit env vars
   const prerequisites = buildAssetPrerequisitesFromMetadata({
     providers: ["openai", "unknown-provider"],
     envVars: ["EXTRA_TOKEN"],
+    hostLogins: ["vscode"],
+    oauthProviders: ["OpenAI"],
     setupUrl: "https://example.com/setup",
   });
 
   assert.deepEqual(
     prerequisites.map((prerequisite) => prerequisite.id),
-    ["auth:openai", "auth:unknown-provider", "env:EXTRA_TOKEN"],
+    [
+      "auth:openai",
+      "auth:unknown-provider",
+      "env:EXTRA_TOKEN",
+      "host-login:copilot-vscode",
+      "oauth:openai",
+    ],
   );
   assert.deepEqual(prerequisites[0]?.envVars, ["OPENAI_API_KEY"]);
   assert.equal(prerequisites[0]?.setupUrl, "https://example.com/setup");
   assert.equal(prerequisites[1]?.kind, "manual");
   assert.equal(prerequisites[1]?.setupUrl, "https://example.com/setup");
   assert.equal(prerequisites[2]?.setupUrl, undefined);
+  assert.equal(prerequisites[3]?.host, "copilot-vscode");
+  assert.equal(prerequisites[4]?.provider, "openai");
 });
 
 void test("missing and present environment prerequisites produce actionable diagnostics", (context) => {

--- a/src/tests/official-index.test.ts
+++ b/src/tests/official-index.test.ts
@@ -11,6 +11,8 @@ void test("official index repo extraction respects checked-in owner allowlist", 
     join(tmpdir(), "agent-harness-official-index-"),
   );
   const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
 
   try {
     await mkdir(join(projectRoot, "discover"), { recursive: true });
@@ -51,6 +53,7 @@ void test("official index repo extraction respects checked-in owner allowlist", 
       );
     context.after(() => {
       globalThis.fetch = originalFetch;
+      restoreFetchMockFlag(previousFetchMockFlag);
     });
 
     const entries = await harvestOfficialSkillIndexes(projectRoot, null, {
@@ -74,6 +77,16 @@ void test("official index repo extraction respects checked-in owner allowlist", 
     );
   } finally {
     globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
     await rm(projectRoot, { force: true, recursive: true });
   }
 });
+
+function restoreFetchMockFlag(previousValue: string | undefined): void {
+  if (previousValue === undefined) {
+    delete process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+    return;
+  }
+
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = previousValue;
+}

--- a/src/tests/public-docstrings.test.ts
+++ b/src/tests/public-docstrings.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+
+const EXPORTED_DECLARATION_PATTERN =
+  /^export\s+(?:default\s+)?(?:(?:async\s+)?(?:function|class|interface|type|enum)\s+(?<name>[A-Za-z_$][\w$]*)|(?:const|let|var)\s+(?<variable>[A-Za-z_$][\w$]*|[[{])|\{\s*[^}]+\s*\}(?:\s*from\s*["'][^"']+["'])?)/u;
+
+void test("public exported declarations have docstrings", async () => {
+  const sourceRoot = join(process.cwd(), "src");
+  const missingDocstrings: string[] = [];
+
+  for (const filePath of await listSourceFiles(sourceRoot)) {
+    const content = await readFile(filePath, "utf8");
+    const lines = content.split(/\r?\n/u);
+
+    lines.forEach((line, index) => {
+      const match = EXPORTED_DECLARATION_PATTERN.exec(line);
+      if (!match || hasDocComment(lines, index)) {
+        return;
+      }
+
+      missingDocstrings.push(
+        `${filePath.replace(process.cwd(), "").replace(/^[/\\]/u, "")}:${index + 1}:${match.groups?.name ?? match.groups?.variable ?? "re-export"}`,
+      );
+    });
+  }
+
+  assert.deepEqual(missingDocstrings, []);
+});
+
+async function listSourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "tests") {
+        continue;
+      }
+      files.push(...(await listSourceFiles(entryPath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function hasDocComment(lines: string[], declarationIndex: number): boolean {
+  for (let index = declarationIndex - 1; index >= 0; index -= 1) {
+    const trimmedLine = lines[index]?.trim() ?? "";
+    if (trimmedLine.length === 0) {
+      continue;
+    }
+
+    return trimmedLine.endsWith("*/");
+  }
+
+  return false;
+}

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildTopRecommendationsForHost } from "../recommend/selection.js";
+import { buildSuggestedBundle } from "../recommend/summary.js";
+import type {
+  AssetCatalogEntry,
+  RecommendationEntry,
+  RecommendationPolicy,
+} from "../types.js";
+
+void test("recommendation preselection preserves minimum counts above one", () => {
+  const policy = buildPolicy({
+    recommendationLimit: 3,
+    targetAssetKinds: [{ assetKind: "skill", minimum: 2, weight: 500 }],
+  });
+  const entries = [
+    buildCatalogEntry("skill-a", "skill", 100),
+    buildCatalogEntry("skill-b", "skill", 90),
+    ...Array.from({ length: 260 }, (_, index) =>
+      buildCatalogEntry(`instruction-${index}`, "instruction", 1_000 - index),
+    ),
+  ];
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    entries,
+    createEmptyDemandContext(),
+    policy,
+  );
+
+  assert.ok(
+    recommendations.filter((entry) => entry.assetKind === "skill").length >= 2,
+  );
+});
+
+void test("recommendation fallback keeps source-family and duplicate caps", () => {
+  const policy = buildPolicy({
+    recommendationLimit: 4,
+    maxPerSourceFamily: 1,
+    maxPerDuplicateGroup: 1,
+  });
+  const entries = [
+    buildCatalogEntry("same-a", "skill", 100, {
+      sourceId: "same",
+      duplicateGroup: "same-group",
+    }),
+    buildCatalogEntry("same-b", "skill", 95, {
+      sourceId: "same",
+      duplicateGroup: "same-group",
+    }),
+    buildCatalogEntry("other-a", "skill", 80, { sourceId: "other-a" }),
+  ];
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    entries,
+    createEmptyDemandContext(),
+    policy,
+  );
+
+  assert.equal(
+    recommendations.filter((entry) => entry.sourceFamily === "same").length,
+    1,
+  );
+  assert.equal(
+    recommendations.filter((entry) => entry.duplicateGroup === "same-group")
+      .length,
+    1,
+  );
+});
+
+void test("suggested bundle skips over-budget first recommendation", () => {
+  const policy = buildPolicy({ recommendationLimit: 2, activationBudget: 5 });
+  const bundle = buildSuggestedBundle(
+    "copilot-vscode",
+    [
+      buildRecommendationEntry("oversized", 8),
+      buildRecommendationEntry("small", 3),
+    ],
+    policy,
+  );
+
+  assert.deepEqual(bundle.assetIds, ["small"]);
+  assert.equal(bundle.estimatedPromptWeight, 3);
+});
+
+function buildPolicy(
+  overrides: Partial<RecommendationPolicy["hosts"]["copilot-vscode"]> = {},
+): RecommendationPolicy {
+  return {
+    schemaVersion: 1,
+    scoring: {
+      demandMatchCap: 20,
+      portfolioFitMultiplier: 10,
+      trustDivisor: 10,
+      sourcePriorityDivisor: 10,
+      authorityWeights: {
+        "official-first-party": 100,
+        "official-marketplace": 80,
+        "official-compatible": 70,
+        "trusted-local": 60,
+        "trusted-community": 40,
+        "unverified-community": 10,
+      },
+      compatibilityWeights: {
+        native: 30,
+        adaptable: 20,
+        partial: 10,
+        "reference-only": 5,
+        incompatible: -100,
+      },
+      costPenalties: { tiny: 0, small: 1, medium: 2, large: 4 },
+      demandSignalWeights: {
+        languages: 1,
+        packageManagers: 1,
+        frameworks: 1,
+        concerns: 1,
+        tooling: 1,
+      },
+      riskLevelPenalties: { low: 0, medium: 2, high: 5 },
+      riskFlagPenalties: { hasHooks: 1, hasExecScripts: 1, requiresNetwork: 1 },
+      freshness: {
+        recentDays: 30,
+        recentBoost: 2,
+        staleDays: 365,
+        stalePenalty: 2,
+        unknownPenalty: 0,
+      },
+      genericCapabilityPenalty: 0,
+      lowFitPenaltyThreshold: 0,
+      lowFitPenalty: 0,
+      weakDemandPenalty: 0,
+      outOfDomainGroupPenalty: 0,
+      coverageGainWeight: 1,
+      sourceDiversityBonus: 1,
+      overlapPenalty: 1,
+      demandTermMultipliers: {},
+    },
+    hosts: {
+      "copilot-vscode": {
+        recommendationLimit: 10,
+        activationBudget: 100,
+        suggestedBundleId: "test-bundle",
+        maxPerSourceFamily: 100,
+        maxPerDuplicateGroup: 100,
+        maxPerAssetKind: {},
+        targetAssetKinds: [],
+        targetConcerns: [],
+        suppressedAssetIdPatterns: [],
+        suppressedCapabilityTerms: [],
+        ...overrides,
+      },
+    } as RecommendationPolicy["hosts"],
+    concernKeywordMap: {},
+    taskModeKeywordMap: {},
+    domainKeywordGroups: {},
+    synonyms: {},
+  };
+}
+
+function buildCatalogEntry(
+  id: string,
+  assetKind: AssetCatalogEntry["assetKind"],
+  sourcePriority: number,
+  options: { duplicateGroup?: string; sourceId?: string } = {},
+): AssetCatalogEntry {
+  const sourceId = options.sourceId ?? id;
+  return {
+    id,
+    displayName: id,
+    assetKind,
+    hosts: ["copilot-vscode"],
+    compatibilityMode: "native",
+    source: {
+      sourceId,
+      authorityTier: "trusted-community",
+      sourceKind: "repo",
+      sourcePriority,
+      originUrl: `https://example.com/${id}`,
+      publisher: sourceId,
+      publisherVerified: false,
+    },
+    trust: { score: sourcePriority, signals: [] },
+    capabilities: [assetKind, id],
+    install: { method: "local-file" },
+    evidence: {
+      manifestFound: true,
+      readmeFound: true,
+      examplesFound: false,
+      docsLinked: true,
+    },
+    maintenance: {
+      lastUpdated: new Date().toISOString(),
+      stars: 0,
+      releaseCadence: "test",
+    },
+    risk: {
+      level: "low",
+      hasHooks: false,
+      hasExecScripts: false,
+      requiresNetwork: false,
+    },
+    contextCost: { sizeClass: "tiny", estimatedPromptWeight: 1 },
+    fit: { portfolioFit: 1, hostFit: 1 },
+    dedupe: {
+      duplicateGroup: options.duplicateGroup,
+      candidateRankHint: "test",
+    },
+    status: {
+      cataloged: true,
+      mirrorEligible: true,
+      installEligible: true,
+      activationEligible: true,
+    },
+  };
+}
+
+function buildRecommendationEntry(
+  assetId: string,
+  estimatedPromptWeight: number,
+): RecommendationEntry {
+  return {
+    assetId,
+    host: "copilot-vscode",
+    rank: 1,
+    score: 1,
+    reasons: [],
+    assetKind: "skill",
+    sourceId: "test",
+    sourceFamily: "test",
+    contextSizeClass: "tiny",
+    estimatedPromptWeight,
+    selectionStage: "top-by-host",
+    coverageTags: [],
+    taskModes: [],
+    matchedSignals: [],
+    scoreBreakdown: {
+      authority: 0,
+      compatibility: 0,
+      portfolioFit: 0,
+      trust: 0,
+      sourcePriority: 0,
+      demand: 0,
+      hostPreference: 0,
+      coverage: 0,
+      diversity: 0,
+      freshness: 0,
+      costPenalty: 0,
+      riskPenalty: 0,
+      negativePenalty: 0,
+      redundancyPenalty: 0,
+      budgetPenalty: 0,
+      total: 1,
+    },
+  };
+}
+
+function createEmptyDemandContext() {
+  return {
+    terms: [],
+    hasSignals: false,
+    activeDomainGroups: new Set<string>(),
+  };
+}

--- a/src/tests/reference-harvesters.test.ts
+++ b/src/tests/reference-harvesters.test.ts
@@ -6,16 +6,19 @@ import type { DemandProfile, SourceDefinition } from "../types.js";
 
 void test("generic docs harvester extracts same-origin reference links", async (context) => {
   const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
   globalThis.fetch = async () =>
     new Response(
       `<html><head><title>Docs Home</title></head><body>
         <a href="/guide">Guide</a>
-        <a href="https://external.example/ignore">External</a>
+        <a href="https://external.invalid/ignore">External</a>
       </body></html>`,
       { status: 200 },
     );
   context.after(() => {
     globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
   });
 
   const items = await harvestReferenceItems(buildDocsSource(), null);
@@ -23,15 +26,19 @@ void test("generic docs harvester extracts same-origin reference links", async (
   assert.equal(items.length, 2);
   assert.equal(items[0]?.assetKind, "reference-pack");
   assert.ok(
-    items.some((item) => item.originUrl === "https://docs.example/guide"),
+    items.some((item) => item.originUrl === "https://example.com/guide"),
   );
   assert.ok(
-    items.every((item) => item.originUrl.startsWith("https://docs.example")),
+    items.every(
+      (item) => new URL(item.originUrl).origin === "https://example.com",
+    ),
   );
 });
 
 void test("VS Code marketplace harvester produces native extension assets", async (context) => {
   const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
   let observedMethod: string | undefined;
   const observedBodies: string[] = [];
   globalThis.fetch = async (_url, init) => {
@@ -58,6 +65,7 @@ void test("VS Code marketplace harvester produces native extension assets", asyn
   };
   context.after(() => {
     globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
   });
 
   const items = await harvestReferenceItems(
@@ -73,6 +81,15 @@ void test("VS Code marketplace harvester produces native extension assets", asyn
   assert.equal(items[0]?.manifestEntry, "GitHub.copilot");
 });
 
+function restoreFetchMockFlag(previousValue: string | undefined): void {
+  if (previousValue === undefined) {
+    delete process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+    return;
+  }
+
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = previousValue;
+}
+
 function buildDocsSource(): SourceDefinition {
   return {
     id: "docs-example",
@@ -84,7 +101,7 @@ function buildDocsSource(): SourceDefinition {
     discoveryMode: "catalog",
     priority: 100,
     enabled: true,
-    endpoints: { docsUrl: "https://docs.example" },
+    endpoints: { docsUrl: "https://example.com" },
     rules: {
       officialPreferred: true,
       allowMirror: true,

--- a/src/tests/security-hardening.test.ts
+++ b/src/tests/security-hardening.test.ts
@@ -1,17 +1,22 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import test from "node:test";
 
 import {
   assertAllowedPublicHttpUrl,
+  assertAllowedPublicHttpUrlWithDns,
   fetchTextWithGuards,
+  type HostnameResolver,
 } from "../lib/http.js";
 import {
   resolveAllowedMirrorEvidenceFilePath,
+  resolveAllowedMirrorEvidenceFilePathForRead,
   resolveSafeMirrorFilePath,
 } from "../mirror.js";
 import {
+  extractRepositoryUrlFromNpmMetadata,
   extractRepositoryUrlFromPypiMetadata,
   fetchPypiPackageMetadata,
 } from "../package-registries.js";
@@ -39,6 +44,8 @@ void test("mirror file path resolution rejects path traversal", () => {
 
 void test("guarded fetches preserve caller abort signals", async (context) => {
   const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
   const controller = new AbortController();
   let observedSignal: AbortSignal | undefined;
 
@@ -49,12 +56,14 @@ void test("guarded fetches preserve caller abort signals", async (context) => {
   };
   context.after(() => {
     globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
   });
 
   await fetchTextWithGuards("https://example.com/index.txt", {
     allowedOrigins: ["https://example.com"],
     timeoutMs: 10_000,
     headers: {},
+    resolveHostname: publicHostnameResolver,
     signal: controller.signal,
   } as Parameters<typeof fetchTextWithGuards>[1] & { signal: AbortSignal });
 
@@ -89,6 +98,30 @@ void test("mirror evidence file paths must stay inside allowed roots", () => {
     resolveAllowedMirrorEvidenceFilePath("relative/SKILL.md", [allowedRoot]),
     null,
   );
+});
+
+void test("mirror evidence file reads reject symlink escapes", async () => {
+  const allowedRoot = await mkdtemp(
+    join(tmpdir(), "agent-harness-evidence-root-"),
+  );
+  const outsideRoot = await mkdtemp(join(tmpdir(), "agent-harness-outside-"));
+  const outsideFile = join(outsideRoot, "agent-harness-outside-secret.txt");
+  const linkedFile = join(allowedRoot, "linked-secret.txt");
+
+  try {
+    await writeFile(outsideFile, "secret", "utf8");
+    await symlink(outsideFile, linkedFile);
+
+    assert.equal(
+      await resolveAllowedMirrorEvidenceFilePathForRead(linkedFile, [
+        allowedRoot,
+      ]),
+      null,
+    );
+  } finally {
+    await rm(allowedRoot, { force: true, recursive: true });
+    await rm(outsideRoot, { force: true, recursive: true });
+  }
 });
 
 void test("guarded public URL validation rejects circular SSRF origins", () => {
@@ -136,8 +169,21 @@ void test("guarded public URL validation rejects circular SSRF origins", () => {
   );
 });
 
+void test("guarded public URL validation rejects private DNS answers", async () => {
+  await assert.rejects(
+    assertAllowedPublicHttpUrlWithDns(
+      "https://api.openai.com/v1/chat/completions",
+      ["https://api.openai.com"],
+      async () => [{ address: "10.0.0.5", family: 4 }],
+    ),
+    /non-public/u,
+  );
+});
+
 void test("guarded fetches disable automatic cross-origin redirects", async (context) => {
   const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
   let observedRedirectMode: RequestRedirect | undefined;
 
   globalThis.fetch = async (_url, init) => {
@@ -146,10 +192,12 @@ void test("guarded fetches disable automatic cross-origin redirects", async (con
   };
   context.after(() => {
     globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
   });
 
   const content = await fetchTextWithGuards("https://example.com/index.txt", {
     allowedOrigins: ["https://example.com"],
+    resolveHostname: publicHostnameResolver,
   });
 
   assert.equal(content, "ok");
@@ -158,6 +206,8 @@ void test("guarded fetches disable automatic cross-origin redirects", async (con
 
 void test("PyPI metadata fetch validates response shape before use", async (context) => {
   const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
   const responsePayload = JSON.stringify({
     info: {
       name: 42,
@@ -178,9 +228,12 @@ void test("PyPI metadata fetch validates response shape before use", async (cont
     });
   context.after(() => {
     globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
   });
 
-  const metadata = await fetchPypiPackageMetadata("fallback-name");
+  const metadata = await fetchPypiPackageMetadata("fallback-name", {
+    resolveHostname: publicHostnameResolver,
+  });
 
   assert.equal(metadata?.info.name, "fallback-name");
   assert.equal(metadata?.info.summary, "Example package");
@@ -204,3 +257,33 @@ void test("PyPI metadata fetch validates response shape before use", async (cont
     undefined,
   );
 });
+
+void test("npm repository extraction normalizes common GitHub syntaxes", () => {
+  for (const repository of [
+    "github:owner/repo",
+    "git@github.com:owner/repo.git",
+    "git+ssh://git@github.com/owner/repo.git",
+    "https://github.com/owner/repo.git",
+    "git+https://github.com/owner/repo.git",
+    "https://github.com/owner/repo/tree/main#readme",
+    "https://github.com/owner/repo/blob/main/README.md?plain=1",
+  ]) {
+    assert.equal(
+      extractRepositoryUrlFromNpmMetadata({ name: "fixture", repository }),
+      "https://github.com/owner/repo",
+    );
+  }
+});
+
+const publicHostnameResolver: HostnameResolver = async () => [
+  { address: "93.184.216.34", family: 4 },
+];
+
+function restoreFetchMockFlag(previousValue: string | undefined): void {
+  if (previousValue === undefined) {
+    delete process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+    return;
+  }
+
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = previousValue;
+}

--- a/src/types/activation.ts
+++ b/src/types/activation.ts
@@ -1,5 +1,8 @@
 import type { HostTarget } from "./core.js";
 
+/**
+ * Describes activation manifest data exchanged by the lifecycle pipeline.
+ */
 export interface ActivationManifest {
   schemaVersion: number;
   host: HostTarget;
@@ -11,6 +14,9 @@ export interface ActivationManifest {
   notes: string[];
 }
 
+/**
+ * Describes copilot workspace overlay manifest data exchanged by the lifecycle pipeline.
+ */
 export interface CopilotWorkspaceOverlayManifest {
   schemaVersion: 1;
   host: "copilot-vscode";
@@ -25,6 +31,9 @@ export interface CopilotWorkspaceOverlayManifest {
   taskModeBuckets?: Record<string, string[]>;
 }
 
+/**
+ * Describes copilot workspace profile manifest data exchanged by the lifecycle pipeline.
+ */
 export interface CopilotWorkspaceProfileManifest {
   schemaVersion: number;
   generatedAt: string;
@@ -43,6 +52,9 @@ export interface CopilotWorkspaceProfileManifest {
   sessionIntent?: string;
 }
 
+/**
+ * Describes wire plan manifest data exchanged by the lifecycle pipeline.
+ */
 export interface WirePlanManifest {
   schemaVersion: number;
   host:
@@ -70,6 +82,9 @@ export interface WirePlanManifest {
   notes: string[];
 }
 
+/**
+ * Describes wire preview manifest data exchanged by the lifecycle pipeline.
+ */
 export interface WirePreviewManifest {
   schemaVersion: number;
   host: "vscode" | "opencode";

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -6,6 +6,9 @@ import type {
   SourceKind,
 } from "./core.js";
 
+/**
+ * Describes asset source metadata data exchanged by the lifecycle pipeline.
+ */
 export interface AssetSourceMetadata {
   sourceId: string;
   authorityTier: AuthorityTier;
@@ -16,13 +19,22 @@ export interface AssetSourceMetadata {
   publisherVerified: boolean;
 }
 
+/**
+ * Describes asset trust data exchanged by the lifecycle pipeline.
+ */
 export interface AssetTrust {
   score: number;
   signals: string[];
 }
 
+/**
+ * Defines the supported asset prerequisite kind values.
+ */
 export type AssetPrerequisiteKind = "env" | "host-login" | "oauth" | "manual";
 
+/**
+ * Describes asset prerequisite data exchanged by the lifecycle pipeline.
+ */
 export interface AssetPrerequisite {
   id: string;
   kind: AssetPrerequisiteKind;
@@ -34,6 +46,9 @@ export interface AssetPrerequisite {
   host?: HostTarget;
 }
 
+/**
+ * Describes asset install metadata data exchanged by the lifecycle pipeline.
+ */
 export interface AssetInstallMetadata {
   method: string;
   nativeHosts?: HostTarget[];
@@ -44,6 +59,9 @@ export interface AssetInstallMetadata {
   prerequisites?: AssetPrerequisite[];
 }
 
+/**
+ * Describes asset evidence data exchanged by the lifecycle pipeline.
+ */
 export interface AssetEvidence {
   manifestFound: boolean;
   readmeFound: boolean;
@@ -56,12 +74,18 @@ export interface AssetEvidence {
   rootPath?: string;
 }
 
+/**
+ * Describes asset maintenance data exchanged by the lifecycle pipeline.
+ */
 export interface AssetMaintenance {
   lastUpdated: string;
   stars: number;
   releaseCadence: string;
 }
 
+/**
+ * Describes asset risk data exchanged by the lifecycle pipeline.
+ */
 export interface AssetRisk {
   level: "low" | "medium" | "high";
   hasHooks: boolean;
@@ -69,21 +93,33 @@ export interface AssetRisk {
   requiresNetwork: boolean;
 }
 
+/**
+ * Describes asset context cost data exchanged by the lifecycle pipeline.
+ */
 export interface AssetContextCost {
   sizeClass: "tiny" | "small" | "medium" | "large";
   estimatedPromptWeight: number;
 }
 
+/**
+ * Describes asset fit data exchanged by the lifecycle pipeline.
+ */
 export interface AssetFit {
   portfolioFit: number;
   hostFit: number;
 }
 
+/**
+ * Describes asset dedupe data exchanged by the lifecycle pipeline.
+ */
 export interface AssetDedupe {
   duplicateGroup?: string;
   candidateRankHint: string;
 }
 
+/**
+ * Describes asset status data exchanged by the lifecycle pipeline.
+ */
 export interface AssetStatus {
   cataloged: boolean;
   mirrorEligible: boolean;
@@ -91,6 +127,9 @@ export interface AssetStatus {
   activationEligible: boolean;
 }
 
+/**
+ * Describes asset catalog entry data exchanged by the lifecycle pipeline.
+ */
 export interface AssetCatalogEntry {
   id: string;
   displayName: string;

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -1,3 +1,6 @@
+/**
+ * Defines the supported authority tier values.
+ */
 export type AuthorityTier =
   | "trusted-local"
   | "official-first-party"
@@ -6,6 +9,9 @@ export type AuthorityTier =
   | "trusted-community"
   | "unverified-community";
 
+/**
+ * Defines the supported source kind values.
+ */
 export type SourceKind =
   | "repo"
   | "docs"
@@ -15,6 +21,9 @@ export type SourceKind =
   | "local-manifest"
   | "local-directory";
 
+/**
+ * Defines the supported asset kind values.
+ */
 export type AssetKind =
   | "skill"
   | "plugin"
@@ -27,6 +36,9 @@ export type AssetKind =
   | "prompt-pack"
   | "reference-pack";
 
+/**
+ * Defines the supported built in host target values.
+ */
 export type BuiltInHostTarget =
   | "copilot-vscode"
   | "opencode"
@@ -36,8 +48,14 @@ export type BuiltInHostTarget =
   | "claude-code"
   | "pi";
 
+/**
+ * Defines the supported host target values.
+ */
 export type HostTarget = BuiltInHostTarget | (string & {});
 
+/**
+ * Defines the supported compatibility mode values.
+ */
 export type CompatibilityMode =
   | "native"
   | "adaptable"

--- a/src/types/discovery.ts
+++ b/src/types/discovery.ts
@@ -5,18 +5,27 @@ import type {
   SourceKind,
 } from "./core.js";
 
+/**
+ * Describes source publisher data exchanged by the lifecycle pipeline.
+ */
 export interface SourcePublisher {
   name: string;
   verified?: boolean;
   owner?: string;
 }
 
+/**
+ * Describes source rules data exchanged by the lifecycle pipeline.
+ */
 export interface SourceRules {
   officialPreferred: boolean;
   allowMirror: boolean;
   allowInstall: boolean;
 }
 
+/**
+ * Describes source definition data exchanged by the lifecycle pipeline.
+ */
 export interface SourceDefinition {
   id: string;
   name: string;
@@ -32,12 +41,18 @@ export interface SourceDefinition {
   rules: SourceRules;
 }
 
+/**
+ * Describes source registry data exchanged by the lifecycle pipeline.
+ */
 export interface SourceRegistry {
   $schema?: string;
   schemaVersion: number;
   sources: SourceDefinition[];
 }
 
+/**
+ * Describes selection policies data exchanged by the lifecycle pipeline.
+ */
 export interface SelectionPolicies {
   officialBeatsPopularity: boolean;
   starsAreTieBreakerOnly: boolean;
@@ -47,6 +62,9 @@ export interface SelectionPolicies {
   communityDefaultPolicy: "catalog-only-unless-promoted";
 }
 
+/**
+ * Describes duplicate group data exchanged by the lifecycle pipeline.
+ */
 export interface DuplicateGroup {
   id: string;
   capability: string;
@@ -54,6 +72,9 @@ export interface DuplicateGroup {
   selectionReason: string;
 }
 
+/**
+ * Describes selection registry data exchanged by the lifecycle pipeline.
+ */
 export interface SelectionRegistry {
   $schema?: string;
   schemaVersion: number;
@@ -62,6 +83,9 @@ export interface SelectionRegistry {
   duplicateGroups: DuplicateGroup[];
 }
 
+/**
+ * Describes demand signal set data exchanged by the lifecycle pipeline.
+ */
 export interface DemandSignalSet {
   languages: string[];
   packageManagers: string[];
@@ -70,12 +94,18 @@ export interface DemandSignalSet {
   tooling: string[];
 }
 
+/**
+ * Describes demand evidence data exchanged by the lifecycle pipeline.
+ */
 export interface DemandEvidence {
   path: string;
   fileName: string;
   matchedSignals: DemandSignalSet;
 }
 
+/**
+ * Describes demand profile data exchanged by the lifecycle pipeline.
+ */
 export interface DemandProfile {
   schemaVersion: number;
   generatedAt: string;
@@ -91,6 +121,9 @@ export interface DemandProfile {
   evidence: DemandEvidence[];
 }
 
+/**
+ * Describes source index data exchanged by the lifecycle pipeline.
+ */
 export interface SourceIndex {
   schemaVersion: number;
   generatedAt: string;
@@ -106,4 +139,44 @@ export interface SourceIndex {
     priority: number;
     hosts: HostTarget[];
   }>;
+}
+
+/**
+ * Describes git hub repo snapshot data exchanged by the lifecycle pipeline.
+ */
+export interface GitHubRepoSnapshot {
+  owner: string;
+  repo: string;
+  sourceId: string;
+  fetchedAt: string;
+  repoSummary: {
+    name: string;
+    fullName: string;
+    description: string | null;
+    defaultBranch: string;
+    updatedAt: string | null;
+    pushedAt: string | null;
+    stars: number;
+    language: string | null;
+    topics: string[];
+    archived: boolean;
+    htmlUrl: string;
+  };
+  readme: {
+    path: string;
+    sha: string;
+    size: number;
+    htmlUrl: string | null;
+    downloadUrl: string | null;
+  } | null;
+  tree: {
+    sha: string;
+    truncated: boolean;
+    entries: Array<{
+      path: string;
+      type: string;
+      size: number | null;
+      sha: string;
+    }>;
+  };
 }

--- a/src/types/install.ts
+++ b/src/types/install.ts
@@ -1,6 +1,9 @@
 import type { AssetContextCost } from "./catalog.js";
 import type { AssetKind, AuthorityTier, HostTarget } from "./core.js";
 
+/**
+ * Describes installed package manifest data exchanged by the lifecycle pipeline.
+ */
 export interface InstalledPackageManifest {
   schemaVersion: number;
   assetId: string;
@@ -18,6 +21,9 @@ export interface InstalledPackageManifest {
   activeByDefault: boolean;
 }
 
+/**
+ * Describes installed bundle manifest data exchanged by the lifecycle pipeline.
+ */
 export interface InstalledBundleManifest {
   schemaVersion: number;
   bundleId: string;
@@ -30,6 +36,9 @@ export interface InstalledBundleManifest {
   }>;
 }
 
+/**
+ * Describes install generation manifest data exchanged by the lifecycle pipeline.
+ */
 export interface InstallGenerationManifest {
   schemaVersion: number;
   generationId: string;
@@ -41,6 +50,9 @@ export interface InstallGenerationManifest {
   pinReason?: string;
 }
 
+/**
+ * Describes install progress state data exchanged by the lifecycle pipeline.
+ */
 export interface InstallProgressState {
   schemaVersion: number;
   updatedAt: string;

--- a/src/types/mirror.ts
+++ b/src/types/mirror.ts
@@ -1,5 +1,8 @@
 import type { AssetKind, AuthorityTier, HostTarget } from "./core.js";
 
+/**
+ * Describes bundle template data exchanged by the lifecycle pipeline.
+ */
 export interface BundleTemplate {
   id: string;
   host: HostTarget;
@@ -8,6 +11,9 @@ export interface BundleTemplate {
   defaultPromotion: string;
 }
 
+/**
+ * Describes mirror policy data exchanged by the lifecycle pipeline.
+ */
 export interface MirrorPolicy {
   schemaVersion: number;
   selection: {
@@ -30,6 +36,9 @@ export interface MirrorPolicy {
   bundleTemplates: BundleTemplate[];
 }
 
+/**
+ * Describes mirror plan data exchanged by the lifecycle pipeline.
+ */
 export interface MirrorPlan {
   schemaVersion: number;
   generatedAt: string;
@@ -53,6 +62,9 @@ export interface MirrorPlan {
   nextActions: string[];
 }
 
+/**
+ * Describes selection duplicate decision data exchanged by the lifecycle pipeline.
+ */
 export interface SelectionDuplicateDecision {
   duplicateGroup: string;
   selectedAssetId: string;
@@ -60,6 +72,9 @@ export interface SelectionDuplicateDecision {
   selectionReason: string;
 }
 
+/**
+ * Describes selection report data exchanged by the lifecycle pipeline.
+ */
 export interface SelectionReport {
   schemaVersion: number;
   generatedAt: string;
@@ -69,6 +84,9 @@ export interface SelectionReport {
   duplicateDecisions: SelectionDuplicateDecision[];
 }
 
+/**
+ * Describes bundle lock asset data exchanged by the lifecycle pipeline.
+ */
 export interface BundleLockAsset {
   assetId: string;
   mirrorId: string;
@@ -77,6 +95,9 @@ export interface BundleLockAsset {
   notes?: string;
 }
 
+/**
+ * Describes bundle lock data exchanged by the lifecycle pipeline.
+ */
 export interface BundleLock {
   schemaVersion: number;
   bundleId: string;
@@ -85,6 +106,9 @@ export interface BundleLock {
   assets: BundleLockAsset[];
 }
 
+/**
+ * Describes mirror index entry data exchanged by the lifecycle pipeline.
+ */
 export interface MirrorIndexEntry {
   mirrorId: string;
   assetId: string;
@@ -114,6 +138,9 @@ export interface MirrorIndexEntry {
     | "reference-only";
 }
 
+/**
+ * Describes mirror acquire state data exchanged by the lifecycle pipeline.
+ */
 export interface MirrorAcquireState {
   schemaVersion: number;
   updatedAt: string;

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -11,8 +11,14 @@ import type {
 } from "./core.js";
 import type { DemandProfile, DemandSignalSet } from "./discovery.js";
 
+/**
+ * Defines the supported recommendation signal type values.
+ */
 export type RecommendationSignalType = keyof DemandSignalSet;
 
+/**
+ * Describes recommendation scoring policy data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationScoringPolicy {
   demandMatchCap: number;
   portfolioFitMultiplier: number;
@@ -46,28 +52,43 @@ export interface RecommendationScoringPolicy {
   demandTermMultipliers: Record<string, number>;
 }
 
+/**
+ * Describes recommendation target asset kind preference data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationTargetAssetKindPreference {
   assetKind: AssetKind;
   minimum: number;
   weight: number;
 }
 
+/**
+ * Describes recommendation target concern preference data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationTargetConcernPreference {
   concern: string;
   minimum: number;
   weight: number;
 }
 
+/**
+ * Describes recommendation policy presets data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationPolicyPresets {
   targetAssetKinds?: Record<string, RecommendationTargetAssetKindPreference[]>;
   targetConcerns?: Record<string, RecommendationTargetConcernPreference[]>;
 }
 
+/**
+ * Describes recommendation policy preset refs data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationPolicyPresetRefs {
   targetAssetKinds?: string[];
   targetConcerns?: string[];
 }
 
+/**
+ * Describes recommendation host policy data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationHostPolicy {
   recommendationLimit: number;
   activationBudget: number;
@@ -87,6 +108,9 @@ export interface RecommendationHostPolicy {
   sourceSaturationPenaltyStep?: number;
 }
 
+/**
+ * Describes recommendation policy base data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationPolicyBase {
   schemaVersion: number;
   scoring: RecommendationScoringPolicy;
@@ -98,6 +122,9 @@ export interface RecommendationPolicyBase {
   synonyms: Record<string, string[]>;
 }
 
+/**
+ * Describes recommendation host policy override data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationHostPolicyOverride {
   schemaVersion: number;
   host: HostTarget;
@@ -105,6 +132,9 @@ export interface RecommendationHostPolicyOverride {
   policy: Partial<RecommendationHostPolicy>;
 }
 
+/**
+ * Describes recommendation policy data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationPolicy {
   schemaVersion: number;
   scoring: RecommendationScoringPolicy;
@@ -115,6 +145,9 @@ export interface RecommendationPolicy {
   synonyms: Record<string, string[]>;
 }
 
+/**
+ * Describes recommendation signal match data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationSignalMatch {
   term: string;
   signalType: RecommendationSignalType;
@@ -122,6 +155,9 @@ export interface RecommendationSignalMatch {
   evidenceCount: number;
 }
 
+/**
+ * Describes recommendation score breakdown data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationScoreBreakdown {
   authority: number;
   compatibility: number;
@@ -141,6 +177,9 @@ export interface RecommendationScoreBreakdown {
   total: number;
 }
 
+/**
+ * Describes recommendation entry data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationEntry {
   assetId: string;
   host: HostTarget;
@@ -160,6 +199,9 @@ export interface RecommendationEntry {
   scoreBreakdown: RecommendationScoreBreakdown;
 }
 
+/**
+ * Describes recommendation host summary data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationHostSummary {
   host: HostTarget;
   recommendationLimit: number;
@@ -174,6 +216,9 @@ export interface RecommendationHostSummary {
   taskModeBuckets: Record<string, string[]>;
 }
 
+/**
+ * Describes recommendation suggested bundle data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationSuggestedBundle {
   host: HostTarget;
   bundleId: string;
@@ -183,6 +228,9 @@ export interface RecommendationSuggestedBundle {
   taskModeBuckets: Record<string, string[]>;
 }
 
+/**
+ * Describes recommendation report data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationReport {
   schemaVersion: number;
   generatedAt: string;
@@ -192,6 +240,9 @@ export interface RecommendationReport {
   suggestedBundles: RecommendationSuggestedBundle[];
 }
 
+/**
+ * Describes recommendation evaluation expectation data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationEvaluationExpectation {
   host: HostTarget;
   requiredAssetIds?: string[];
@@ -207,6 +258,9 @@ export interface RecommendationEvaluationExpectation {
   }>;
 }
 
+/**
+ * Describes recommendation evaluation fixture data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationEvaluationFixture {
   schemaVersion: number;
   id: string;
@@ -216,12 +270,18 @@ export interface RecommendationEvaluationFixture {
   expectations: RecommendationEvaluationExpectation[];
 }
 
+/**
+ * Describes recommendation evaluation check data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationEvaluationCheck {
   name: string;
   passed: boolean;
   details: string;
 }
 
+/**
+ * Describes recommendation evaluation result data exchanged by the lifecycle pipeline.
+ */
 export interface RecommendationEvaluationResult {
   schemaVersion: number;
   generatedAt: string;


### PR DESCRIPTION
## Summary

This PR resolves all currently open audit/code-review issues in one branch and now also covers public exported API docstrings:

- Harden guarded outbound HTTP by resolving and pinning requests to validated public DNS answers, retrying resolved public addresses, rejecting private/reserved DNS results, and avoiding substring URL host checks.
- Reject symlink-escaped mirror evidence reads and verify GitHub raw downloads against raw upstream blob bytes, including fail-closed official-index package mirroring.
- Expand prompt-injection quarantine detection for normalized jailbreak and secret-exfiltration variants.
- Respect source install policy for native reference assets and normalize npm/GitHub repository identities across shorthand, SSH, HTTPS, refs, and extra path suffixes.
- Avoid official-index owner-only fallback mismatches and make catalog IDs collision-resistant.
- Reduce demand-signal and scanner hot-path I/O, inspect actor manifests, skip generated discovery output, and reuse workspace roots during rebuild.
- Break manifest-validation/GitHub and native-wire/registry cycles with leaf type modules.
- Preserve user-owned VS Code skill-location preferences, merge bundle membership, atomically stage activation runtime views before swapping, and keep native preview non-destructive.
- Fix recommendation minimum preservation, fallback hard caps, suggested bundle budget enforcement, and shared coverage-tag counting duplication.
- Validate all Copilot workspace profile selected arrays and add runtime/version/readiness plus canonical host-login/OAuth prerequisite guidance.
- Add JSDoc docstrings for exported source declarations and a regression test that fails when public exported declarations are missing docstrings, including barrel re-exports and exported destructuring patterns.

## Resolved issues

Fixes #66. Fixes #67. Fixes #68. Fixes #69. Fixes #70. Fixes #71. Fixes #72. Fixes #73. Fixes #74. Fixes #75. Fixes #76. Fixes #77. Fixes #78. Fixes #79. Fixes #80. Fixes #81. Fixes #82. Fixes #83. Fixes #84. Fixes #85. Fixes #86. Fixes #87. Fixes #88. Fixes #89. Fixes #90. Fixes #91. Fixes #92. Fixes #93. Fixes #94. Fixes #95. Fixes #96.

## Validation

- `npm run validate`
- `npm run build`
- `npm test`
- `npm run smoke:pack`
- `npm run validate:recommendations`
- `git diff --check`
- secondary AI security audit of the final diff: no blocking findings

## Notes

- Added `public exported declarations have docstrings` test coverage so future exported source declarations must include JSDoc.