### PR TITLE
Fix manual testing findings for discovery and Windows preflight

### DIFF
--- a/src/domains/discovery/catalog-selection.ts
+++ b/src/domains/discovery/catalog-selection.ts
@@ -14,7 +14,8 @@ interface RelevanceFilterResult {
 }
 
 interface DemandRelevanceTerms {
-  highSignalTerms: Set<string>;
+  exactHighSignalTerms: Set<string>;
+  highSignalPhrases: string[][];
   lowSignalTerms: Set<string>;
 }
 
@@ -51,6 +52,9 @@ const LOW_SIGNAL_TERMS = new Set([
 const IGNORED_CONCERN_TERMS = new Set(["base", "detector"]);
 const PORTFOLIO_FIT_RELEVANCE_THRESHOLD = 0.1;
 const LOW_SIGNAL_CONCERN_MATCH_THRESHOLD = 4;
+const HIGH_SIGNAL_PHRASE_MATCH_THRESHOLD = 2;
+const COMMON_HIGH_SIGNAL_CATALOG_SHARE_THRESHOLD = 0.2;
+const MIN_CATALOG_SIZE_FOR_COMMON_HIGH_SIGNAL_FILTER = 200;
 
 /**
  * Filters catalog entries to assets that overlap with workspace demand signals.
@@ -59,10 +63,17 @@ export function filterCatalogEntriesByDemandRelevance(
   catalogEntries: AssetCatalogEntry[],
   demandProfile: DemandProfile | null,
 ): RelevanceFilterResult {
-  const demandTerms = buildDemandTermSet(demandProfile);
+  const catalogTermDocumentFrequency =
+    buildCatalogTermDocumentFrequency(catalogEntries);
+  const demandTerms = buildDemandTermSet(
+    demandProfile,
+    catalogTermDocumentFrequency,
+    catalogEntries.length,
+  );
 
   if (
-    demandTerms.highSignalTerms.size === 0 &&
+    demandTerms.exactHighSignalTerms.size === 0 &&
+    demandTerms.highSignalPhrases.length === 0 &&
     demandTerms.lowSignalTerms.size === 0
   ) {
     return { selectedEntries: catalogEntries, rejectedEntries: [] };
@@ -208,27 +219,52 @@ export function buildSelectionReason(
 
 function buildDemandTermSet(
   demandProfile: DemandProfile | null,
+  catalogTermDocumentFrequency: Map<string, number>,
+  catalogEntryCount: number,
 ): DemandRelevanceTerms {
   if (!demandProfile) {
     return {
-      highSignalTerms: new Set(),
+      exactHighSignalTerms: new Set(),
+      highSignalPhrases: [],
       lowSignalTerms: new Set(),
     };
   }
 
-  const highSignalTerms = new Set<string>();
+  const exactHighSignalTerms = new Set<string>();
+  const highSignalPhrases: string[][] = [];
   const lowSignalTerms = new Set<string>();
 
   for (const language of demandProfile.signals.languages) {
-    addDemandKeywords(language, highSignalTerms, lowSignalTerms);
+    addDemandSignal(
+      language,
+      exactHighSignalTerms,
+      highSignalPhrases,
+      lowSignalTerms,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    );
   }
 
   for (const framework of demandProfile.signals.frameworks) {
-    addDemandKeywords(framework, highSignalTerms, lowSignalTerms);
+    addDemandSignal(
+      framework,
+      exactHighSignalTerms,
+      highSignalPhrases,
+      lowSignalTerms,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    );
   }
 
   for (const concern of demandProfile.signals.concerns) {
-    addDemandKeywords(concern, highSignalTerms, lowSignalTerms);
+    addDemandSignal(
+      concern,
+      exactHighSignalTerms,
+      highSignalPhrases,
+      lowSignalTerms,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    );
   }
 
   for (const tooling of demandProfile.signals.tooling) {
@@ -236,11 +272,19 @@ function buildDemandTermSet(
       continue;
     }
 
-    addDemandKeywords(tooling, highSignalTerms, lowSignalTerms);
+    addDemandSignal(
+      tooling,
+      exactHighSignalTerms,
+      highSignalPhrases,
+      lowSignalTerms,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    );
   }
 
   return {
-    highSignalTerms,
+    exactHighSignalTerms,
+    highSignalPhrases,
     lowSignalTerms,
   };
 }
@@ -251,23 +295,126 @@ function hasPackageEvidencePrefix(value: string): boolean {
   );
 }
 
-function addDemandKeywords(
+function addDemandSignal(
   value: string,
-  highSignalTerms: Set<string>,
+  exactHighSignalTerms: Set<string>,
+  highSignalPhrases: string[][],
   lowSignalTerms: Set<string>,
+  catalogTermDocumentFrequency: Map<string, number>,
+  catalogEntryCount: number,
 ): void {
-  for (const keyword of splitIntoKeywords(stripPackageEvidencePrefix(value))) {
-    if (IGNORED_CONCERN_TERMS.has(keyword)) {
-      continue;
-    }
-
-    if (LOW_SIGNAL_TERMS.has(keyword)) {
-      lowSignalTerms.add(keyword);
-      continue;
-    }
-
-    highSignalTerms.add(keyword);
+  const keywords = normalizeDemandSignalKeywords(value);
+  if (keywords.length === 0) {
+    return;
   }
+
+  if (keywords.length === 1) {
+    addDemandKeyword(
+      keywords[0],
+      exactHighSignalTerms,
+      lowSignalTerms,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    );
+    return;
+  }
+
+  const uncommonKeywords = keywords.filter(
+    (keyword) =>
+      !LOW_SIGNAL_TERMS.has(keyword) &&
+      !isCatalogCommonHighSignal(
+        keyword,
+        catalogTermDocumentFrequency,
+        catalogEntryCount,
+      ),
+  );
+
+  if (uncommonKeywords.length >= HIGH_SIGNAL_PHRASE_MATCH_THRESHOLD) {
+    highSignalPhrases.push(uncommonKeywords);
+    return;
+  }
+
+  if (uncommonKeywords.length === 1) {
+    exactHighSignalTerms.add(uncommonKeywords[0]);
+  }
+
+  for (const keyword of keywords) {
+    if (uncommonKeywords.includes(keyword)) {
+      continue;
+    }
+
+    lowSignalTerms.add(keyword);
+  }
+}
+
+function addDemandKeyword(
+  keyword: string,
+  exactHighSignalTerms: Set<string>,
+  lowSignalTerms: Set<string>,
+  catalogTermDocumentFrequency: Map<string, number>,
+  catalogEntryCount: number,
+): void {
+  if (
+    LOW_SIGNAL_TERMS.has(keyword) ||
+    isCatalogCommonHighSignal(
+      keyword,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    )
+  ) {
+    lowSignalTerms.add(keyword);
+    return;
+  }
+
+  exactHighSignalTerms.add(keyword);
+}
+
+function normalizeDemandSignalKeywords(value: string): string[] {
+  return Array.from(
+    new Set(
+      splitIntoKeywords(stripPackageEvidencePrefix(value)).filter(
+        (keyword) => !IGNORED_CONCERN_TERMS.has(keyword),
+      ),
+    ),
+  );
+}
+
+function isCatalogCommonHighSignal(
+  keyword: string,
+  catalogTermDocumentFrequency: Map<string, number>,
+  catalogEntryCount: number,
+): boolean {
+  if (catalogEntryCount < MIN_CATALOG_SIZE_FOR_COMMON_HIGH_SIGNAL_FILTER) {
+    return false;
+  }
+
+  return (
+    (catalogTermDocumentFrequency.get(keyword) ?? 0) / catalogEntryCount >=
+    COMMON_HIGH_SIGNAL_CATALOG_SHARE_THRESHOLD
+  );
+}
+
+function buildCatalogTermDocumentFrequency(
+  catalogEntries: AssetCatalogEntry[],
+): Map<string, number> {
+  const documentFrequency = new Map<string, number>();
+
+  for (const entry of catalogEntries) {
+    const entryTerms = new Set(
+      [
+        ...entry.capabilities,
+        entry.install.relativePath ?? "",
+        entry.install.manifestEntry ?? "",
+        entry.evidence.filePath ?? "",
+      ].flatMap((value) => splitIntoKeywords(value)),
+    );
+
+    for (const term of entryTerms) {
+      documentFrequency.set(term, (documentFrequency.get(term) ?? 0) + 1);
+    }
+  }
+
+  return documentFrequency;
 }
 
 function stripPackageEvidencePrefix(value: string): string {
@@ -298,8 +445,24 @@ function isEntryRelevantToDemand(
     ].flatMap((value) => splitIntoKeywords(value)),
   );
 
-  for (const demandTerm of demandTerms.highSignalTerms) {
+  for (const demandTerm of demandTerms.exactHighSignalTerms) {
     if (entryTerms.has(demandTerm)) {
+      return true;
+    }
+  }
+
+  for (const demandPhrase of demandTerms.highSignalPhrases) {
+    let phraseMatchCount = 0;
+    for (const demandTerm of demandPhrase) {
+      if (entryTerms.has(demandTerm)) {
+        phraseMatchCount += 1;
+      }
+    }
+
+    if (
+      phraseMatchCount >=
+      Math.min(HIGH_SIGNAL_PHRASE_MATCH_THRESHOLD, demandPhrase.length)
+    ) {
       return true;
     }
   }

--- a/src/domains/discovery/catalog-selection.ts
+++ b/src/domains/discovery/catalog-selection.ts
@@ -13,6 +13,45 @@ interface RelevanceFilterResult {
   rejectedEntries: AssetCatalogEntry[];
 }
 
+interface DemandRelevanceTerms {
+  highSignalTerms: Set<string>;
+  lowSignalTerms: Set<string>;
+}
+
+const LOW_SIGNAL_TERMS = new Set([
+  "api",
+  "automation",
+  "backend",
+  "cd",
+  "ci",
+  "cloud",
+  "data",
+  "database",
+  "debugging",
+  "devops",
+  "docker",
+  "documentation",
+  "express",
+  "frontend",
+  "fullstack",
+  "infrastructure",
+  "integration",
+  "javascript",
+  "knowledge",
+  "logging",
+  "mobile",
+  "node",
+  "python",
+  "react",
+  "testing",
+  "tooling",
+  "typescript",
+]);
+
+const IGNORED_CONCERN_TERMS = new Set(["base", "detector"]);
+const PORTFOLIO_FIT_RELEVANCE_THRESHOLD = 0.1;
+const LOW_SIGNAL_CONCERN_MATCH_THRESHOLD = 4;
+
 /**
  * Filters catalog entries to assets that overlap with workspace demand signals.
  */
@@ -22,7 +61,10 @@ export function filterCatalogEntriesByDemandRelevance(
 ): RelevanceFilterResult {
   const demandTerms = buildDemandTermSet(demandProfile);
 
-  if (demandTerms.size === 0) {
+  if (
+    demandTerms.highSignalTerms.size === 0 &&
+    demandTerms.lowSignalTerms.size === 0
+  ) {
     return { selectedEntries: catalogEntries, rejectedEntries: [] };
   }
 
@@ -164,19 +206,68 @@ export function buildSelectionReason(
   return "Selected by compatibility, portfolio fit, risk, and context-cost ordering.";
 }
 
-function buildDemandTermSet(demandProfile: DemandProfile | null): Set<string> {
+function buildDemandTermSet(
+  demandProfile: DemandProfile | null,
+): DemandRelevanceTerms {
   if (!demandProfile) {
-    return new Set();
+    return {
+      highSignalTerms: new Set(),
+      lowSignalTerms: new Set(),
+    };
   }
 
-  return new Set(
-    [
-      ...demandProfile.signals.languages,
-      ...demandProfile.signals.frameworks,
-      ...demandProfile.signals.concerns,
-      ...demandProfile.signals.tooling,
-    ].flatMap((value) => splitIntoKeywords(stripPackageEvidencePrefix(value))),
+  const highSignalTerms = new Set<string>();
+  const lowSignalTerms = new Set<string>();
+
+  for (const language of demandProfile.signals.languages) {
+    addDemandKeywords(language, highSignalTerms, lowSignalTerms);
+  }
+
+  for (const framework of demandProfile.signals.frameworks) {
+    addDemandKeywords(framework, highSignalTerms, lowSignalTerms);
+  }
+
+  for (const concern of demandProfile.signals.concerns) {
+    addDemandKeywords(concern, highSignalTerms, lowSignalTerms);
+  }
+
+  for (const tooling of demandProfile.signals.tooling) {
+    if (hasPackageEvidencePrefix(tooling)) {
+      continue;
+    }
+
+    addDemandKeywords(tooling, highSignalTerms, lowSignalTerms);
+  }
+
+  return {
+    highSignalTerms,
+    lowSignalTerms,
+  };
+}
+
+function hasPackageEvidencePrefix(value: string): boolean {
+  return /^(?:cargo|cocoapods|gem|go|gradle|maven|npm|nuget|packagist|pub|pypi|swift):/iu.test(
+    value,
   );
+}
+
+function addDemandKeywords(
+  value: string,
+  highSignalTerms: Set<string>,
+  lowSignalTerms: Set<string>,
+): void {
+  for (const keyword of splitIntoKeywords(stripPackageEvidencePrefix(value))) {
+    if (IGNORED_CONCERN_TERMS.has(keyword)) {
+      continue;
+    }
+
+    if (LOW_SIGNAL_TERMS.has(keyword)) {
+      lowSignalTerms.add(keyword);
+      continue;
+    }
+
+    highSignalTerms.add(keyword);
+  }
 }
 
 function stripPackageEvidencePrefix(value: string): string {
@@ -188,22 +279,18 @@ function stripPackageEvidencePrefix(value: string): string {
 
 function isEntryRelevantToDemand(
   entry: AssetCatalogEntry,
-  demandTerms: Set<string>,
+  demandTerms: DemandRelevanceTerms,
 ): boolean {
   if (isExecutableMcpServerEntry(entry)) {
     return true;
   }
 
-  if (entry.fit.portfolioFit > 0) {
+  if (entry.fit.portfolioFit >= PORTFOLIO_FIT_RELEVANCE_THRESHOLD) {
     return true;
   }
 
   const entryTerms = new Set(
     [
-      entry.id,
-      entry.displayName,
-      entry.source.sourceId,
-      entry.source.publisher,
       ...entry.capabilities,
       entry.install.relativePath ?? "",
       entry.install.manifestEntry ?? "",
@@ -211,8 +298,20 @@ function isEntryRelevantToDemand(
     ].flatMap((value) => splitIntoKeywords(value)),
   );
 
-  for (const demandTerm of demandTerms) {
+  for (const demandTerm of demandTerms.highSignalTerms) {
     if (entryTerms.has(demandTerm)) {
+      return true;
+    }
+  }
+
+  let lowSignalOverlapCount = 0;
+  for (const demandTerm of demandTerms.lowSignalTerms) {
+    if (!entryTerms.has(demandTerm)) {
+      continue;
+    }
+
+    lowSignalOverlapCount += 1;
+    if (lowSignalOverlapCount >= LOW_SIGNAL_CONCERN_MATCH_THRESHOLD) {
       return true;
     }
   }

--- a/src/domains/discovery/catalog-selection.ts
+++ b/src/domains/discovery/catalog-selection.ts
@@ -49,8 +49,9 @@ const LOW_SIGNAL_TERMS = new Set([
   "typescript",
 ]);
 
+const PACKAGE_REGISTRY_PREFIX_RE =
+  /^(?:cargo|cocoapods|gem|go|gradle|maven|npm|nuget|packagist|pub|pypi|swift):/iu;
 const IGNORED_CONCERN_TERMS = new Set(["base", "detector"]);
-const PORTFOLIO_FIT_RELEVANCE_THRESHOLD = 0.1;
 const LOW_SIGNAL_CONCERN_MATCH_THRESHOLD = 4;
 const HIGH_SIGNAL_PHRASE_MATCH_THRESHOLD = 2;
 const COMMON_HIGH_SIGNAL_CATALOG_SHARE_THRESHOLD = 0.2;
@@ -290,9 +291,7 @@ function buildDemandTermSet(
 }
 
 function hasPackageEvidencePrefix(value: string): boolean {
-  return /^(?:cargo|cocoapods|gem|go|gradle|maven|npm|nuget|packagist|pub|pypi|swift):/iu.test(
-    value,
-  );
+  return PACKAGE_REGISTRY_PREFIX_RE.test(value);
 }
 
 function addDemandSignal(
@@ -418,10 +417,7 @@ function buildCatalogTermDocumentFrequency(
 }
 
 function stripPackageEvidencePrefix(value: string): string {
-  return value.replace(
-    /^(?:cargo|cocoapods|gem|go|gradle|maven|npm|nuget|packagist|pub|pypi|swift):/iu,
-    "",
-  );
+  return value.replace(PACKAGE_REGISTRY_PREFIX_RE, "");
 }
 
 function isEntryRelevantToDemand(
@@ -429,10 +425,6 @@ function isEntryRelevantToDemand(
   demandTerms: DemandRelevanceTerms,
 ): boolean {
   if (isExecutableMcpServerEntry(entry)) {
-    return true;
-  }
-
-  if (entry.fit.portfolioFit >= PORTFOLIO_FIT_RELEVANCE_THRESHOLD) {
     return true;
   }
 

--- a/src/domains/discovery/catalog-selection.ts
+++ b/src/domains/discovery/catalog-selection.ts
@@ -19,13 +19,22 @@ interface DemandRelevanceTerms {
   lowSignalTerms: Set<string>;
 }
 
+interface CatalogTermData {
+  documentFrequency: Map<string, number>;
+  entryTermsByEntry: Map<AssetCatalogEntry, Set<string>>;
+}
+
 const LOW_SIGNAL_TERMS = new Set([
   "api",
   "automation",
   "backend",
+  "bun",
+  "bundler",
+  "cargo",
   "cd",
   "ci",
   "cloud",
+  "composer",
   "data",
   "database",
   "debugging",
@@ -35,18 +44,28 @@ const LOW_SIGNAL_TERMS = new Set([
   "express",
   "frontend",
   "fullstack",
+  "go",
+  "gradle",
   "infrastructure",
   "integration",
   "javascript",
   "knowledge",
   "logging",
+  "maven",
   "mobile",
   "node",
+  "npm",
+  "nuget",
+  "pip",
+  "pnpm",
+  "pub",
   "python",
   "react",
+  "swift",
   "testing",
   "tooling",
   "typescript",
+  "yarn",
 ]);
 
 const PACKAGE_REGISTRY_PREFIX_RE =
@@ -64,11 +83,10 @@ export function filterCatalogEntriesByDemandRelevance(
   catalogEntries: AssetCatalogEntry[],
   demandProfile: DemandProfile | null,
 ): RelevanceFilterResult {
-  const catalogTermDocumentFrequency =
-    buildCatalogTermDocumentFrequency(catalogEntries);
+  const catalogTermData = buildCatalogTermData(catalogEntries);
   const demandTerms = buildDemandTermSet(
     demandProfile,
-    catalogTermDocumentFrequency,
+    catalogTermData.documentFrequency,
     catalogEntries.length,
   );
 
@@ -84,7 +102,9 @@ export function filterCatalogEntriesByDemandRelevance(
   const rejectedEntries: AssetCatalogEntry[] = [];
 
   for (const entry of catalogEntries) {
-    if (isEntryRelevantToDemand(entry, demandTerms)) {
+    const entryTerms =
+      catalogTermData.entryTermsByEntry.get(entry) ?? new Set();
+    if (isEntryRelevantToDemand(entry, entryTerms, demandTerms)) {
       selectedEntries.push(entry);
     } else {
       rejectedEntries.push(entry);
@@ -257,6 +277,17 @@ function buildDemandTermSet(
     );
   }
 
+  for (const packageManager of demandProfile.signals.packageManagers) {
+    addDemandSignal(
+      packageManager,
+      exactHighSignalTerms,
+      highSignalPhrases,
+      lowSignalTerms,
+      catalogTermDocumentFrequency,
+      catalogEntryCount,
+    );
+  }
+
   for (const concern of demandProfile.signals.concerns) {
     addDemandSignal(
       concern,
@@ -269,10 +300,6 @@ function buildDemandTermSet(
   }
 
   for (const tooling of demandProfile.signals.tooling) {
-    if (hasPackageEvidencePrefix(tooling)) {
-      continue;
-    }
-
     addDemandSignal(
       tooling,
       exactHighSignalTerms,
@@ -288,10 +315,6 @@ function buildDemandTermSet(
     highSignalPhrases,
     lowSignalTerms,
   };
-}
-
-function hasPackageEvidencePrefix(value: string): boolean {
-  return PACKAGE_REGISTRY_PREFIX_RE.test(value);
 }
 
 function addDemandSignal(
@@ -333,15 +356,15 @@ function addDemandSignal(
     return;
   }
 
-  if (uncommonKeywords.length === 1) {
-    exactHighSignalTerms.add(uncommonKeywords[0]);
+  if (
+    uncommonKeywords.length > 0 &&
+    keywords.length >= HIGH_SIGNAL_PHRASE_MATCH_THRESHOLD
+  ) {
+    highSignalPhrases.push(keywords);
+    return;
   }
 
   for (const keyword of keywords) {
-    if (uncommonKeywords.includes(keyword)) {
-      continue;
-    }
-
     lowSignalTerms.add(keyword);
   }
 }
@@ -393,42 +416,33 @@ function isCatalogCommonHighSignal(
   );
 }
 
-function buildCatalogTermDocumentFrequency(
+function buildCatalogTermData(
   catalogEntries: AssetCatalogEntry[],
-): Map<string, number> {
+): CatalogTermData {
   const documentFrequency = new Map<string, number>();
+  const entryTermsByEntry = new Map<AssetCatalogEntry, Set<string>>();
 
   for (const entry of catalogEntries) {
-    const entryTerms = new Set(
-      [
-        ...entry.capabilities,
-        entry.install.relativePath ?? "",
-        entry.install.manifestEntry ?? "",
-        entry.evidence.filePath ?? "",
-      ].flatMap((value) => splitIntoKeywords(value)),
-    );
+    const entryTerms = buildEntryTermSet(entry);
+    entryTermsByEntry.set(entry, entryTerms);
 
     for (const term of entryTerms) {
       documentFrequency.set(term, (documentFrequency.get(term) ?? 0) + 1);
     }
   }
 
-  return documentFrequency;
+  return {
+    documentFrequency,
+    entryTermsByEntry,
+  };
 }
 
 function stripPackageEvidencePrefix(value: string): string {
   return value.replace(PACKAGE_REGISTRY_PREFIX_RE, "");
 }
 
-function isEntryRelevantToDemand(
-  entry: AssetCatalogEntry,
-  demandTerms: DemandRelevanceTerms,
-): boolean {
-  if (isExecutableMcpServerEntry(entry)) {
-    return true;
-  }
-
-  const entryTerms = new Set(
+function buildEntryTermSet(entry: AssetCatalogEntry): Set<string> {
+  return new Set(
     [
       ...entry.capabilities,
       entry.install.relativePath ?? "",
@@ -436,6 +450,16 @@ function isEntryRelevantToDemand(
       entry.evidence.filePath ?? "",
     ].flatMap((value) => splitIntoKeywords(value)),
   );
+}
+
+function isEntryRelevantToDemand(
+  entry: AssetCatalogEntry,
+  entryTerms: Set<string>,
+  demandTerms: DemandRelevanceTerms,
+): boolean {
+  if (isExecutableMcpServerEntry(entry)) {
+    return true;
+  }
 
   for (const demandTerm of demandTerms.exactHighSignalTerms) {
     if (entryTerms.has(demandTerm)) {

--- a/src/domains/discovery/demand-signals.ts
+++ b/src/domains/discovery/demand-signals.ts
@@ -174,7 +174,10 @@ export async function collectDemandSignalsForFile(
   }
 
   if (shouldReadTextForTechnologySignals(fileName)) {
-    enrichGenericTextSignals(fileContent, matchedSignals);
+    enrichGenericTextSignals(
+      getTechnologySignalTextContent(fileName, fileContent),
+      matchedSignals,
+    );
   }
 
   return matchedSignals;
@@ -851,7 +854,7 @@ function shouldReadTextForTechnologySignals(fileName: string): boolean {
   }
 
   if (isDockerfileName(fileName)) {
-    return false;
+    return true;
   }
 
   return (
@@ -859,7 +862,6 @@ function shouldReadTextForTechnologySignals(fileName: string): boolean {
       fileName,
     ) ||
     [
-      "Containerfile",
       "Gemfile",
       "Package.swift",
       "Podfile",
@@ -873,6 +875,24 @@ function shouldReadTextForTechnologySignals(fileName: string): boolean {
       "project.godot",
     ].includes(fileName)
   );
+}
+
+function getTechnologySignalTextContent(
+  fileName: string,
+  content: string | null,
+): string | null {
+  if (!content) {
+    return null;
+  }
+
+  if (!isDockerfileName(fileName)) {
+    return content;
+  }
+
+  return content
+    .split(/\r?\n/u)
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n");
 }
 
 function enrichActorJsonSignals(

--- a/src/domains/discovery/demand-signals.ts
+++ b/src/domains/discovery/demand-signals.ts
@@ -850,11 +850,14 @@ function shouldReadTextForTechnologySignals(fileName: string): boolean {
     return false;
   }
 
+  if (isDockerfileName(fileName)) {
+    return false;
+  }
+
   return (
     /\.(json|ya?ml|toml|xml|gradle|csproj|props|targets|md|mdx|txt|ini|cfg|conf)$/iu.test(
       fileName,
     ) ||
-    isDockerfileName(fileName) ||
     [
       "Containerfile",
       "Gemfile",

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -340,14 +340,37 @@ async function runRuntimeCommand(
   executable: string,
   args: string[],
 ): Promise<{ exitCode: number | null; message: string }> {
-  const timeoutMs = 5_000;
+  const timeoutMs = 10_000;
+  const resolvedExecutable =
+    process.platform === "win32"
+      ? ((await findExecutableOnPath(executable)) ?? executable)
+      : executable;
+  const isWindowsShellWrapper =
+    process.platform === "win32" && /\.(?:cmd|bat)$/iu.test(resolvedExecutable);
 
   return new Promise((resolve) => {
-    const child = spawn(executable, args, {
-      shell: false,
-      stdio: ["ignore", "ignore", "pipe"],
-      windowsHide: true,
-    });
+    const child = isWindowsShellWrapper
+      ? spawn(
+          "powershell.exe",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            buildWindowsPowerShellCommand(executable, args),
+          ],
+          {
+            shell: false,
+            stdio: ["ignore", "ignore", "pipe"],
+            windowsHide: true,
+          },
+        )
+      : spawn(resolvedExecutable, args, {
+          shell: false,
+          stdio: ["ignore", "ignore", "pipe"],
+          windowsHide: true,
+        });
     let settled = false;
     let stderr = "";
     const finish = (exitCode: number | null, message: string): void => {
@@ -373,6 +396,19 @@ async function runRuntimeCommand(
       finish(exitCode, stderr.trim() || `exit code ${String(exitCode)}`);
     });
   });
+}
+
+function buildWindowsPowerShellCommand(
+  executable: string,
+  args: string[],
+): string {
+  const quotedExecutable = quotePowerShellLiteral(executable);
+  const quotedArgs = args.map((argument) => quotePowerShellLiteral(argument));
+  return [`& ${quotedExecutable}`, ...quotedArgs].join(" ");
+}
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/gu, "''")}'`;
 }
 
 /**

--- a/src/lib/preflight.ts
+++ b/src/lib/preflight.ts
@@ -351,6 +351,11 @@ async function runRuntimeCommand(
   return new Promise((resolve) => {
     const child = isWindowsShellWrapper
       ? spawn(
+          // We intentionally avoid `shell: true` here because Windows wrapper
+          // paths with spaces (notably VS Code's `code.cmd`) were misparsed
+          // during real-host validation. PowerShell preserves the executable
+          // path and argv boundaries while still invoking `.cmd` / `.bat`
+          // wrappers reliably.
           "powershell.exe",
           [
             "-NoProfile",

--- a/src/tests/catalog-selection.test.ts
+++ b/src/tests/catalog-selection.test.ts
@@ -76,6 +76,26 @@ void test("catalog selection rejects low-signal concern overlap without stronger
   ]);
 });
 
+void test("catalog selection keeps package-registry tooling evidence", () => {
+  const result = filterCatalogEntriesByDemandRelevance(
+    [
+      buildCatalogEntry("axum-helper", ["axum"]),
+      buildCatalogEntry("duckdb-helper", ["duckdb"]),
+      buildCatalogEntry("generic-tool", ["tooling"]),
+    ],
+    buildPackageRegistryDemandProfile(),
+  );
+
+  assert.deepEqual(result.selectedEntries.map((entry) => entry.id).sort(), [
+    "axum-helper",
+    "duckdb-helper",
+  ]);
+  assert.deepEqual(
+    result.rejectedEntries.map((entry) => entry.id),
+    ["generic-tool"],
+  );
+});
+
 void test("catalog selection requires compound signal specificity", () => {
   const result = filterCatalogEntriesByDemandRelevance(
     [
@@ -101,6 +121,28 @@ void test("catalog selection requires compound signal specificity", () => {
     "analytics-only-pack",
     "engineering-only-pack",
     "sdk-only-pack",
+  ]);
+});
+
+void test("catalog selection does not collapse mixed phrases into generic exact terms", () => {
+  const result = filterCatalogEntriesByDemandRelevance(
+    [
+      buildCatalogEntry("api-design-helper", ["api", "design"]),
+      buildCatalogEntry("design-only-helper", ["design"]),
+      buildCatalogEntry("api-only-helper", ["api"]),
+      buildCatalogEntry("backend-helper", ["backend"]),
+    ],
+    buildApiDesignDemandProfile(),
+  );
+
+  assert.deepEqual(
+    result.selectedEntries.map((entry) => entry.id),
+    ["api-design-helper"],
+  );
+  assert.deepEqual(result.rejectedEntries.map((entry) => entry.id).sort(), [
+    "api-only-helper",
+    "backend-helper",
+    "design-only-helper",
   ]);
 });
 
@@ -182,6 +224,26 @@ function buildLowSignalDemandProfile(): DemandProfile {
   };
 }
 
+function buildPackageRegistryDemandProfile(): DemandProfile {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "/tmp/project",
+    summary: {
+      scannedFiles: 1,
+      matchedFiles: 1,
+    },
+    signals: {
+      languages: [],
+      packageManagers: ["cargo"],
+      frameworks: [],
+      concerns: [],
+      tooling: ["cargo:axum", "pypi:duckdb"],
+    },
+    evidence: [],
+  };
+}
+
 function buildCompoundSignalDemandProfile(): DemandProfile {
   return {
     schemaVersion: 1,
@@ -197,6 +259,26 @@ function buildCompoundSignalDemandProfile(): DemandProfile {
       frameworks: [],
       concerns: ["analytics-engineering"],
       tooling: ["ai-sdk"],
+    },
+    evidence: [],
+  };
+}
+
+function buildApiDesignDemandProfile(): DemandProfile {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "/tmp/project",
+    summary: {
+      scannedFiles: 1,
+      matchedFiles: 1,
+    },
+    signals: {
+      languages: [],
+      packageManagers: [],
+      frameworks: [],
+      concerns: ["api-design"],
+      tooling: [],
     },
     evidence: [],
   };

--- a/src/tests/catalog-selection.test.ts
+++ b/src/tests/catalog-selection.test.ts
@@ -75,6 +75,53 @@ void test("catalog selection rejects low-signal concern overlap without stronger
   );
 });
 
+void test("catalog selection requires compound signal specificity", () => {
+  const result = filterCatalogEntriesByDemandRelevance(
+    [
+      buildCatalogEntry("analytics-engineering-pack", [
+        "analytics",
+        "engineering",
+      ]),
+      buildCatalogEntry("analytics-only-pack", ["analytics"]),
+      buildCatalogEntry("engineering-only-pack", ["engineering"]),
+      buildCatalogEntry("ai-sdk-pack", ["ai", "sdk"]),
+      buildCatalogEntry("ai-only-pack", ["ai"]),
+      buildCatalogEntry("sdk-only-pack", ["sdk"]),
+    ],
+    buildCompoundSignalDemandProfile(),
+  );
+
+  assert.deepEqual(result.selectedEntries.map((entry) => entry.id).sort(), [
+    "ai-sdk-pack",
+    "analytics-engineering-pack",
+  ]);
+  assert.deepEqual(result.rejectedEntries.map((entry) => entry.id).sort(), [
+    "ai-only-pack",
+    "analytics-only-pack",
+    "engineering-only-pack",
+    "sdk-only-pack",
+  ]);
+});
+
+void test("catalog selection demotes catalog-common exact terms", () => {
+  const catalogEntries = [
+    ...Array.from({ length: 205 }, (_, index) =>
+      buildCatalogEntry(`ai-pack-${index + 1}`, ["ai"]),
+    ),
+    buildCatalogEntry("webhook-pack", ["webhook"]),
+  ];
+  const result = filterCatalogEntriesByDemandRelevance(
+    catalogEntries,
+    buildCommonTermDemandProfile(),
+  );
+
+  assert.deepEqual(
+    result.selectedEntries.map((entry) => entry.id),
+    ["webhook-pack"],
+  );
+  assert.equal(result.rejectedEntries.length, 205);
+});
+
 void test("catalog display names use parent folders for generic filenames", () => {
   assert.equal(
     deriveDisplayNameFromPath("skills/flutter-add-integration-test/SKILL.md"),
@@ -128,6 +175,46 @@ function buildLowSignalDemandProfile(): DemandProfile {
         "backend",
         "webhook",
       ],
+      tooling: [],
+    },
+    evidence: [],
+  };
+}
+
+function buildCompoundSignalDemandProfile(): DemandProfile {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "/tmp/project",
+    summary: {
+      scannedFiles: 1,
+      matchedFiles: 1,
+    },
+    signals: {
+      languages: [],
+      packageManagers: [],
+      frameworks: [],
+      concerns: ["analytics-engineering"],
+      tooling: ["ai-sdk"],
+    },
+    evidence: [],
+  };
+}
+
+function buildCommonTermDemandProfile(): DemandProfile {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "/tmp/project",
+    summary: {
+      scannedFiles: 1,
+      matchedFiles: 1,
+    },
+    signals: {
+      languages: [],
+      packageManagers: [],
+      frameworks: [],
+      concerns: ["ai", "webhook"],
       tooling: [],
     },
     evidence: [],

--- a/src/tests/catalog-selection.test.ts
+++ b/src/tests/catalog-selection.test.ts
@@ -42,6 +42,39 @@ void test("catalog selection rejects entries without demand overlap", () => {
   );
 });
 
+void test("catalog selection rejects low-signal concern overlap without stronger evidence", () => {
+  const result = filterCatalogEntriesByDemandRelevance(
+    [
+      buildCatalogEntry("generic-docs", [
+        "documentation",
+        "knowledge-base",
+        "testing",
+      ]),
+      buildCatalogEntry("generic-stack", [
+        "backend",
+        "frontend",
+        "testing",
+        "documentation",
+      ]),
+      buildCatalogEntry("specific-webhook", ["webhook", "integration"]),
+      buildCatalogEntry("high-fit-entry", ["misc"], {
+        portfolioFit: 0.12,
+      }),
+    ],
+    buildLowSignalDemandProfile(),
+  );
+
+  assert.deepEqual(result.selectedEntries.map((entry) => entry.id).sort(), [
+    "generic-stack",
+    "high-fit-entry",
+    "specific-webhook",
+  ]);
+  assert.deepEqual(
+    result.rejectedEntries.map((entry) => entry.id),
+    ["generic-docs"],
+  );
+});
+
 void test("catalog display names use parent folders for generic filenames", () => {
   assert.equal(
     deriveDisplayNameFromPath("skills/flutter-add-integration-test/SKILL.md"),
@@ -74,6 +107,33 @@ function buildDemandProfile(): DemandProfile {
   };
 }
 
+function buildLowSignalDemandProfile(): DemandProfile {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "/tmp/project",
+    summary: {
+      scannedFiles: 1,
+      matchedFiles: 1,
+    },
+    signals: {
+      languages: [],
+      packageManagers: [],
+      frameworks: [],
+      concerns: [
+        "documentation",
+        "knowledge-base",
+        "testing",
+        "frontend",
+        "backend",
+        "webhook",
+      ],
+      tooling: [],
+    },
+    evidence: [],
+  };
+}
+
 function buildCatalogEntry(
   id: string,
   capabilities: string[],
@@ -83,6 +143,7 @@ function buildCatalogEntry(
     installEligible: boolean;
     relativePath: string;
     sourceKind: AssetCatalogEntry["source"]["sourceKind"];
+    portfolioFit: number;
   }> = {},
 ): AssetCatalogEntry {
   return {
@@ -124,7 +185,10 @@ function buildCatalogEntry(
       requiresNetwork: false,
     },
     contextCost: { sizeClass: "tiny", estimatedPromptWeight: 1 },
-    fit: { portfolioFit: id === "apify-skill" ? 0.2 : 0, hostFit: 1 },
+    fit: {
+      portfolioFit: options.portfolioFit ?? (id === "apify-skill" ? 0.2 : 0),
+      hostFit: 1,
+    },
     dedupe: { candidateRankHint: "test" },
     status: {
       cataloged: true,

--- a/src/tests/catalog-selection.test.ts
+++ b/src/tests/catalog-selection.test.ts
@@ -8,7 +8,9 @@ import type { AssetCatalogEntry, DemandProfile } from "../types.js";
 void test("catalog selection rejects entries without demand overlap", () => {
   const result = filterCatalogEntriesByDemandRelevance(
     [
-      buildCatalogEntry("apify-skill", ["apify", "actor", "webhook"]),
+      buildCatalogEntry("apify-skill", ["apify", "actor", "webhook"], {
+        portfolioFit: 0.2,
+      }),
       buildCatalogEntry("flutter-skill", ["flutter", "dart", "mobile"]),
       buildCatalogEntry("postgres-mcp", ["postgres", "mcp"], {
         assetKind: "mcp-server",
@@ -66,13 +68,12 @@ void test("catalog selection rejects low-signal concern overlap without stronger
 
   assert.deepEqual(result.selectedEntries.map((entry) => entry.id).sort(), [
     "generic-stack",
-    "high-fit-entry",
     "specific-webhook",
   ]);
-  assert.deepEqual(
-    result.rejectedEntries.map((entry) => entry.id),
-    ["generic-docs"],
-  );
+  assert.deepEqual(result.rejectedEntries.map((entry) => entry.id).sort(), [
+    "generic-docs",
+    "high-fit-entry",
+  ]);
 });
 
 void test("catalog selection requires compound signal specificity", () => {
@@ -273,7 +274,7 @@ function buildCatalogEntry(
     },
     contextCost: { sizeClass: "tiny", estimatedPromptWeight: 1 },
     fit: {
-      portfolioFit: options.portfolioFit ?? (id === "apify-skill" ? 0.2 : 0),
+      portfolioFit: options.portfolioFit ?? 0,
       hostFit: 1,
     },
     dedupe: { candidateRankHint: "test" },

--- a/src/tests/demand-profile.test.ts
+++ b/src/tests/demand-profile.test.ts
@@ -433,6 +433,28 @@ const repoFixtures: DemandProfileRepoFixture[] = [
     expectedMatchedFilesMin: 1,
   },
   {
+    archetype: "dockerfile-run-text-signals",
+    files: [
+      {
+        path: "Dockerfile",
+        content: [
+          "FROM node:20",
+          "RUN npm install -g apify",
+          "RUN echo webhook >> /tmp/features.txt",
+        ].join("\n"),
+      },
+    ],
+    expectedSignals: {
+      frameworks: ["apify"],
+      concerns: ["automation", "web-scraping", "containerization", "webhook"],
+      tooling: ["actor", "crawler", "docker", "webhook"],
+    },
+    unexpectedSignals: {
+      concerns: ["embedded", "firmware", "rtos", "hardware", "iot"],
+    },
+    expectedMatchedFilesMin: 1,
+  },
+  {
     archetype: "mlops-rag-creative-media",
     files: [
       {

--- a/src/tests/demand-profile.test.ts
+++ b/src/tests/demand-profile.test.ts
@@ -412,6 +412,27 @@ const repoFixtures: DemandProfileRepoFixture[] = [
     expectedMatchedFilesMin: 4,
   },
   {
+    archetype: "dockerfile-comment-no-embedded",
+    files: [
+      {
+        path: "Dockerfile",
+        content: [
+          "FROM ubuntu:22.04",
+          "# Create an embedded entrypoint script",
+          "RUN echo ready",
+        ].join("\n"),
+      },
+    ],
+    expectedSignals: {
+      concerns: ["containerization", "infrastructure"],
+      tooling: ["docker"],
+    },
+    unexpectedSignals: {
+      concerns: ["embedded", "firmware", "rtos", "hardware", "iot"],
+    },
+    expectedMatchedFilesMin: 1,
+  },
+  {
     archetype: "mlops-rag-creative-media",
     files: [
       {

--- a/src/tests/preflight.test.ts
+++ b/src/tests/preflight.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
 import type { HostAdapter } from "../host-adapters/registry.js";
@@ -40,6 +43,61 @@ void test("native install preflight rejects adapters without native provider", a
         diagnostic.code === "fake-host-native-install-unsupported",
     ),
   );
+});
+
+void test("adapter runtime preflight can execute Windows cmd wrappers", async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("Windows-specific wrapper execution test.");
+    return;
+  }
+
+  const tempRoot = await mkdtemp(
+    join(tmpdir(), "agent-harness-preflight-wrapper-"),
+  );
+  await t.test("cmd wrapper resolves and executes", async () => {
+    const wrapperPath = join(tempRoot, "fake-wrapper.cmd");
+    await writeFile(
+      wrapperPath,
+      [
+        "@echo off",
+        'if "%~1"=="--version" echo fake-wrapper 1.0.0',
+        'if "%~1"=="--version" exit /b 0',
+        "echo unexpected args",
+        "exit /b 1",
+      ].join("\r\n"),
+      "utf8",
+    );
+
+    const originalPath = process.env.PATH ?? "";
+    const originalPathext = process.env.PATHEXT;
+    process.env.PATH = `${tempRoot};${originalPath}`;
+    process.env.PATHEXT = ".CMD;.EXE;.BAT;.COM";
+
+    try {
+      const diagnostics = await runAdapterPreflight({
+        ...buildFakeAdapter(),
+        runtime: {
+          executable: "fake-wrapper",
+          versionArgs: ["--version"],
+          guidance: "Install the fake host CLI.",
+        },
+      });
+
+      assert.equal(diagnostics.length, 2);
+      assert.equal(diagnostics[0]?.severity, "info");
+      assert.equal(diagnostics[1]?.severity, "info");
+      assert.equal(diagnostics[1]?.code, "fake-host-version");
+    } finally {
+      process.env.PATH = originalPath;
+      if (originalPathext === undefined) {
+        delete process.env.PATHEXT;
+      } else {
+        process.env.PATHEXT = originalPathext;
+      }
+    }
+  });
+
+  await rm(tempRoot, { recursive: true, force: true });
 });
 
 function buildFakeAdapter(): HostAdapter {

--- a/src/tests/preflight.test.ts
+++ b/src/tests/preflight.test.ts
@@ -54,50 +54,53 @@ void test("adapter runtime preflight can execute Windows cmd wrappers", async (t
   const tempRoot = await mkdtemp(
     join(tmpdir(), "agent-harness-preflight-wrapper-"),
   );
-  await t.test("cmd wrapper resolves and executes", async () => {
-    const wrapperPath = join(tempRoot, "fake-wrapper.cmd");
-    await writeFile(
-      wrapperPath,
-      [
-        "@echo off",
-        'if "%~1"=="--version" echo fake-wrapper 1.0.0',
-        'if "%~1"=="--version" exit /b 0',
-        "echo unexpected args",
-        "exit /b 1",
-      ].join("\r\n"),
-      "utf8",
-    );
 
-    const originalPath = process.env.PATH ?? "";
-    const originalPathext = process.env.PATHEXT;
-    process.env.PATH = `${tempRoot};${originalPath}`;
-    process.env.PATHEXT = ".CMD;.EXE;.BAT;.COM";
+  try {
+    await t.test("cmd wrapper resolves and executes", async () => {
+      const wrapperPath = join(tempRoot, "fake-wrapper.cmd");
+      await writeFile(
+        wrapperPath,
+        [
+          "@echo off",
+          'if "%~1"=="--version" echo fake-wrapper 1.0.0',
+          'if "%~1"=="--version" exit /b 0',
+          "echo unexpected args",
+          "exit /b 1",
+        ].join("\r\n"),
+        "utf8",
+      );
 
-    try {
-      const diagnostics = await runAdapterPreflight({
-        ...buildFakeAdapter(),
-        runtime: {
-          executable: "fake-wrapper",
-          versionArgs: ["--version"],
-          guidance: "Install the fake host CLI.",
-        },
-      });
+      const originalPath = process.env.PATH ?? "";
+      const originalPathext = process.env.PATHEXT;
+      process.env.PATH = `${tempRoot};${originalPath}`;
+      process.env.PATHEXT = ".CMD;.EXE;.BAT;.COM";
 
-      assert.equal(diagnostics.length, 2);
-      assert.equal(diagnostics[0]?.severity, "info");
-      assert.equal(diagnostics[1]?.severity, "info");
-      assert.equal(diagnostics[1]?.code, "fake-host-version");
-    } finally {
-      process.env.PATH = originalPath;
-      if (originalPathext === undefined) {
-        delete process.env.PATHEXT;
-      } else {
-        process.env.PATHEXT = originalPathext;
+      try {
+        const diagnostics = await runAdapterPreflight({
+          ...buildFakeAdapter(),
+          runtime: {
+            executable: "fake-wrapper",
+            versionArgs: ["--version"],
+            guidance: "Install the fake host CLI.",
+          },
+        });
+
+        assert.equal(diagnostics.length, 2);
+        assert.equal(diagnostics[0]?.severity, "info");
+        assert.equal(diagnostics[1]?.severity, "info");
+        assert.equal(diagnostics[1]?.code, "fake-host-version");
+      } finally {
+        process.env.PATH = originalPath;
+        if (originalPathext === undefined) {
+          delete process.env.PATHEXT;
+        } else {
+          process.env.PATHEXT = originalPathext;
+        }
       }
-    }
-  });
-
-  await rm(tempRoot, { recursive: true, force: true });
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });
 
 function buildFakeAdapter(): HostAdapter {


### PR DESCRIPTION
## Summary
- stop Dockerfile free-text scanning from emitting false embedded-system demand signals
- make Windows runtime preflight handle wrapper CLIs reliably and allow enough time for real host version checks
- tighten catalog-demand relevance so generic dependency noise keeps fewer entries selected on real repos

## Validation
- npm run validate
- npm run validate:release
- node .\\dist\\cli.js setup doctor --host vscode
- node .\\dist\\cli.js setup doctor --host opencode
- node .\\dist\\cli.js setup doctor --host pi
- real workspace spot checks:
  - gpt-pilot demand profile no longer emits embedded/firmware/rtos/hardware/iot from Dockerfile comments
  - selection counts improved from 3100/3159 to 2528/3160 on gpt-pilot
  - selection counts improved from 2859/3159 to 1765/3160 on agent-harness
  - selection counts improved from 2860/3159 to 2625/3160 on ClauseHound

Closes #107
Closes #108
Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More precise catalog relevance matching using structured high-/low-signal demand logic
  * Improved Windows runtime invocation with safer command quoting and longer timeout

* **Bug Fixes**
  * More accurate Dockerfile signal extraction by ignoring comment lines and refining text preprocessing

* **Tests**
  * Expanded demand-relevance test scenarios and fixtures, including Dockerfile and Windows runtime cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->