### PR TITLE
Fix mirror acquire batching follow-ups

### DIFF
--- a/src/manifest-validation/mirror.ts
+++ b/src/manifest-validation/mirror.ts
@@ -135,6 +135,7 @@ export function assertMirrorAcquireState(
   assertNumber(record.mirroredCount, `${context}.mirroredCount`);
   assertNumber(record.remainingCount, `${context}.remainingCount`);
   assertNumber(record.skippedCount, `${context}.skippedCount`);
+  assertStringArray(record.skippedAssetIds, `${context}.skippedAssetIds`);
   assertStringArray(record.lastBatchAssetIds, `${context}.lastBatchAssetIds`);
   assertNumber(
     record.lastBatchMirroredCount,

--- a/src/mirror/acquire-state.ts
+++ b/src/mirror/acquire-state.ts
@@ -14,6 +14,12 @@ export function assertMirrorAcquireCheckpoint(
     );
   }
 
+  if (state.skippedAssetIds.length !== state.skippedCount) {
+    throw new Error(
+      `${context} mirror acquire state is inconsistent: skippedAssetIds(${state.skippedAssetIds.length}) != skippedCount(${state.skippedCount})`,
+    );
+  }
+
   if (
     state.mirroredCount + state.skippedCount + state.remainingCount !==
     state.totalEligibleCount

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -249,10 +249,15 @@ export async function acquireMirrorArtifacts(
     ...scopedSkippedAssetIds,
     ...skippedAssetIds,
   ]);
+  const effectiveSkippedAssetIds = new Set(
+    [...cumulativeSkippedAssetIds].filter(
+      (assetId) => !mirroredAssetIds.has(assetId),
+    ),
+  );
   const totalMirroredCount = mirrorEligibleEntries.filter((entry) =>
     mirroredAssetIds.has(entry.id),
   ).length;
-  const totalSkippedCount = cumulativeSkippedAssetIds.size;
+  const totalSkippedCount = effectiveSkippedAssetIds.size;
   const actualRemainingCount = Math.max(
     0,
     mirrorEligibleEntries.length - totalMirroredCount - totalSkippedCount,
@@ -267,7 +272,7 @@ export async function acquireMirrorArtifacts(
     mirroredCount: totalMirroredCount,
     remainingCount: actualRemainingCount,
     skippedCount: totalSkippedCount,
-    skippedAssetIds: [...cumulativeSkippedAssetIds].sort(),
+    skippedAssetIds: [...effectiveSkippedAssetIds].sort(),
     lastBatchAssetIds: entriesToAcquire.map((entry) => entry.id),
     lastBatchMirroredCount: newMirrorIndexEntries.length,
     lastBatchSkippedCount: skippedAssetIds.length,

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -7,6 +7,7 @@ import {
   ensureCleanDirectory,
   ensureDirectory,
   readJsonFile,
+  readJsonFileOrNull,
   readJsonLinesFile,
   readTextFileOrNull,
   toPosixPath,
@@ -76,6 +77,15 @@ interface MirrorFileManifest {
   }>;
 }
 
+interface AcquireMirrorArtifactsDependencies {
+  materializeArtifact?: (
+    entry: AssetCatalogEntry,
+    projectRoot: string,
+    requirePinnedProvenance: boolean,
+    evidenceAllowedRoots: readonly string[],
+  ) => Promise<MaterializedMirrorArtifact | null>;
+}
+
 /**
  * Provides acquire mirror artifacts for the lifecycle pipeline.
  */
@@ -83,6 +93,7 @@ export async function acquireMirrorArtifacts(
   projectRoot: string,
   workingDirectory: string,
   args: string[],
+  dependencies: AcquireMirrorArtifactsDependencies = {},
 ): Promise<void> {
   const policy = await readJsonFile<MirrorPolicy>(
     join(projectRoot, "mirror", "policy.json"),
@@ -109,11 +120,16 @@ export async function acquireMirrorArtifacts(
     join(projectRoot, ...MIRROR_INDEX_OUTPUT_PATH),
     assertMirrorIndexEntry,
   );
+  const previouslySkippedAssetIds = await readPersistedSkippedAssetIds(
+    projectRoot,
+  );
   const existingMirrorIdsByAssetId = new Map(
     existingMirrorIndexEntries.map((entry) => [entry.assetId, entry.mirrorId]),
   );
   const unresolvedEntries = mirrorEligibleEntries.filter(
-    (entry) => !existingMirrorIdsByAssetId.has(entry.id),
+    (entry) =>
+      !existingMirrorIdsByAssetId.has(entry.id) &&
+      !previouslySkippedAssetIds.has(entry.id),
   );
   const entriesToAcquire = unresolvedEntries.slice(0, batchSize);
   const newMirrorIndexEntries: MirrorIndexEntry[] = [];
@@ -122,9 +138,11 @@ export async function acquireMirrorArtifacts(
     projectRoot,
     workingDirectory,
   );
+  const materializeArtifact =
+    dependencies.materializeArtifact ?? materializeMirrorArtifact;
 
   for (const entry of entriesToAcquire) {
-    const materializedArtifact = await materializeMirrorArtifact(
+    const materializedArtifact = await materializeArtifact(
       entry,
       projectRoot,
       policy.selection.requirePinnedProvenance,
@@ -219,23 +237,19 @@ export async function acquireMirrorArtifacts(
   const mirroredAssetIds = new Set(
     mergedMirrorIndexEntries.map((mirrorEntry) => mirrorEntry.assetId),
   );
+  const cumulativeSkippedAssetIds = new Set([
+    ...previouslySkippedAssetIds,
+    ...skippedAssetIds,
+  ]);
   const totalMirroredCount = mirrorEligibleEntries.filter((entry) =>
     mirroredAssetIds.has(entry.id),
   ).length;
-  const batchRemainingCount =
-    mirrorEligibleEntries.length - totalMirroredCount - skippedAssetIds.length;
-  const exhaustedEligibleEntries = batchRemainingCount <= 0;
-  const stalledBatch =
-    entriesToAcquire.length > 0 &&
-    newMirrorIndexEntries.length === 0 &&
-    !exhaustedEligibleEntries;
-  const isTerminal = exhaustedEligibleEntries || stalledBatch;
-  const totalSkippedCount = exhaustedEligibleEntries
-    ? Math.max(0, mirrorEligibleEntries.length - totalMirroredCount)
-    : skippedAssetIds.length;
-  const actualRemainingCount = exhaustedEligibleEntries
-    ? 0
-    : Math.max(0, batchRemainingCount);
+  const totalSkippedCount = cumulativeSkippedAssetIds.size;
+  const actualRemainingCount = Math.max(
+    0,
+    mirrorEligibleEntries.length - totalMirroredCount - totalSkippedCount,
+  );
+  const isTerminal = actualRemainingCount <= 0;
 
   await writeMirrorAcquireState(projectRoot, {
     schemaVersion: 1,
@@ -243,8 +257,9 @@ export async function acquireMirrorArtifacts(
     batchSize,
     totalEligibleCount: mirrorEligibleEntries.length,
     mirroredCount: totalMirroredCount,
-    remainingCount: Math.max(0, actualRemainingCount),
+    remainingCount: actualRemainingCount,
     skippedCount: totalSkippedCount,
+    skippedAssetIds: [...cumulativeSkippedAssetIds].sort(),
     lastBatchAssetIds: entriesToAcquire.map((entry) => entry.id),
     lastBatchMirroredCount: newMirrorIndexEntries.length,
     lastBatchSkippedCount: skippedAssetIds.length,
@@ -255,17 +270,13 @@ export async function acquireMirrorArtifacts(
     console.log(
       `Mirror acquire complete: ${totalMirroredCount}/${mirrorEligibleEntries.length} artifacts under ${toPosixPath(join(projectRoot, "mirror"))}`,
     );
-  } else if (stalledBatch) {
-    console.log(
-      `Mirror acquire stalled: ${totalMirroredCount}/${mirrorEligibleEntries.length} mirrored, ${skippedAssetIds.length} skipped in last batch, ${actualRemainingCount} remaining`,
-    );
   } else if (isTerminal) {
     console.log(
       `Mirror acquire terminal: ${totalMirroredCount} mirrored, ${totalSkippedCount} skipped (unmirrorable) of ${mirrorEligibleEntries.length} eligible`,
     );
   } else {
     console.log(
-      `Mirror acquire batch: ${newMirrorIndexEntries.length} mirrored, ${skippedAssetIds.length} skipped this batch (${totalMirroredCount}/${mirrorEligibleEntries.length} total)`,
+      `Mirror acquire batch: ${newMirrorIndexEntries.length} mirrored, ${skippedAssetIds.length} skipped this batch (${totalMirroredCount}/${mirrorEligibleEntries.length} mirrored, ${totalSkippedCount} skipped total, ${actualRemainingCount} remaining)`,
     );
   }
 }
@@ -819,6 +830,24 @@ function createGitBlobSha(content: Buffer): string {
 
 function isGitBlobSha(value: string | undefined): value is string {
   return Boolean(value && /^[a-f0-9]{40}$/iu.test(value));
+}
+
+async function readPersistedSkippedAssetIds(
+  projectRoot: string,
+): Promise<Set<string>> {
+  const state = await readJsonFileOrNull<{ skippedAssetIds?: unknown }>(
+    join(projectRoot, ...MIRROR_ACQUIRE_STATE_OUTPUT_PATH),
+  );
+
+  if (!state || !Array.isArray(state.skippedAssetIds)) {
+    return new Set();
+  }
+
+  return new Set(
+    state.skippedAssetIds.filter(
+      (value): value is string => typeof value === "string",
+    ),
+  );
 }
 
 async function writeMirrorAcquireState(

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -106,6 +106,9 @@ export async function acquireMirrorArtifacts(
   const mirrorEligibleEntries = selectedEntries.filter(
     (entry) => entry.status.mirrorEligible,
   );
+  const mirrorEligibleAssetIds = new Set(
+    mirrorEligibleEntries.map((entry) => entry.id),
+  );
   const rawBatchSize = Number(
     getOptionValue(args, "--batch-size") ??
       getRuntimeConfig().batches.mirrorAcquire,
@@ -123,13 +126,18 @@ export async function acquireMirrorArtifacts(
   const previouslySkippedAssetIds = await readPersistedSkippedAssetIds(
     projectRoot,
   );
+  const scopedSkippedAssetIds = new Set(
+    [...previouslySkippedAssetIds].filter((assetId) =>
+      mirrorEligibleAssetIds.has(assetId),
+    ),
+  );
   const existingMirrorIdsByAssetId = new Map(
     existingMirrorIndexEntries.map((entry) => [entry.assetId, entry.mirrorId]),
   );
   const unresolvedEntries = mirrorEligibleEntries.filter(
     (entry) =>
       !existingMirrorIdsByAssetId.has(entry.id) &&
-      !previouslySkippedAssetIds.has(entry.id),
+      !scopedSkippedAssetIds.has(entry.id),
   );
   const entriesToAcquire = unresolvedEntries.slice(0, batchSize);
   const newMirrorIndexEntries: MirrorIndexEntry[] = [];
@@ -238,7 +246,7 @@ export async function acquireMirrorArtifacts(
     mergedMirrorIndexEntries.map((mirrorEntry) => mirrorEntry.assetId),
   );
   const cumulativeSkippedAssetIds = new Set([
-    ...previouslySkippedAssetIds,
+    ...scopedSkippedAssetIds,
     ...skippedAssetIds,
   ]);
   const totalMirroredCount = mirrorEligibleEntries.filter((entry) =>

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1,8 +1,27 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
+import {
+  readJsonFile,
+  readJsonLinesFile,
+  writeJsonFile,
+  writeJsonLinesFile,
+} from "../files.js";
+import {
+  assertMirrorAcquireState,
+  assertMirrorIndexEntry,
+} from "../manifest-validation/mirror.js";
 import { assertMirrorAcquireCheckpoint } from "../mirror/acquire-state.js";
-import type { MirrorAcquireState } from "../types.js";
+import { acquireMirrorArtifacts } from "../mirror/acquire.js";
+import type {
+  AssetCatalogEntry,
+  MirrorAcquireState,
+  MirrorIndexEntry,
+  MirrorPolicy,
+} from "../types.js";
 
 function createAcquireState(
   overrides: Partial<MirrorAcquireState> = {},
@@ -15,11 +34,148 @@ function createAcquireState(
     mirroredCount: 0,
     remainingCount: 0,
     skippedCount: 0,
+    skippedAssetIds: [],
     lastBatchAssetIds: [],
     lastBatchMirroredCount: 0,
     lastBatchSkippedCount: 0,
     terminal: false,
     ...overrides,
+  };
+}
+
+function buildMirrorPolicy(): MirrorPolicy {
+  return {
+    schemaVersion: 1,
+    selection: {
+      officialBeatsPopularity: true,
+      requirePinnedProvenance: false,
+      communityDefaultPolicy: "allow",
+    },
+    audit: {
+      alwaysAudit: false,
+      quarantineOn: [],
+    },
+    store: {
+      root: "mirror",
+      rawDirectories: ["raw"],
+      normalizedDirectories: [],
+      bundlesDirectory: "bundles",
+      quarantineDirectory: "quarantine",
+      auditDirectory: "audit",
+    },
+    bundleTemplates: [],
+  };
+}
+
+function buildAsset(id: string): AssetCatalogEntry {
+  return {
+    id,
+    displayName: id,
+    assetKind: "skill",
+    hosts: ["cursor"],
+    compatibilityMode: "adaptable",
+    source: {
+      sourceId: "test-source",
+      authorityTier: "trusted-local",
+      sourceKind: "local-directory",
+      sourcePriority: 100,
+      originUrl: `file:///fixture/${id}`,
+      publisher: "test",
+      publisherVerified: true,
+    },
+    trust: {
+      score: 100,
+      signals: [],
+    },
+    capabilities: ["test"],
+    install: {
+      method: "local-file",
+      adaptableHosts: ["cursor"],
+    },
+    evidence: {
+      manifestFound: true,
+      readmeFound: false,
+      examplesFound: false,
+      docsLinked: false,
+      lineCount: 1,
+      filePath: `${id}.md`,
+      rootPath: "/fixture",
+    },
+    maintenance: {
+      lastUpdated: "2026-01-01T00:00:00.000Z",
+      stars: 0,
+      releaseCadence: "test",
+    },
+    risk: {
+      level: "low",
+      hasHooks: false,
+      hasExecScripts: false,
+      requiresNetwork: false,
+    },
+    contextCost: {
+      sizeClass: "tiny",
+      estimatedPromptWeight: 1,
+    },
+    fit: {
+      portfolioFit: 1,
+      hostFit: 1,
+    },
+    dedupe: {
+      candidateRankHint: "test",
+    },
+    status: {
+      cataloged: true,
+      mirrorEligible: true,
+      installEligible: true,
+      activationEligible: true,
+    },
+  };
+}
+
+async function createAcquireFixture(
+  entries: AssetCatalogEntry[],
+): Promise<string> {
+  const projectRoot = await mkdtemp(join(tmpdir(), "agent-harness-acquire-"));
+  await writeJsonFile(
+    join(projectRoot, "mirror", "policy.json"),
+    buildMirrorPolicy(),
+  );
+  await writeJsonLinesFile(
+    join(projectRoot, "discover", "output", "catalog.selected.jsonl"),
+    entries,
+  );
+  return projectRoot;
+}
+
+async function readAcquireStateFixture(
+  projectRoot: string,
+): Promise<MirrorAcquireState> {
+  return readJsonFile<MirrorAcquireState>(
+    join(projectRoot, "state", "mirror", "acquire-state.json"),
+    assertMirrorAcquireState,
+  );
+}
+
+async function readMirrorIndexFixture(
+  projectRoot: string,
+): Promise<MirrorIndexEntry[]> {
+  return readJsonLinesFile<MirrorIndexEntry>(
+    join(projectRoot, "mirror", "index.jsonl"),
+    assertMirrorIndexEntry,
+  );
+}
+
+function createMaterializer(skippedIds: readonly string[]) {
+  const skipped = new Set(skippedIds);
+
+  return async (entry: AssetCatalogEntry) => {
+    if (skipped.has(entry.id)) {
+      return null;
+    }
+
+    return {
+      content: Buffer.from(`fixture:${entry.id}`, "utf8"),
+    };
   };
 }
 
@@ -30,78 +186,12 @@ void test("mirror acquire checkpoint throws when persisted state is missing", ()
   );
 });
 
-void test("mirror acquire checkpoint returns false while more batches are needed", () => {
-  const state = createAcquireState({
-    totalEligibleCount: 20,
-    mirroredCount: 10,
-    skippedCount: 3,
-    remainingCount: 7,
-    lastBatchAssetIds: ["a", "b", "c"],
-    lastBatchMirroredCount: 7,
-    lastBatchSkippedCount: 3,
-    terminal: false,
-  });
-
-  assert.equal(
-    assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
-    false,
-  );
-});
-
-void test("mirror acquire checkpoint returns true for terminal full success", () => {
-  const state = createAcquireState({
-    totalEligibleCount: 10,
-    mirroredCount: 10,
-    remainingCount: 0,
-    lastBatchAssetIds: ["a", "b", "c"],
-    lastBatchMirroredCount: 3,
-    terminal: true,
-  });
-
-  assert.equal(
-    assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
-    true,
-  );
-});
-
-void test("mirror acquire checkpoint throws for incomplete terminal state", () => {
-  const state = createAcquireState({
-    totalEligibleCount: 10,
-    mirroredCount: 3,
-    remainingCount: 0,
-    skippedCount: 7,
-    lastBatchSkippedCount: 7,
-    terminal: true,
-  });
-
-  assert.throws(
-    () => assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
-    /mirror acquire ended incomplete: 3\/10 mirrored, 7 skipped/,
-  );
-});
-
-void test("mirror acquire checkpoint throws for terminal stalled state", () => {
-  const state = createAcquireState({
-    totalEligibleCount: 20,
-    mirroredCount: 14,
-    skippedCount: 3,
-    remainingCount: 3,
-    lastBatchAssetIds: ["a", "b", "c"],
-    lastBatchSkippedCount: 3,
-    terminal: true,
-  });
-
-  assert.throws(
-    () => assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
-    /mirror acquire stalled after batch: 14\/20 mirrored, 3 skipped in last batch, 3 remaining/,
-  );
-});
-
 void test("mirror acquire checkpoint rejects inconsistent state arithmetic", () => {
   const state = createAcquireState({
     totalEligibleCount: 20,
     mirroredCount: 8,
     skippedCount: 5,
+    skippedAssetIds: ["skip-a", "skip-b", "skip-c", "skip-d", "skip-e"],
     remainingCount: 6,
     lastBatchMirroredCount: 3,
     lastBatchSkippedCount: 2,
@@ -111,4 +201,171 @@ void test("mirror acquire checkpoint rejects inconsistent state arithmetic", () 
     () => assertMirrorAcquireCheckpoint(state, "workspace pipeline"),
     /workspace pipeline mirror acquire state is inconsistent/,
   );
+});
+
+void test("acquireMirrorArtifacts writes terminal incomplete state for all-skip fixtures", async () => {
+  const entries = [buildAsset("skip-a"), buildAsset("skip-b")];
+  const projectRoot = await createAcquireFixture(entries);
+
+  try {
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      {
+        materializeArtifact: createMaterializer(
+          entries.map((entry) => entry.id),
+        ),
+      },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.totalEligibleCount, 2);
+    assert.equal(state.mirroredCount, 0);
+    assert.equal(state.skippedCount, 2);
+    assert.deepEqual(state.skippedAssetIds, ["skip-a", "skip-b"]);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 0);
+    assert.equal(state.lastBatchSkippedCount, 2);
+    assert.deepEqual(state.lastBatchAssetIds, ["skip-a", "skip-b"]);
+    assert.equal(mirrorIndex.length, 0);
+
+    assert.throws(
+      () => assertMirrorAcquireCheckpoint(state, "fixture"),
+      /fixture mirror acquire ended incomplete: 0\/2 mirrored, 2 skipped/,
+    );
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts continues past skipped first slice and mirrors later entries", async () => {
+  const entries = [
+    buildAsset("skip-a"),
+    buildAsset("skip-b"),
+    buildAsset("mirror-c"),
+  ];
+  const projectRoot = await createAcquireFixture(entries);
+  const materializeArtifact = createMaterializer(["skip-a", "skip-b"]);
+
+  try {
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "2"],
+      { materializeArtifact },
+    );
+
+    const firstState = await readAcquireStateFixture(projectRoot);
+    const firstMirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(firstState.terminal, false);
+    assert.equal(firstState.mirroredCount, 0);
+    assert.equal(firstState.skippedCount, 2);
+    assert.deepEqual(firstState.skippedAssetIds, ["skip-a", "skip-b"]);
+    assert.equal(firstState.remainingCount, 1);
+    assert.equal(firstState.lastBatchMirroredCount, 0);
+    assert.equal(firstState.lastBatchSkippedCount, 2);
+    assert.deepEqual(firstState.lastBatchAssetIds, ["skip-a", "skip-b"]);
+    assert.equal(firstMirrorIndex.length, 0);
+    assert.equal(assertMirrorAcquireCheckpoint(firstState, "fixture"), false);
+
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "2"],
+      { materializeArtifact },
+    );
+
+    const secondState = await readAcquireStateFixture(projectRoot);
+    const secondMirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(secondState.terminal, true);
+    assert.equal(secondState.mirroredCount, 1);
+    assert.equal(secondState.skippedCount, 2);
+    assert.deepEqual(secondState.skippedAssetIds, ["skip-a", "skip-b"]);
+    assert.equal(secondState.remainingCount, 0);
+    assert.equal(secondState.lastBatchMirroredCount, 1);
+    assert.equal(secondState.lastBatchSkippedCount, 0);
+    assert.deepEqual(secondState.lastBatchAssetIds, ["mirror-c"]);
+    assert.deepEqual(
+      secondMirrorIndex.map((entry) => entry.assetId),
+      ["mirror-c"],
+    );
+
+    assert.throws(
+      () => assertMirrorAcquireCheckpoint(secondState, "fixture"),
+      /fixture mirror acquire ended incomplete: 1\/3 mirrored, 2 skipped/,
+    );
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts records partial skip and mirror results from one batch", async () => {
+  const entries = [buildAsset("mirror-a"), buildAsset("skip-b")];
+  const projectRoot = await createAcquireFixture(entries);
+
+  try {
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer(["skip-b"]) },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 1);
+    assert.deepEqual(state.skippedAssetIds, ["skip-b"]);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 1);
+    assert.equal(state.lastBatchSkippedCount, 1);
+    assert.deepEqual(state.lastBatchAssetIds, ["mirror-a", "skip-b"]);
+    assert.deepEqual(
+      mirrorIndex.map((entry) => entry.assetId),
+      ["mirror-a"],
+    );
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts writes terminal complete state for full success fixtures", async () => {
+  const entries = [buildAsset("mirror-a"), buildAsset("mirror-b")];
+  const projectRoot = await createAcquireFixture(entries);
+
+  try {
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer([]) },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 2);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 2);
+    assert.equal(state.lastBatchSkippedCount, 0);
+    assert.deepEqual(state.lastBatchAssetIds, ["mirror-a", "mirror-b"]);
+    assert.deepEqual(
+      mirrorIndex.map((entry) => entry.assetId),
+      ["mirror-a", "mirror-b"],
+    );
+    assert.equal(assertMirrorAcquireCheckpoint(state, "fixture"), true);
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
 });

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -147,11 +147,15 @@ async function createAcquireFixture(
   return projectRoot;
 }
 
+function acquireStatePath(projectRoot: string): string {
+  return join(projectRoot, "state", "mirror", "acquire-state.json");
+}
+
 async function readAcquireStateFixture(
   projectRoot: string,
 ): Promise<MirrorAcquireState> {
   return readJsonFile<MirrorAcquireState>(
-    join(projectRoot, "state", "mirror", "acquire-state.json"),
+    acquireStatePath(projectRoot),
     assertMirrorAcquireState,
   );
 }
@@ -236,6 +240,49 @@ void test("acquireMirrorArtifacts writes terminal incomplete state for all-skip 
     assert.throws(
       () => assertMirrorAcquireCheckpoint(state, "fixture"),
       /fixture mirror acquire ended incomplete: 0\/2 mirrored, 2 skipped/,
+    );
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts ignores stale persisted skipped ids outside the current eligible set", async () => {
+  const entries = [buildAsset("mirror-a")];
+  const projectRoot = await createAcquireFixture(entries);
+
+  try {
+    await writeJsonFile(
+      acquireStatePath(projectRoot),
+      createAcquireState({
+        totalEligibleCount: 1,
+        skippedCount: 1,
+        skippedAssetIds: ["stale-skip"],
+        remainingCount: 0,
+        terminal: true,
+      }),
+    );
+
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer([]) },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 1);
+    assert.equal(state.lastBatchSkippedCount, 0);
+    assert.deepEqual(state.lastBatchAssetIds, ["mirror-a"]);
+    assert.deepEqual(
+      mirrorIndex.map((entry) => entry.assetId),
+      ["mirror-a"],
     );
   } finally {
     await rm(projectRoot, { force: true, recursive: true });

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -151,6 +151,30 @@ function acquireStatePath(projectRoot: string): string {
   return join(projectRoot, "state", "mirror", "acquire-state.json");
 }
 
+function mirrorIndexPath(projectRoot: string): string {
+  return join(projectRoot, "mirror", "index.jsonl");
+}
+
+function createMirrorIndexEntry(assetId: string): MirrorIndexEntry {
+  return {
+    mirrorId: `sha256-${assetId}`,
+    assetId,
+    upstream: {
+      type: "local",
+      url: `file:///fixture/${assetId}`,
+    },
+    source: {
+      authorityTier: "trusted-local",
+      publisher: "test",
+      publisherVerified: true,
+    },
+    mirroredAt: new Date().toISOString(),
+    contentHash: `hash-${assetId}`,
+    projectionCandidates: [],
+    status: "approved",
+  };
+}
+
 async function readAcquireStateFixture(
   projectRoot: string,
 ): Promise<MirrorAcquireState> {
@@ -284,6 +308,54 @@ void test("acquireMirrorArtifacts ignores stale persisted skipped ids outside th
       mirrorIndex.map((entry) => entry.assetId),
       ["mirror-a"],
     );
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts treats mirrored overlap ids as mirrored instead of skipped", async () => {
+  const entries = [buildAsset("mirror-a")];
+  const projectRoot = await createAcquireFixture(entries);
+
+  try {
+    await writeJsonLinesFile(mirrorIndexPath(projectRoot), [
+      createMirrorIndexEntry("mirror-a"),
+    ]);
+    await writeJsonFile(
+      acquireStatePath(projectRoot),
+      createAcquireState({
+        totalEligibleCount: 1,
+        mirroredCount: 0,
+        skippedCount: 1,
+        skippedAssetIds: ["mirror-a"],
+        remainingCount: 0,
+        terminal: true,
+      }),
+    );
+
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer([]) },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 0);
+    assert.equal(state.lastBatchSkippedCount, 0);
+    assert.deepEqual(state.lastBatchAssetIds, []);
+    assert.deepEqual(
+      mirrorIndex.map((entry) => entry.assetId),
+      ["mirror-a"],
+    );
+    assert.equal(assertMirrorAcquireCheckpoint(state, "fixture"), true);
   } finally {
     await rm(projectRoot, { force: true, recursive: true });
   }

--- a/src/types/mirror.ts
+++ b/src/types/mirror.ts
@@ -149,6 +149,7 @@ export interface MirrorAcquireState {
   mirroredCount: number;
   remainingCount: number;
   skippedCount: number;
+  skippedAssetIds: string[];
   lastBatchAssetIds: string[];
   lastBatchMirroredCount: number;
   lastBatchSkippedCount: number;


### PR DESCRIPTION
## Summary
- persist cumulative skipped asset ids in mirror acquire state and exclude them from later unresolved slices
- continue scanning past zero-mirror batches when those batches only contain newly skipped entries, while keeping terminal state/checkpoint arithmetic explicit
- add fixture-backed `acquireMirrorArtifacts(...)` tests that assert on-disk acquire state and mirror index outputs for all-skip, partial skip + partial mirror, full success, and the new cross-batch scheduling case

## Validation
- `npm run validate`
- `npm run build`
- `node --test dist/tests/mirror-acquire-state.test.js`
- `npm run smoke:workspace`
- `npm pack --dry-run`
- real repro on temp clone of `C:\Projects\Apify\Webhook Debugger and Logger` with `node C:\Projects\agent-harness\dist\cli.js workspace opencode --intent backend`
  - first acquire batch: `0 mirrored, 120 skipped this batch (0/177 mirrored, 120 skipped total, 57 remaining)`
  - second acquire batch reached later entries and mirrored `14`
  - terminal state persisted `mirroredCount: 14`, `skippedCount: 163`, `remainingCount: 0`
  - mirror index contained `14` entries instead of staying empty

Closes #115
Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mirror acquisition now persists and tracks skipped asset IDs across runs to avoid reprocessing.

* **Bug Fixes**
  * Added validations to ensure skipped-asset counts and lists stay consistent and prevent state mismatches.
  * Improved progress reporting for terminal vs batch acquisition states.

* **Tests**
  * Expanded end-to-end tests covering skip, partial-skip, recovery, and checkpoint scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->