### PR TITLE
Fix mirror acquire terminal state handling

### DIFF
--- a/src/manifest-validation/mirror.ts
+++ b/src/manifest-validation/mirror.ts
@@ -134,5 +134,15 @@ export function assertMirrorAcquireState(
   assertNumber(record.totalEligibleCount, `${context}.totalEligibleCount`);
   assertNumber(record.mirroredCount, `${context}.mirroredCount`);
   assertNumber(record.remainingCount, `${context}.remainingCount`);
+  assertNumber(record.skippedCount, `${context}.skippedCount`);
   assertStringArray(record.lastBatchAssetIds, `${context}.lastBatchAssetIds`);
+  assertNumber(
+    record.lastBatchMirroredCount,
+    `${context}.lastBatchMirroredCount`,
+  );
+  assertNumber(
+    record.lastBatchSkippedCount,
+    `${context}.lastBatchSkippedCount`,
+  );
+  assertBoolean(record.terminal, `${context}.terminal`);
 }

--- a/src/mirror/acquire-state.ts
+++ b/src/mirror/acquire-state.ts
@@ -14,8 +14,24 @@ export function assertMirrorAcquireCheckpoint(
     );
   }
 
+  if (
+    state.mirroredCount + state.skippedCount + state.remainingCount !==
+    state.totalEligibleCount
+  ) {
+    throw new Error(
+      `${context} mirror acquire state is inconsistent: mirrored(${state.mirroredCount}) + skipped(${state.skippedCount}) + remaining(${state.remainingCount}) != total(${state.totalEligibleCount})`,
+    );
+  }
+
   if (!state.terminal) {
     return false;
+  }
+
+  if (state.remainingCount > 0) {
+    throw new Error(
+      `mirror acquire stalled after batch: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.lastBatchSkippedCount} skipped in last batch, ${state.remainingCount} remaining. ` +
+        `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.`,
+    );
   }
 
   if (state.mirroredCount < state.totalEligibleCount) {

--- a/src/mirror/acquire-state.ts
+++ b/src/mirror/acquire-state.ts
@@ -29,14 +29,14 @@ export function assertMirrorAcquireCheckpoint(
 
   if (state.remainingCount > 0) {
     throw new Error(
-      `mirror acquire stalled after batch: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.lastBatchSkippedCount} skipped in last batch, ${state.remainingCount} remaining. ` +
+      `${context} mirror acquire stalled after batch: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.lastBatchSkippedCount} skipped in last batch, ${state.remainingCount} remaining. ` +
         `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.`,
     );
   }
 
   if (state.mirroredCount < state.totalEligibleCount) {
     throw new Error(
-      `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
+      `${context} mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
         `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.`,
     );
   }

--- a/src/mirror/acquire-state.ts
+++ b/src/mirror/acquire-state.ts
@@ -21,7 +21,7 @@ export function assertMirrorAcquireCheckpoint(
   if (state.mirroredCount < state.totalEligibleCount) {
     throw new Error(
       `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
-        `Review skipped assets or adjust mirror policy.`,
+        `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.`,
     );
   }
 

--- a/src/mirror/acquire-state.ts
+++ b/src/mirror/acquire-state.ts
@@ -1,0 +1,29 @@
+import type { MirrorAcquireState } from "../types.js";
+
+/**
+ * Validates a persisted mirror acquire checkpoint for batch orchestration.
+ * Returns true when acquisition is terminal and complete.
+ */
+export function assertMirrorAcquireCheckpoint(
+  state: MirrorAcquireState | null,
+  context: string,
+): boolean {
+  if (!state) {
+    throw new Error(
+      `${context} missing mirror acquire state after mirror acquire batch`,
+    );
+  }
+
+  if (!state.terminal) {
+    return false;
+  }
+
+  if (state.mirroredCount < state.totalEligibleCount) {
+    throw new Error(
+      `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
+        `Review skipped assets or adjust mirror policy.`,
+    );
+  }
+
+  return true;
+}

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -224,13 +224,16 @@ export async function acquireMirrorArtifacts(
   ).length;
   const batchRemainingCount =
     mirrorEligibleEntries.length - totalMirroredCount - skippedAssetIds.length;
-  const isTerminal =
-    batchRemainingCount <= 0 || newMirrorIndexEntries.length === 0;
-  const totalSkippedCount = isTerminal
+  const exhaustedEligibleEntries = batchRemainingCount <= 0;
+  const stalledBatch =
+    entriesToAcquire.length > 0 && newMirrorIndexEntries.length === 0;
+  const isTerminal = exhaustedEligibleEntries || stalledBatch;
+  const totalSkippedCount = exhaustedEligibleEntries
     ? Math.max(0, mirrorEligibleEntries.length - totalMirroredCount)
     : skippedAssetIds.length;
-  const actualRemainingCount =
-    mirrorEligibleEntries.length - totalMirroredCount - totalSkippedCount;
+  const actualRemainingCount = exhaustedEligibleEntries
+    ? 0
+    : Math.max(0, batchRemainingCount);
 
   await writeMirrorAcquireState(projectRoot, {
     schemaVersion: 1,
@@ -249,6 +252,10 @@ export async function acquireMirrorArtifacts(
   if (isTerminal && totalMirroredCount === mirrorEligibleEntries.length) {
     console.log(
       `Mirror acquire complete: ${totalMirroredCount}/${mirrorEligibleEntries.length} artifacts under ${toPosixPath(join(projectRoot, "mirror"))}`,
+    );
+  } else if (stalledBatch) {
+    console.log(
+      `Mirror acquire stalled: ${totalMirroredCount}/${mirrorEligibleEntries.length} mirrored, ${skippedAssetIds.length} skipped in last batch, ${actualRemainingCount} remaining`,
     );
   } else if (isTerminal) {
     console.log(

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -226,7 +226,9 @@ export async function acquireMirrorArtifacts(
     mirrorEligibleEntries.length - totalMirroredCount - skippedAssetIds.length;
   const exhaustedEligibleEntries = batchRemainingCount <= 0;
   const stalledBatch =
-    entriesToAcquire.length > 0 && newMirrorIndexEntries.length === 0;
+    entriesToAcquire.length > 0 &&
+    newMirrorIndexEntries.length === 0 &&
+    !exhaustedEligibleEntries;
   const isTerminal = exhaustedEligibleEntries || stalledBatch;
   const totalSkippedCount = exhaustedEligibleEntries
     ? Math.max(0, mirrorEligibleEntries.length - totalMirroredCount)

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -216,15 +216,21 @@ export async function acquireMirrorArtifacts(
     policy.bundleTemplates.map((template) => template.id),
   );
 
+  const mirroredAssetIds = new Set(
+    mergedMirrorIndexEntries.map((mirrorEntry) => mirrorEntry.assetId),
+  );
   const totalMirroredCount = mirrorEligibleEntries.filter((entry) =>
-    mergedMirrorIndexEntries.some(
-      (mirrorEntry) => mirrorEntry.assetId === entry.id,
-    ),
+    mirroredAssetIds.has(entry.id),
   ).length;
-  const actualRemainingCount =
+  const batchRemainingCount =
     mirrorEligibleEntries.length - totalMirroredCount - skippedAssetIds.length;
   const isTerminal =
-    actualRemainingCount <= 0 || newMirrorIndexEntries.length === 0;
+    batchRemainingCount <= 0 || newMirrorIndexEntries.length === 0;
+  const totalSkippedCount = isTerminal
+    ? Math.max(0, mirrorEligibleEntries.length - totalMirroredCount)
+    : skippedAssetIds.length;
+  const actualRemainingCount =
+    mirrorEligibleEntries.length - totalMirroredCount - totalSkippedCount;
 
   await writeMirrorAcquireState(projectRoot, {
     schemaVersion: 1,
@@ -233,7 +239,7 @@ export async function acquireMirrorArtifacts(
     totalEligibleCount: mirrorEligibleEntries.length,
     mirroredCount: totalMirroredCount,
     remainingCount: Math.max(0, actualRemainingCount),
-    skippedCount: skippedAssetIds.length,
+    skippedCount: totalSkippedCount,
     lastBatchAssetIds: entriesToAcquire.map((entry) => entry.id),
     lastBatchMirroredCount: newMirrorIndexEntries.length,
     lastBatchSkippedCount: skippedAssetIds.length,
@@ -246,7 +252,7 @@ export async function acquireMirrorArtifacts(
     );
   } else if (isTerminal) {
     console.log(
-      `Mirror acquire terminal: ${totalMirroredCount} mirrored, ${skippedAssetIds.length} skipped (unmirrorable) of ${mirrorEligibleEntries.length} eligible`,
+      `Mirror acquire terminal: ${totalMirroredCount} mirrored, ${totalSkippedCount} skipped (unmirrorable) of ${mirrorEligibleEntries.length} eligible`,
     );
   } else {
     console.log(

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -117,6 +117,7 @@ export async function acquireMirrorArtifacts(
   );
   const entriesToAcquire = unresolvedEntries.slice(0, batchSize);
   const newMirrorIndexEntries: MirrorIndexEntry[] = [];
+  const skippedAssetIds: string[] = [];
   const evidenceAllowedRoots = buildMirrorEvidenceAllowedRoots(
     projectRoot,
     workingDirectory,
@@ -130,6 +131,7 @@ export async function acquireMirrorArtifacts(
       evidenceAllowedRoots,
     );
     if (materializedArtifact === null) {
+      skippedAssetIds.push(entry.id);
       continue;
     }
 
@@ -213,26 +215,44 @@ export async function acquireMirrorArtifacts(
     mergedMirrorIndexEntries,
     policy.bundleTemplates.map((template) => template.id),
   );
+
+  const totalMirroredCount = mirrorEligibleEntries.filter((entry) =>
+    mergedMirrorIndexEntries.some(
+      (mirrorEntry) => mirrorEntry.assetId === entry.id,
+    ),
+  ).length;
+  const actualRemainingCount =
+    mirrorEligibleEntries.length - totalMirroredCount - skippedAssetIds.length;
+  const isTerminal =
+    actualRemainingCount <= 0 || newMirrorIndexEntries.length === 0;
+
   await writeMirrorAcquireState(projectRoot, {
     schemaVersion: 1,
     updatedAt: new Date().toISOString(),
     batchSize,
     totalEligibleCount: mirrorEligibleEntries.length,
-    mirroredCount: mirrorEligibleEntries.filter((entry) =>
-      mergedMirrorIndexEntries.some(
-        (mirrorEntry) => mirrorEntry.assetId === entry.id,
-      ),
-    ).length,
-    remainingCount: Math.max(
-      0,
-      unresolvedEntries.length - entriesToAcquire.length,
-    ),
+    mirroredCount: totalMirroredCount,
+    remainingCount: Math.max(0, actualRemainingCount),
+    skippedCount: skippedAssetIds.length,
     lastBatchAssetIds: entriesToAcquire.map((entry) => entry.id),
+    lastBatchMirroredCount: newMirrorIndexEntries.length,
+    lastBatchSkippedCount: skippedAssetIds.length,
+    terminal: isTerminal,
   });
 
-  console.log(
-    `Mirror artifacts acquired under ${toPosixPath(join(projectRoot, "mirror"))}`,
-  );
+  if (isTerminal && totalMirroredCount === mirrorEligibleEntries.length) {
+    console.log(
+      `Mirror acquire complete: ${totalMirroredCount}/${mirrorEligibleEntries.length} artifacts under ${toPosixPath(join(projectRoot, "mirror"))}`,
+    );
+  } else if (isTerminal) {
+    console.log(
+      `Mirror acquire terminal: ${totalMirroredCount} mirrored, ${skippedAssetIds.length} skipped (unmirrorable) of ${mirrorEligibleEntries.length} eligible`,
+    );
+  } else {
+    console.log(
+      `Mirror acquire batch: ${newMirrorIndexEntries.length} mirrored, ${skippedAssetIds.length} skipped this batch (${totalMirroredCount}/${mirrorEligibleEntries.length} total)`,
+    );
+  }
 }
 
 async function materializeMirrorArtifact(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -4,6 +4,7 @@ import { getRuntimeConfig } from "./config/runtime.js";
 import { readJsonFileOrNull } from "./files.js";
 import { runDiscover } from "./discover.js";
 import { runMirror } from "./mirror.js";
+import { assertMirrorAcquireState } from "./manifest-validation/mirror.js";
 import { assertMirrorAcquireCheckpoint } from "./mirror/acquire-state.js";
 import { runInstall } from "./install.js";
 import { runRecommend } from "./recommend.js";
@@ -95,6 +96,7 @@ async function acquireAllMirrorBatches(
     );
     const state = await readJsonFileOrNull<MirrorAcquireState>(
       join(projectRoot, ...MIRROR_ACQUIRE_STATE_PATH),
+      assertMirrorAcquireState,
     );
     if (assertMirrorAcquireCheckpoint(state, "workspace pipeline")) {
       return;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -95,7 +95,16 @@ async function acquireAllMirrorBatches(
     const state = await readJsonFileOrNull<MirrorAcquireState>(
       join(projectRoot, ...MIRROR_ACQUIRE_STATE_PATH),
     );
-    if (!state || state.remainingCount <= 0) {
+    if (!state) {
+      return;
+    }
+    if (state.terminal) {
+      if (state.mirroredCount < state.totalEligibleCount) {
+        throw new Error(
+          `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
+            `Review skipped assets or adjust mirror policy.`,
+        );
+      }
       return;
     }
   }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -4,6 +4,7 @@ import { getRuntimeConfig } from "./config/runtime.js";
 import { readJsonFileOrNull } from "./files.js";
 import { runDiscover } from "./discover.js";
 import { runMirror } from "./mirror.js";
+import { assertMirrorAcquireCheckpoint } from "./mirror/acquire-state.js";
 import { runInstall } from "./install.js";
 import { runRecommend } from "./recommend.js";
 import { runActivate } from "./activate.js";
@@ -95,16 +96,7 @@ async function acquireAllMirrorBatches(
     const state = await readJsonFileOrNull<MirrorAcquireState>(
       join(projectRoot, ...MIRROR_ACQUIRE_STATE_PATH),
     );
-    if (!state) {
-      return;
-    }
-    if (state.terminal) {
-      if (state.mirroredCount < state.totalEligibleCount) {
-        throw new Error(
-          `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
-            `Review skipped assets or adjust mirror policy.`,
-        );
-      }
+    if (assertMirrorAcquireCheckpoint(state, "workspace pipeline")) {
       return;
     }
   }

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -4,6 +4,7 @@ import { getRuntimeConfig } from "./config/runtime.js";
 import { readJsonFileOrNull, removePath, toPosixPath } from "./files.js";
 import { runDiscover } from "./discover.js";
 import { runMirror } from "./mirror.js";
+import { assertMirrorAcquireCheckpoint } from "./mirror/acquire-state.js";
 import { runInstall } from "./install.js";
 import { runRecommend } from "./recommend.js";
 import { runActivate } from "./activate.js";
@@ -85,16 +86,7 @@ async function acquireAllMirrorBatches(
     const state = await readJsonFileOrNull<MirrorAcquireState>(
       join(projectRoot, ...MIRROR_ACQUIRE_STATE_PATH),
     );
-    if (!state) {
-      return;
-    }
-    if (state.terminal) {
-      if (state.mirroredCount < state.totalEligibleCount) {
-        throw new Error(
-          `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
-            `Review skipped assets or adjust mirror policy.`,
-        );
-      }
+    if (assertMirrorAcquireCheckpoint(state, "rebuild full")) {
       return;
     }
   }

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -4,6 +4,7 @@ import { getRuntimeConfig } from "./config/runtime.js";
 import { readJsonFileOrNull, removePath, toPosixPath } from "./files.js";
 import { runDiscover } from "./discover.js";
 import { runMirror } from "./mirror.js";
+import { assertMirrorAcquireState } from "./manifest-validation/mirror.js";
 import { assertMirrorAcquireCheckpoint } from "./mirror/acquire-state.js";
 import { runInstall } from "./install.js";
 import { runRecommend } from "./recommend.js";
@@ -85,6 +86,7 @@ async function acquireAllMirrorBatches(
     );
     const state = await readJsonFileOrNull<MirrorAcquireState>(
       join(projectRoot, ...MIRROR_ACQUIRE_STATE_PATH),
+      assertMirrorAcquireState,
     );
     if (assertMirrorAcquireCheckpoint(state, "rebuild full")) {
       return;

--- a/src/rebuild.ts
+++ b/src/rebuild.ts
@@ -85,7 +85,16 @@ async function acquireAllMirrorBatches(
     const state = await readJsonFileOrNull<MirrorAcquireState>(
       join(projectRoot, ...MIRROR_ACQUIRE_STATE_PATH),
     );
-    if (!state || state.remainingCount <= 0) {
+    if (!state) {
+      return;
+    }
+    if (state.terminal) {
+      if (state.mirroredCount < state.totalEligibleCount) {
+        throw new Error(
+          `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
+            `Review skipped assets or adjust mirror policy.`,
+        );
+      }
       return;
     }
   }

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -80,37 +80,35 @@ void test("mirror acquire checkpoint throws for incomplete terminal state", () =
   );
 });
 
-void test("terminal state keeps mirrored and skipped counts cumulative", () => {
+void test("mirror acquire checkpoint throws for terminal stalled state", () => {
   const state = createAcquireState({
     totalEligibleCount: 20,
     mirroredCount: 14,
-    skippedCount: 6,
-    remainingCount: 0,
-    lastBatchMirroredCount: 0,
+    skippedCount: 3,
+    remainingCount: 3,
+    lastBatchAssetIds: ["a", "b", "c"],
     lastBatchSkippedCount: 3,
     terminal: true,
   });
 
-  assert.equal(
-    state.mirroredCount + state.skippedCount,
-    state.totalEligibleCount,
-    "terminal states should fully account for every eligible asset",
+  assert.throws(
+    () => assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
+    /mirror acquire stalled after batch: 14\/20 mirrored, 3 skipped in last batch, 3 remaining/,
   );
 });
 
-void test("remaining count excludes both mirrored and skipped entries", () => {
+void test("mirror acquire checkpoint rejects inconsistent state arithmetic", () => {
   const state = createAcquireState({
     totalEligibleCount: 20,
     mirroredCount: 8,
     skippedCount: 5,
-    remainingCount: 7,
+    remainingCount: 6,
     lastBatchMirroredCount: 3,
     lastBatchSkippedCount: 2,
   });
 
-  assert.equal(
-    state.remainingCount,
-    state.totalEligibleCount - state.mirroredCount - state.skippedCount,
-    "remaining must account for skipped entries to avoid infinite loops",
+  assert.throws(
+    () => assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
+    /workspace pipeline mirror acquire state is inconsistent/,
   );
 });

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { MirrorAcquireState } from "../types.js";
+
+/**
+ * Regression tests for mirror acquire state logic (issues #111, #112, #113).
+ * Validates that terminal state, skipped counts, and pipeline error conditions
+ * behave correctly when entries are unmirrorable.
+ */
+
+void test("acquire state marks terminal when no progress is made in a batch", () => {
+  // Simulates: all entries in batch returned null (skipped)
+  const state: MirrorAcquireState = {
+    schemaVersion: 1,
+    updatedAt: new Date().toISOString(),
+    batchSize: 10,
+    totalEligibleCount: 5,
+    mirroredCount: 0,
+    remainingCount: 0,
+    skippedCount: 5,
+    lastBatchAssetIds: ["a", "b", "c", "d", "e"],
+    lastBatchMirroredCount: 0,
+    lastBatchSkippedCount: 5,
+    terminal: true,
+  };
+
+  assert.equal(
+    state.terminal,
+    true,
+    "state should be terminal when no progress",
+  );
+  assert.equal(state.lastBatchMirroredCount, 0);
+  assert.equal(state.skippedCount, 5);
+});
+
+void test("acquire state is not terminal when progress is still being made", () => {
+  const state: MirrorAcquireState = {
+    schemaVersion: 1,
+    updatedAt: new Date().toISOString(),
+    batchSize: 10,
+    totalEligibleCount: 20,
+    mirroredCount: 10,
+    remainingCount: 7,
+    skippedCount: 3,
+    lastBatchAssetIds: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
+    lastBatchMirroredCount: 7,
+    lastBatchSkippedCount: 3,
+    terminal: false,
+  };
+
+  assert.equal(state.terminal, false);
+  assert.equal(state.remainingCount, 7);
+});
+
+void test("acquire state is terminal with full success when all eligible are mirrored", () => {
+  const state: MirrorAcquireState = {
+    schemaVersion: 1,
+    updatedAt: new Date().toISOString(),
+    batchSize: 10,
+    totalEligibleCount: 10,
+    mirroredCount: 10,
+    remainingCount: 0,
+    skippedCount: 0,
+    lastBatchAssetIds: ["a", "b", "c"],
+    lastBatchMirroredCount: 3,
+    lastBatchSkippedCount: 0,
+    terminal: true,
+  };
+
+  assert.equal(state.terminal, true);
+  assert.equal(state.mirroredCount, state.totalEligibleCount);
+  assert.equal(state.skippedCount, 0);
+});
+
+void test("pipeline should throw when terminal state is incomplete", () => {
+  // Simulates the pipeline check logic from acquireAllMirrorBatches
+  const state: MirrorAcquireState = {
+    schemaVersion: 1,
+    updatedAt: new Date().toISOString(),
+    batchSize: 10,
+    totalEligibleCount: 10,
+    mirroredCount: 3,
+    remainingCount: 0,
+    skippedCount: 7,
+    lastBatchAssetIds: [],
+    lastBatchMirroredCount: 0,
+    lastBatchSkippedCount: 7,
+    terminal: true,
+  };
+
+  // Reproduce the pipeline guard condition
+  const shouldThrow =
+    state.terminal && state.mirroredCount < state.totalEligibleCount;
+  assert.equal(
+    shouldThrow,
+    true,
+    "pipeline must throw for incomplete terminal state",
+  );
+
+  const errorMessage =
+    `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
+    `Review skipped assets or adjust mirror policy.`;
+  assert.match(errorMessage, /incomplete/);
+  assert.match(errorMessage, /skipped/);
+});
+
+void test("remaining count excludes both mirrored and skipped entries", () => {
+  // The key fix: remaining = eligible - mirrored - skipped
+  const totalEligible = 20;
+  const mirrored = 8;
+  const skipped = 5;
+  const remaining = totalEligible - mirrored - skipped;
+
+  assert.equal(remaining, 7);
+
+  const state: MirrorAcquireState = {
+    schemaVersion: 1,
+    updatedAt: new Date().toISOString(),
+    batchSize: 10,
+    totalEligibleCount: totalEligible,
+    mirroredCount: mirrored,
+    remainingCount: remaining,
+    skippedCount: skipped,
+    lastBatchAssetIds: [],
+    lastBatchMirroredCount: 3,
+    lastBatchSkippedCount: 2,
+    terminal: false,
+  };
+
+  assert.equal(
+    state.remainingCount,
+    state.totalEligibleCount - state.mirroredCount - state.skippedCount,
+    "remaining must account for skipped entries to avoid infinite loops",
+  );
+});

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1,132 +1,112 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { assertMirrorAcquireCheckpoint } from "../mirror/acquire-state.js";
 import type { MirrorAcquireState } from "../types.js";
 
-/**
- * Regression tests for mirror acquire state logic (issues #111, #112, #113).
- * Validates that terminal state, skipped counts, and pipeline error conditions
- * behave correctly when entries are unmirrorable.
- */
-
-void test("acquire state marks terminal when no progress is made in a batch", () => {
-  // Simulates: all entries in batch returned null (skipped)
-  const state: MirrorAcquireState = {
-    schemaVersion: 1,
-    updatedAt: new Date().toISOString(),
-    batchSize: 10,
-    totalEligibleCount: 5,
-    mirroredCount: 0,
-    remainingCount: 0,
-    skippedCount: 5,
-    lastBatchAssetIds: ["a", "b", "c", "d", "e"],
-    lastBatchMirroredCount: 0,
-    lastBatchSkippedCount: 5,
-    terminal: true,
-  };
-
-  assert.equal(
-    state.terminal,
-    true,
-    "state should be terminal when no progress",
-  );
-  assert.equal(state.lastBatchMirroredCount, 0);
-  assert.equal(state.skippedCount, 5);
-});
-
-void test("acquire state is not terminal when progress is still being made", () => {
-  const state: MirrorAcquireState = {
-    schemaVersion: 1,
-    updatedAt: new Date().toISOString(),
-    batchSize: 10,
-    totalEligibleCount: 20,
-    mirroredCount: 10,
-    remainingCount: 7,
-    skippedCount: 3,
-    lastBatchAssetIds: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"],
-    lastBatchMirroredCount: 7,
-    lastBatchSkippedCount: 3,
-    terminal: false,
-  };
-
-  assert.equal(state.terminal, false);
-  assert.equal(state.remainingCount, 7);
-});
-
-void test("acquire state is terminal with full success when all eligible are mirrored", () => {
-  const state: MirrorAcquireState = {
+function createAcquireState(
+  overrides: Partial<MirrorAcquireState> = {},
+): MirrorAcquireState {
+  return {
     schemaVersion: 1,
     updatedAt: new Date().toISOString(),
     batchSize: 10,
     totalEligibleCount: 10,
-    mirroredCount: 10,
+    mirroredCount: 0,
     remainingCount: 0,
     skippedCount: 0,
-    lastBatchAssetIds: ["a", "b", "c"],
-    lastBatchMirroredCount: 3,
+    lastBatchAssetIds: [],
+    lastBatchMirroredCount: 0,
     lastBatchSkippedCount: 0,
-    terminal: true,
+    terminal: false,
+    ...overrides,
   };
+}
 
-  assert.equal(state.terminal, true);
-  assert.equal(state.mirroredCount, state.totalEligibleCount);
-  assert.equal(state.skippedCount, 0);
+void test("mirror acquire checkpoint throws when persisted state is missing", () => {
+  assert.throws(
+    () => assertMirrorAcquireCheckpoint(null, "workspace pipeline"),
+    /workspace pipeline missing mirror acquire state/,
+  );
 });
 
-void test("pipeline should throw when terminal state is incomplete", () => {
-  // Simulates the pipeline check logic from acquireAllMirrorBatches
-  const state: MirrorAcquireState = {
-    schemaVersion: 1,
-    updatedAt: new Date().toISOString(),
-    batchSize: 10,
+void test("mirror acquire checkpoint returns false while more batches are needed", () => {
+  const state = createAcquireState({
+    totalEligibleCount: 20,
+    mirroredCount: 10,
+    skippedCount: 3,
+    remainingCount: 7,
+    lastBatchAssetIds: ["a", "b", "c"],
+    lastBatchMirroredCount: 7,
+    lastBatchSkippedCount: 3,
+    terminal: false,
+  });
+
+  assert.equal(
+    assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
+    false,
+  );
+});
+
+void test("mirror acquire checkpoint returns true for terminal full success", () => {
+  const state = createAcquireState({
+    totalEligibleCount: 10,
+    mirroredCount: 10,
+    remainingCount: 0,
+    lastBatchAssetIds: ["a", "b", "c"],
+    lastBatchMirroredCount: 3,
+    terminal: true,
+  });
+
+  assert.equal(
+    assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
+    true,
+  );
+});
+
+void test("mirror acquire checkpoint throws for incomplete terminal state", () => {
+  const state = createAcquireState({
     totalEligibleCount: 10,
     mirroredCount: 3,
     remainingCount: 0,
     skippedCount: 7,
-    lastBatchAssetIds: [],
-    lastBatchMirroredCount: 0,
     lastBatchSkippedCount: 7,
     terminal: true,
-  };
+  });
 
-  // Reproduce the pipeline guard condition
-  const shouldThrow =
-    state.terminal && state.mirroredCount < state.totalEligibleCount;
-  assert.equal(
-    shouldThrow,
-    true,
-    "pipeline must throw for incomplete terminal state",
+  assert.throws(
+    () => assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
+    /mirror acquire ended incomplete: 3\/10 mirrored, 7 skipped/,
   );
+});
 
-  const errorMessage =
-    `mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
-    `Review skipped assets or adjust mirror policy.`;
-  assert.match(errorMessage, /incomplete/);
-  assert.match(errorMessage, /skipped/);
+void test("terminal state keeps mirrored and skipped counts cumulative", () => {
+  const state = createAcquireState({
+    totalEligibleCount: 20,
+    mirroredCount: 14,
+    skippedCount: 6,
+    remainingCount: 0,
+    lastBatchMirroredCount: 0,
+    lastBatchSkippedCount: 3,
+    terminal: true,
+  });
+
+  assert.equal(
+    state.mirroredCount + state.skippedCount,
+    state.totalEligibleCount,
+    "terminal states should fully account for every eligible asset",
+  );
 });
 
 void test("remaining count excludes both mirrored and skipped entries", () => {
-  // The key fix: remaining = eligible - mirrored - skipped
-  const totalEligible = 20;
-  const mirrored = 8;
-  const skipped = 5;
-  const remaining = totalEligible - mirrored - skipped;
-
-  assert.equal(remaining, 7);
-
-  const state: MirrorAcquireState = {
-    schemaVersion: 1,
-    updatedAt: new Date().toISOString(),
-    batchSize: 10,
-    totalEligibleCount: totalEligible,
-    mirroredCount: mirrored,
-    remainingCount: remaining,
-    skippedCount: skipped,
-    lastBatchAssetIds: [],
+  const state = createAcquireState({
+    totalEligibleCount: 20,
+    mirroredCount: 8,
+    skippedCount: 5,
+    remainingCount: 7,
     lastBatchMirroredCount: 3,
     lastBatchSkippedCount: 2,
-    terminal: false,
-  };
+  });
 
   assert.equal(
     state.remainingCount,

--- a/src/tests/workspace-smoke.ts
+++ b/src/tests/workspace-smoke.ts
@@ -4,11 +4,23 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { clearRuntimeConfig } from "../config/runtime.js";
-import { writeJsonFile, removePath } from "../files.js";
+import {
+  readJsonFileOrNull,
+  readJsonLinesFile,
+  writeJsonFile,
+  removePath,
+} from "../files.js";
 import { resolveHostAdapter } from "../host-adapters/registry.js";
 import { resolveDefaultOpenCodeConfigRoot } from "../lib/paths.js";
 import { prepareStateRoot } from "../lib/state-root.js";
+import { assertInstallProgressState } from "../manifest-validation/install.js";
+import {
+  assertMirrorAcquireState,
+  assertMirrorIndexEntry,
+} from "../manifest-validation/mirror.js";
 import { runWorkspacePipeline } from "../pipeline.js";
+import type { InstallProgressState } from "../types/install.js";
+import type { MirrorAcquireState, MirrorIndexEntry } from "../types/mirror.js";
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const hosts = ["vscode", "opencode", "cursor", "zed", "claude-code", "pi"];
@@ -102,6 +114,68 @@ try {
       sessionIntent: "testing",
       bundleIds: adapter.defaultBundleIds,
     });
+
+    // Assert mirror acquire state consistency
+    const acquireState = await readJsonFileOrNull<MirrorAcquireState>(
+      join(stateRoot, "state", "mirror", "acquire-state.json"),
+      assertMirrorAcquireState,
+    );
+    if (!acquireState) {
+      throw new Error(
+        `[${host}] mirror acquire-state.json missing after pipeline`,
+      );
+    }
+    if (!acquireState.terminal) {
+      throw new Error(
+        `[${host}] mirror acquire state is non-terminal (remaining=${acquireState.remainingCount})`,
+      );
+    }
+    if (
+      acquireState.mirroredCount + acquireState.skippedCount !==
+      acquireState.totalEligibleCount
+    ) {
+      throw new Error(
+        `[${host}] mirror acquire state inconsistent: mirrored(${acquireState.mirroredCount}) + skipped(${acquireState.skippedCount}) != total(${acquireState.totalEligibleCount})`,
+      );
+    }
+    if (acquireState.totalEligibleCount > 0) {
+      const mirrorIndex = await readJsonLinesFile<MirrorIndexEntry>(
+        join(stateRoot, "mirror", "index.jsonl"),
+        assertMirrorIndexEntry,
+      );
+      if (mirrorIndex.length === 0) {
+        throw new Error(
+          `[${host}] eligible assets selected (${acquireState.totalEligibleCount}) but mirror index is empty`,
+        );
+      }
+    }
+
+    // Assert install progress state consistency
+    const progressState = await readJsonFileOrNull<InstallProgressState>(
+      join(stateRoot, "state", "install", "progress.json"),
+      assertInstallProgressState,
+    );
+    if (adapter.defaultBundleIds.length > 0 && !progressState) {
+      throw new Error(
+        `[${host}] install progress state missing for ${adapter.defaultBundleIds.length} expected bundle(s)`,
+      );
+    }
+    if (progressState) {
+      for (const bundleId of adapter.defaultBundleIds) {
+        const bundle = progressState.bundles[bundleId];
+        if (!bundle) {
+          throw new Error(
+            `[${host}] install progress missing expected bundle "${bundleId}"`,
+          );
+        }
+        if (bundle.remainingAssets > 0) {
+          throw new Error(
+            `[${host}] install progress bundle "${bundleId}" still has ${bundle.remainingAssets} remaining assets`,
+          );
+        }
+      }
+    }
+
     await adapter.wire({
       projectRoot: stateRoot,
       workspaceRoot,

--- a/src/types/mirror.ts
+++ b/src/types/mirror.ts
@@ -148,5 +148,9 @@ export interface MirrorAcquireState {
   totalEligibleCount: number;
   mirroredCount: number;
   remainingCount: number;
+  skippedCount: number;
   lastBatchAssetIds: string[];
+  lastBatchMirroredCount: number;
+  lastBatchSkippedCount: number;
+  terminal: boolean;
 }


### PR DESCRIPTION
## Summary
- track skipped and terminal mirror acquire state explicitly so incomplete batches stop cleanly
- make workspace/rebuild fail with an actionable error when mirror acquire terminates incomplete
- harden workspace smoke coverage with mirror/install state assertions and add regression tests for acquire state semantics

## Validation
- npm run build
- node --test dist/tests/mirror-acquire-state.test.js
- npm run smoke:workspace
- npm pack --dry-run
- real repro: workspace opencode against temp clone of \Webhook Debugger and Logger\ now terminates with an actionable incomplete-mirror error instead of stalling
- real repro: workspace vscode against temp clone of \gent-harness\ now terminates with an actionable incomplete-mirror error instead of falsely succeeding

Closes #111
Closes #112
Closes #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer batch-level reporting and persisted per-batch metrics; tracks skipped artifacts and terminal completion.

* **Bug Fixes**
  * Improved detection and handling of inconsistent or incomplete mirror states with clearer errors and terminal-driven termination.
  * Better validation and accounting for materialization failures.

* **Tests**
  * Added regression tests for mirror state consistency and completion.
  * Enhanced post-pipeline verification of mirror and install state integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->