### PR TITLE
Fix guarded GitHub mirror fallbacks and expand default sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Optional GitHub token for higher GitHub API throughput during discovery.
+# Optional GitHub token for higher GitHub API throughput during discovery and GitHub-backed mirror acquisition.
 # Prefer a least-privileged token with public repository read access only.
 GITHUB_PERSONAL_ACCESS_TOKEN=
 # GITHUB_TOKEN=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- added `github-awesome-copilot-site` as a default official docs source so discovery can harvest the `awesome-copilot.github.com` catalog alongside the backing repository
+- added `clawhub` as a default community registry source for broader catalog/reference coverage without enabling default mirror/install promotion
+
+### Changed
+
+- mirror acquisition now accepts pinned GitHub-tree and official-index artifacts when raw content verifies against the pinned blob SHA even if the GitHub branch-commit lookup is temporarily unavailable
+- README and `.env.example` now document that GitHub tokens help both discovery and GitHub-backed mirror acquisition on larger real-workspace runs
+
+### Fixed
+
+- guarded pinned GitHub lookups now honor Node's `lookup(..., { all: true })` callback shape, which eliminates the `ERR_INVALID_IP_ADDRESS` failure mode that caused real-workspace GitHub fetches to be skipped as null
+
 ## [1.0.0] - 2026-05-01
 
 ### Added in 1.0.0

--- a/README.md
+++ b/README.md
@@ -743,6 +743,8 @@ Generated outputs include:
 
 `discover/output/source-utilization.json` separates configured sources from operationally harvested sources so you can see whether broad source declarations are producing usable catalog entries.
 
+The checked-in default source registry intentionally mixes several source classes instead of relying on one curated repo. Out of the box it includes official docs and repos (for example GitHub Copilot docs, the `github/awesome-copilot` repo, and the `awesome-copilot.github.com` site), host-native marketplaces/registries (for example the VS Code Marketplace, Zed extension gallery, Pi packages, npm, and PyPI), and lighter-weight community registries such as `skills.sh` and ClawHub. That split keeps official sources preferred while still surfacing broader community references for real workspaces.
+
 Generated local source seeds include host config roots for OpenCode, Claude Code, and Cursor. Claude Code harvesting recognizes `CLAUDE.md`, `.claude`-style `agents/`, `commands/`, `skills/`, hook settings, plugin manifests, and `.mcp.json`. Cursor harvesting recognizes rules, agents, commands, skills, hooks, plugin manifests, marketplace manifests, and `mcp.json` from the default Cursor config root. Claude Code and Cursor generated local config sources are catalog-only by default so local settings, hooks, and MCP files are not mirrored into project state unless a user-authored source explicitly opts in.
 
 ### Dependency-evidence package discovery
@@ -820,7 +822,7 @@ See `.env.example` for documented defaults. On startup, the CLI loads `.env` fro
 
 ### GitHub authentication
 
-Optional GitHub tokens improve API throughput during discovery:
+Optional GitHub tokens improve API throughput during discovery and GitHub-backed mirror acquisition:
 
 ```bash
 GITHUB_PERSONAL_ACCESS_TOKEN=
@@ -1057,7 +1059,7 @@ agent-harness recommend report
 
 `discover select` should reject entries that do not overlap with detected workspace signals. If relevant entries are missing, inspect `discover/output/demand-profile.json` and confirm the workspace manifests are not excluded by `.gitignore`, `.ignore`, or `.agent-harnessignore`.
 
-### GitHub discovery is slow or rate-limited
+### GitHub discovery or mirror acquisition is slow or rate-limited
 
 Set a token before discovery or full workspace runs:
 
@@ -1065,7 +1067,7 @@ Set a token before discovery or full workspace runs:
 GITHUB_PERSONAL_ACCESS_TOKEN=<token>
 ```
 
-Use a least-privileged token with public repository read access unless your sources require more.
+Use a least-privileged token with public repository read access unless your sources require more. This is especially helpful on larger real-workspace runs where the harness needs both GitHub API metadata and raw-content verification for mirrored assets.
 
 ### A generated host file shows up in `git status`
 

--- a/discover/sources.json
+++ b/discover/sources.json
@@ -58,6 +58,37 @@
       }
     },
     {
+      "id": "github-awesome-copilot-site",
+      "name": "Awesome GitHub Copilot",
+      "kind": "docs",
+      "authorityTier": "official-first-party",
+      "publisher": {
+        "name": "GitHub",
+        "verified": true,
+        "owner": "github"
+      },
+      "hosts": ["copilot-vscode", "cursor"],
+      "assetKinds": [
+        "agent",
+        "skill",
+        "instruction",
+        "workflow",
+        "plugin",
+        "reference-pack"
+      ],
+      "discoveryMode": "catalog",
+      "priority": 99,
+      "enabled": true,
+      "endpoints": {
+        "docsUrl": "https://awesome-copilot.github.com/agents/"
+      },
+      "rules": {
+        "officialPreferred": true,
+        "allowMirror": true,
+        "allowInstall": true
+      }
+    },
+    {
       "id": "vscode-marketplace",
       "name": "VS Code Marketplace",
       "kind": "marketplace",
@@ -277,6 +308,46 @@
       },
       "rules": {
         "officialPreferred": true,
+        "allowMirror": false,
+        "allowInstall": false
+      }
+    },
+    {
+      "id": "clawhub",
+      "name": "ClawHub",
+      "kind": "registry",
+      "authorityTier": "unverified-community",
+      "publisher": {
+        "name": "OpenClaw Community",
+        "verified": false,
+        "owner": "openclaw"
+      },
+      "hosts": [
+        "copilot-vscode",
+        "opencode",
+        "cursor",
+        "zed",
+        "claude-code",
+        "pi"
+      ],
+      "assetKinds": [
+        "skill",
+        "agent",
+        "plugin",
+        "workflow",
+        "instruction",
+        "prompt-pack",
+        "reference-pack",
+        "mcp-server"
+      ],
+      "discoveryMode": "catalog",
+      "priority": 62,
+      "enabled": true,
+      "endpoints": {
+        "baseUrl": "https://clawhub.ai/skills"
+      },
+      "rules": {
+        "officialPreferred": false,
         "allowMirror": false,
         "allowInstall": false
       }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -392,9 +392,7 @@ async function requestWithPinnedAddress(
 ): Promise<Response> {
   const body = serializeRequestBody(options.body);
   const headers = buildRequestHeaders(options.headers, body);
-  const pinnedLookup: LookupFunction = (_hostname, _options, callback) => {
-    callback(null, address.address, address.family);
-  };
+  const pinnedLookup = createPinnedLookup(address);
 
   return new Promise((resolve, reject) => {
     const requestMessage = request(
@@ -421,6 +419,23 @@ async function requestWithPinnedAddress(
     }
     requestMessage.end();
   });
+}
+
+/**
+ * Builds a DNS lookup override pinned to a single resolved address while
+ * honoring Node's single-result and all-results lookup callback modes.
+ */
+export function createPinnedLookup(
+  address: ResolvedHostnameAddress,
+): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (options.all) {
+      callback(null, [address]);
+      return;
+    }
+
+    callback(null, address.address, address.family);
+  };
 }
 
 function serializeRequestBody(

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -429,8 +429,7 @@ export function createPinnedLookup(
   address: ResolvedHostnameAddress,
 ): LookupFunction {
   return (_hostname, options, callback) => {
-    const resolvedCallback =
-      typeof options === "function" ? options : callback;
+    const resolvedCallback = typeof options === "function" ? options : callback;
 
     if (!resolvedCallback) {
       throw new TypeError("DNS lookup callback is required.");

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -429,12 +429,25 @@ export function createPinnedLookup(
   address: ResolvedHostnameAddress,
 ): LookupFunction {
   return (_hostname, options, callback) => {
-    if (options.all) {
-      callback(null, [address]);
+    const resolvedCallback =
+      typeof options === "function" ? options : callback;
+
+    if (!resolvedCallback) {
+      throw new TypeError("DNS lookup callback is required.");
+    }
+
+    const all =
+      typeof options === "object" &&
+      options !== null &&
+      "all" in options &&
+      options.all === true;
+
+    if (all) {
+      resolvedCallback(null, [address]);
       return;
     }
 
-    callback(null, address.address, address.family);
+    resolvedCallback(null, address.address, address.family);
   };
 }
 

--- a/src/manifest-validation/mirror.ts
+++ b/src/manifest-validation/mirror.ts
@@ -136,6 +136,15 @@ export function assertMirrorAcquireState(
   assertNumber(record.remainingCount, `${context}.remainingCount`);
   assertNumber(record.skippedCount, `${context}.skippedCount`);
   assertStringArray(record.skippedAssetIds, `${context}.skippedAssetIds`);
+  if (record.skippedAssetReasons !== undefined) {
+    const skippedAssetReasons = assertRecord(
+      record.skippedAssetReasons,
+      `${context}.skippedAssetReasons`,
+    );
+    Object.entries(skippedAssetReasons).forEach(([key, entryValue]) => {
+      assertString(entryValue, `${context}.skippedAssetReasons.${key}`);
+    });
+  }
   assertStringArray(record.lastBatchAssetIds, `${context}.lastBatchAssetIds`);
   assertNumber(
     record.lastBatchMirroredCount,
@@ -145,5 +154,14 @@ export function assertMirrorAcquireState(
     record.lastBatchSkippedCount,
     `${context}.lastBatchSkippedCount`,
   );
+  if (record.lastBatchSkippedReasons !== undefined) {
+    const lastBatchSkippedReasons = assertRecord(
+      record.lastBatchSkippedReasons,
+      `${context}.lastBatchSkippedReasons`,
+    );
+    Object.entries(lastBatchSkippedReasons).forEach(([key, entryValue]) => {
+      assertString(entryValue, `${context}.lastBatchSkippedReasons.${key}`);
+    });
+  }
   assertBoolean(record.terminal, `${context}.terminal`);
 }

--- a/src/mirror/acquire-state.ts
+++ b/src/mirror/acquire-state.ts
@@ -36,16 +36,40 @@ export function assertMirrorAcquireCheckpoint(
   if (state.remainingCount > 0) {
     throw new Error(
       `${context} mirror acquire stalled after batch: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.lastBatchSkippedCount} skipped in last batch, ${state.remainingCount} remaining. ` +
-        `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.`,
+        `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.${buildSkippedReasonSummary(state)}`,
     );
   }
 
   if (state.mirroredCount < state.totalEligibleCount) {
     throw new Error(
       `${context} mirror acquire ended incomplete: ${state.mirroredCount}/${state.totalEligibleCount} mirrored, ${state.skippedCount} skipped (unmirrorable). ` +
-        `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.`,
+        `Review state/mirror/acquire-state.json (last batch: ${state.lastBatchAssetIds.length} asset(s)) or adjust mirror policy.${buildSkippedReasonSummary(state)}`,
     );
   }
 
   return true;
+}
+
+function buildSkippedReasonSummary(state: MirrorAcquireState): string {
+  const skippedAssetReasons = state.skippedAssetReasons;
+  if (!skippedAssetReasons) {
+    return "";
+  }
+
+  const summarizedReasons = Object.entries(skippedAssetReasons)
+    .reduce<Map<string, number>>((counts, [, reason]) => {
+      counts.set(reason, (counts.get(reason) ?? 0) + 1);
+      return counts;
+    }, new Map())
+    .entries();
+  const topReasons = [...summarizedReasons]
+    .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+    .slice(0, 3)
+    .map(([reason, count]) => `${reason} (${count})`);
+
+  if (topReasons.length === 0) {
+    return "";
+  }
+
+  return ` Top skip reasons: ${topReasons.join(", ")}.`;
 }

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -106,6 +106,8 @@ interface AcquireMirrorArtifactsDependencies {
   ) => Promise<MaterializeArtifactResult>;
 }
 
+const officialIndexRepoUrlCache = new Map<string, string | null>();
+
 /**
  * Provides acquire mirror artifacts for the lifecycle pipeline.
  */
@@ -584,9 +586,17 @@ async function buildOfficialIndexRepoUrlCandidates(
   entry: AssetCatalogEntry,
   owner: string,
 ): Promise<string[]> {
-  const officialIndexRepoUrl = await fetchOfficialIndexPageRepositoryUrl(
+  const cachedOfficialIndexRepoUrl = officialIndexRepoUrlCache.get(
     entry.source.originUrl,
   );
+  const officialIndexRepoUrl =
+    cachedOfficialIndexRepoUrl ??
+    (await fetchOfficialIndexPageRepositoryUrl(entry.source.originUrl));
+
+  if (!officialIndexRepoUrlCache.has(entry.source.originUrl)) {
+    officialIndexRepoUrlCache.set(entry.source.originUrl, officialIndexRepoUrl);
+  }
+
   const candidateRepoUrls = [
     officialIndexRepoUrl,
     entry.evidence.rootPath,

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -462,6 +462,7 @@ async function materializeOfficialIndexPackage(
   const slug = entry.install.manifestEntry;
   const owner = entry.source.sourceId.split(":")[1];
   let capSkipReason: MirrorAcquireSkipReason | undefined;
+  let sawNonCapFailure = false;
 
   if (!slug || !owner) {
     return { artifact: null };
@@ -475,6 +476,7 @@ async function materializeOfficialIndexPackage(
     });
 
     if (!snapshot || snapshot.tree.truncated) {
+      sawNonCapFailure = true;
       continue;
     }
 
@@ -483,6 +485,7 @@ async function materializeOfficialIndexPackage(
       slug,
     );
     if (!skillRootPath) {
+      sawNonCapFailure = true;
       continue;
     }
 
@@ -519,6 +522,7 @@ async function materializeOfficialIndexPackage(
     const packageFiles = packageFileCandidates;
 
     if (packageFiles.length === 0) {
+      sawNonCapFailure = true;
       continue;
     }
 
@@ -557,6 +561,7 @@ async function materializeOfficialIndexPackage(
     }
 
     if (materializedFiles.length === 0) {
+      sawNonCapFailure = true;
       continue;
     }
 
@@ -578,7 +583,7 @@ async function materializeOfficialIndexPackage(
 
   return {
     artifact: null,
-    skipReason: capSkipReason,
+    skipReason: sawNonCapFailure ? undefined : capSkipReason,
   };
 }
 
@@ -586,14 +591,14 @@ async function buildOfficialIndexRepoUrlCandidates(
   entry: AssetCatalogEntry,
   owner: string,
 ): Promise<string[]> {
-  const cachedOfficialIndexRepoUrl = officialIndexRepoUrlCache.get(
+  let officialIndexRepoUrl = officialIndexRepoUrlCache.get(
     entry.source.originUrl,
   );
-  const officialIndexRepoUrl =
-    cachedOfficialIndexRepoUrl ??
-    (await fetchOfficialIndexPageRepositoryUrl(entry.source.originUrl));
 
   if (!officialIndexRepoUrlCache.has(entry.source.originUrl)) {
+    officialIndexRepoUrl = await fetchOfficialIndexPageRepositoryUrl(
+      entry.source.originUrl,
+    );
     officialIndexRepoUrlCache.set(entry.source.originUrl, officialIndexRepoUrl);
   }
 

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -459,6 +459,7 @@ async function materializeOfficialIndexPackage(
 ): Promise<MaterializeArtifactResult> {
   const slug = entry.install.manifestEntry;
   const owner = entry.source.sourceId.split(":")[1];
+  let capSkipReason: MirrorAcquireSkipReason | undefined;
 
   if (!slug || !owner) {
     return { artifact: null };
@@ -493,10 +494,8 @@ async function materializeOfficialIndexPackage(
       0,
     );
     if (packageFileCandidates.length > MAX_OFFICIAL_INDEX_PACKAGE_FILES) {
-      return {
-        artifact: null,
-        skipReason: "official-index-package-too-many-files",
-      };
+      capSkipReason ??= "official-index-package-too-many-files";
+      continue;
     }
 
     if (
@@ -506,17 +505,13 @@ async function materializeOfficialIndexPackage(
           treeEntry.size > MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
       )
     ) {
-      return {
-        artifact: null,
-        skipReason: "official-index-file-too-large",
-      };
+      capSkipReason ??= "official-index-file-too-large";
+      continue;
     }
 
     if (packageTotalBytes > MAX_OFFICIAL_INDEX_PACKAGE_TOTAL_BYTES) {
-      return {
-        artifact: null,
-        skipReason: "official-index-package-too-large",
-      };
+      capSkipReason ??= "official-index-package-too-large";
+      continue;
     }
 
     const packageFiles = packageFileCandidates;
@@ -581,6 +576,7 @@ async function materializeOfficialIndexPackage(
 
   return {
     artifact: null,
+    skipReason: capSkipReason,
   };
 }
 

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -30,7 +30,10 @@ import {
   assertMirrorIndexEntry,
   assertMirrorPolicy,
 } from "../manifest-validation.js";
-import { fetchOfficialIndexPageContent } from "../official-index.js";
+import {
+  fetchOfficialIndexPageContent,
+  fetchOfficialIndexPageRepositoryUrl,
+} from "../official-index.js";
 import type {
   AssetCatalogEntry,
   MirrorAcquireState,
@@ -319,7 +322,6 @@ async function materializeMirrorArtifact(
     const officialIndexPackageArtifact = await materializeOfficialIndexPackage(
       entry,
       projectRoot,
-      requirePinnedProvenance,
     );
     if (officialIndexPackageArtifact !== null) {
       return officialIndexPackageArtifact;
@@ -387,10 +389,6 @@ async function materializeGitHubTreeArtifact(
     repoInfo.repo,
     repoInfo.ref,
   );
-  if (requirePinnedProvenance && !commitSha) {
-    return null;
-  }
-
   const fetchRef = commitSha ?? repoInfo.ref;
   const content = await fetchVerifiedGitHubFileContent(
     repoInfo.owner,
@@ -415,7 +413,6 @@ async function materializeGitHubTreeArtifact(
 async function materializeOfficialIndexPackage(
   entry: AssetCatalogEntry,
   projectRoot: string,
-  requirePinnedProvenance: boolean,
 ): Promise<MaterializedMirrorArtifact | null> {
   const slug = entry.install.manifestEntry;
   const owner = entry.source.sourceId.split(":")[1];
@@ -424,7 +421,7 @@ async function materializeOfficialIndexPackage(
     return null;
   }
 
-  for (const repoUrl of buildOfficialIndexRepoUrlCandidates(entry, owner)) {
+  for (const repoUrl of await buildOfficialIndexRepoUrlCandidates(entry, owner)) {
     const snapshot = await fetchGitHubRepoSnapshotByRepoUrl({
       repoUrl,
       projectRoot,
@@ -470,9 +467,6 @@ async function materializeOfficialIndexPackage(
       snapshot.repo,
       snapshot.repoSummary.defaultBranch,
     );
-    if (requirePinnedProvenance && !commitSha) {
-      continue;
-    }
 
     const materializedFiles: Array<{
       relativePath: string;
@@ -523,11 +517,15 @@ async function materializeOfficialIndexPackage(
   return null;
 }
 
-function buildOfficialIndexRepoUrlCandidates(
+async function buildOfficialIndexRepoUrlCandidates(
   entry: AssetCatalogEntry,
   owner: string,
-): string[] {
+): Promise<string[]> {
+  const officialIndexRepoUrl = await fetchOfficialIndexPageRepositoryUrl(
+    entry.source.originUrl,
+  );
   const candidateRepoUrls = [
+    officialIndexRepoUrl,
     entry.evidence.rootPath,
     `https://github.com/${owner}/${owner}-skills`,
     `https://github.com/${owner}/skills`,

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -47,6 +47,7 @@ import {
   MAX_GITHUB_MIRROR_FILE_SIZE_BYTES,
   MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
   MAX_OFFICIAL_INDEX_PACKAGE_FILES,
+  MAX_OFFICIAL_INDEX_PACKAGE_TOTAL_BYTES,
   MIRROR_ACQUIRE_STATE_OUTPUT_PATH,
   MIRROR_INDEX_OUTPUT_PATH,
   MIRROR_INDEX_SNAPSHOT_PATH,
@@ -80,13 +81,29 @@ interface MirrorFileManifest {
   }>;
 }
 
+type MirrorAcquireSkipReason =
+  | "materialize-failed"
+  | "official-index-package-too-many-files"
+  | "official-index-file-too-large"
+  | "official-index-package-too-large";
+
+interface MaterializeArtifactResult {
+  artifact: MaterializedMirrorArtifact | null;
+  skipReason?: MirrorAcquireSkipReason;
+}
+
+interface PersistedSkippedAssets {
+  assetIds: Set<string>;
+  assetReasons: Map<string, string>;
+}
+
 interface AcquireMirrorArtifactsDependencies {
   materializeArtifact?: (
     entry: AssetCatalogEntry,
     projectRoot: string,
     requirePinnedProvenance: boolean,
     evidenceAllowedRoots: readonly string[],
-  ) => Promise<MaterializedMirrorArtifact | null>;
+  ) => Promise<MaterializeArtifactResult>;
 }
 
 /**
@@ -126,11 +143,14 @@ export async function acquireMirrorArtifacts(
     join(projectRoot, ...MIRROR_INDEX_OUTPUT_PATH),
     assertMirrorIndexEntry,
   );
-  const previouslySkippedAssetIds = await readPersistedSkippedAssetIds(
-    projectRoot,
-  );
+  const previouslySkippedAssets = await readPersistedSkippedAssets(projectRoot);
   const scopedSkippedAssetIds = new Set(
-    [...previouslySkippedAssetIds].filter((assetId) =>
+    [...previouslySkippedAssets.assetIds].filter((assetId) =>
+      mirrorEligibleAssetIds.has(assetId),
+    ),
+  );
+  const scopedSkippedAssetReasons = new Map(
+    [...previouslySkippedAssets.assetReasons].filter(([assetId]) =>
       mirrorEligibleAssetIds.has(assetId),
     ),
   );
@@ -145,6 +165,7 @@ export async function acquireMirrorArtifacts(
   const entriesToAcquire = unresolvedEntries.slice(0, batchSize);
   const newMirrorIndexEntries: MirrorIndexEntry[] = [];
   const skippedAssetIds: string[] = [];
+  const skippedAssetReasons = new Map<string, string>();
   const evidenceAllowedRoots = buildMirrorEvidenceAllowedRoots(
     projectRoot,
     workingDirectory,
@@ -153,17 +174,22 @@ export async function acquireMirrorArtifacts(
     dependencies.materializeArtifact ?? materializeMirrorArtifact;
 
   for (const entry of entriesToAcquire) {
-    const materializedArtifact = await materializeArtifact(
+    const materializedArtifactResult = await materializeArtifact(
       entry,
       projectRoot,
       policy.selection.requirePinnedProvenance,
       evidenceAllowedRoots,
     );
-    if (materializedArtifact === null) {
+    if (materializedArtifactResult.artifact === null) {
       skippedAssetIds.push(entry.id);
+      skippedAssetReasons.set(
+        entry.id,
+        materializedArtifactResult.skipReason ?? "materialize-failed",
+      );
       continue;
     }
 
+    const materializedArtifact = materializedArtifactResult.artifact;
     const fileManifest = buildMirrorFileManifest(materializedArtifact, entry);
     const mirrorId = `sha256-${createContentHash(`${entry.id}\n${fileManifest.aggregateHash}`)}`;
     const rawRoot = join(
@@ -252,9 +278,18 @@ export async function acquireMirrorArtifacts(
     ...scopedSkippedAssetIds,
     ...skippedAssetIds,
   ]);
+  const cumulativeSkippedAssetReasons = new Map(scopedSkippedAssetReasons);
+  for (const [assetId, reason] of skippedAssetReasons) {
+    cumulativeSkippedAssetReasons.set(assetId, reason);
+  }
   const effectiveSkippedAssetIds = new Set(
     [...cumulativeSkippedAssetIds].filter(
       (assetId) => !mirroredAssetIds.has(assetId),
+    ),
+  );
+  const effectiveSkippedAssetReasons = new Map(
+    [...cumulativeSkippedAssetReasons].filter(([assetId]) =>
+      effectiveSkippedAssetIds.has(assetId),
     ),
   );
   const totalMirroredCount = mirrorEligibleEntries.filter((entry) =>
@@ -276,9 +311,11 @@ export async function acquireMirrorArtifacts(
     remainingCount: actualRemainingCount,
     skippedCount: totalSkippedCount,
     skippedAssetIds: [...effectiveSkippedAssetIds].sort(),
+    skippedAssetReasons: buildSortedReasonRecord(effectiveSkippedAssetReasons),
     lastBatchAssetIds: entriesToAcquire.map((entry) => entry.id),
     lastBatchMirroredCount: newMirrorIndexEntries.length,
     lastBatchSkippedCount: skippedAssetIds.length,
+    lastBatchSkippedReasons: buildSortedReasonRecord(skippedAssetReasons),
     terminal: isTerminal,
   });
 
@@ -302,14 +339,16 @@ async function materializeMirrorArtifact(
   projectRoot: string,
   requirePinnedProvenance: boolean,
   evidenceAllowedRoots: readonly string[],
-): Promise<MaterializedMirrorArtifact | null> {
+): Promise<MaterializeArtifactResult> {
   if (entry.install.method.endsWith("-summary")) {
     const referenceContent = await fetchOfficialIndexPageContent(
       entry.source.originUrl,
     );
     if (referenceContent !== null) {
       return {
-        content: Buffer.from(referenceContent, "utf8"),
+        artifact: {
+          content: Buffer.from(referenceContent, "utf8"),
+        },
       };
     }
   }
@@ -319,15 +358,7 @@ async function materializeMirrorArtifact(
   }
 
   if (entry.install.method === "official-index-entry") {
-    const officialIndexPackageArtifact = await materializeOfficialIndexPackage(
-      entry,
-      projectRoot,
-    );
-    if (officialIndexPackageArtifact !== null) {
-      return officialIndexPackageArtifact;
-    }
-
-    return null;
+    return materializeOfficialIndexPackage(entry, projectRoot);
   }
 
   const filePath = entry.evidence.filePath;
@@ -345,7 +376,9 @@ async function materializeMirrorArtifact(
     const fileContent = await readTextFileOrNull(safeFilePath);
     if (fileContent !== null) {
       return {
-        content: Buffer.from(fileContent, "utf8"),
+        artifact: {
+          content: Buffer.from(fileContent, "utf8"),
+        },
       };
     }
   }
@@ -359,29 +392,37 @@ async function materializeMirrorArtifact(
     const cacheContent = await readTextFileOrNull(cachePath);
     if (cacheContent !== null) {
       return {
-        content: Buffer.from(cacheContent, "utf8"),
+        artifact: {
+          content: Buffer.from(cacheContent, "utf8"),
+        },
       };
     }
   }
 
   return {
-    content: Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
+    artifact: {
+      content: Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
+    },
   };
 }
 
 async function materializeGitHubTreeArtifact(
   entry: AssetCatalogEntry,
   requirePinnedProvenance: boolean,
-): Promise<MaterializedMirrorArtifact | null> {
+): Promise<MaterializeArtifactResult> {
   const repoInfo = parseGitHubBlobEntry(entry);
   if (!repoInfo) {
     return requirePinnedProvenance
-      ? null
-      : { content: Buffer.from(JSON.stringify(entry, null, 2), "utf8") };
+      ? { artifact: null }
+      : {
+          artifact: {
+            content: Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
+          },
+        };
   }
 
   if (!repoInfo.expectedBlobSha) {
-    return null;
+    return { artifact: null };
   }
 
   const commitSha = await fetchGitHubBranchCommitSha(
@@ -399,26 +440,28 @@ async function materializeGitHubTreeArtifact(
     repoInfo.expectedBlobSha,
   );
   if (content === null) {
-    return null;
+    return { artifact: null };
   }
 
   return {
-    content,
-    upstreamRef: repoInfo.ref,
-    upstreamCommit: commitSha ?? undefined,
-    upstreamBlobSha: repoInfo.expectedBlobSha,
+    artifact: {
+      content,
+      upstreamRef: repoInfo.ref,
+      upstreamCommit: commitSha ?? undefined,
+      upstreamBlobSha: repoInfo.expectedBlobSha,
+    },
   };
 }
 
 async function materializeOfficialIndexPackage(
   entry: AssetCatalogEntry,
   projectRoot: string,
-): Promise<MaterializedMirrorArtifact | null> {
+): Promise<MaterializeArtifactResult> {
   const slug = entry.install.manifestEntry;
   const owner = entry.source.sourceId.split(":")[1];
 
   if (!slug || !owner) {
-    return null;
+    return { artifact: null };
   }
 
   for (const repoUrl of await buildOfficialIndexRepoUrlCandidates(entry, owner)) {
@@ -445,15 +488,35 @@ async function materializeOfficialIndexPackage(
         treeEntry.type === "blob" &&
         treeEntry.path.startsWith(`${skillRootPath}/`),
     );
+    const packageTotalBytes = packageFileCandidates.reduce(
+      (totalBytes, treeEntry) => totalBytes + Math.max(0, treeEntry.size ?? 0),
+      0,
+    );
+    if (packageFileCandidates.length > MAX_OFFICIAL_INDEX_PACKAGE_FILES) {
+      return {
+        artifact: null,
+        skipReason: "official-index-package-too-many-files",
+      };
+    }
+
     if (
-      packageFileCandidates.length > MAX_OFFICIAL_INDEX_PACKAGE_FILES ||
       packageFileCandidates.some(
         (treeEntry) =>
           treeEntry.size !== null &&
           treeEntry.size > MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
       )
     ) {
-      continue;
+      return {
+        artifact: null,
+        skipReason: "official-index-file-too-large",
+      };
+    }
+
+    if (packageTotalBytes > MAX_OFFICIAL_INDEX_PACKAGE_TOTAL_BYTES) {
+      return {
+        artifact: null,
+        skipReason: "official-index-package-too-large",
+      };
     }
 
     const packageFiles = packageFileCandidates;
@@ -505,16 +568,20 @@ async function materializeOfficialIndexPackage(
     );
 
     return {
-      content:
-        skillMarkdownFile?.content ??
-        Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
-      files: materializedFiles,
-      upstreamRef: snapshot.repoSummary.defaultBranch,
-      upstreamCommit: commitSha ?? undefined,
+      artifact: {
+        content:
+          skillMarkdownFile?.content ??
+          Buffer.from(JSON.stringify(entry, null, 2), "utf8"),
+        files: materializedFiles,
+        upstreamRef: snapshot.repoSummary.defaultBranch,
+        upstreamCommit: commitSha ?? undefined,
+      },
     };
   }
 
-  return null;
+  return {
+    artifact: null,
+  };
 }
 
 async function buildOfficialIndexRepoUrlCandidates(
@@ -843,20 +910,51 @@ function isGitBlobSha(value: string | undefined): value is string {
   return Boolean(value && /^[a-f0-9]{40}$/iu.test(value));
 }
 
-async function readPersistedSkippedAssetIds(
+async function readPersistedSkippedAssets(
   projectRoot: string,
-): Promise<Set<string>> {
-  const state = await readJsonFileOrNull<{ skippedAssetIds?: unknown }>(
-    join(projectRoot, ...MIRROR_ACQUIRE_STATE_OUTPUT_PATH),
-  );
+): Promise<PersistedSkippedAssets> {
+  const state = await readJsonFileOrNull<{
+    skippedAssetIds?: unknown;
+    skippedAssetReasons?: unknown;
+  }>(join(projectRoot, ...MIRROR_ACQUIRE_STATE_OUTPUT_PATH));
 
   if (!state || !Array.isArray(state.skippedAssetIds)) {
-    return new Set();
+    return {
+      assetIds: new Set(),
+      assetReasons: new Map(),
+    };
   }
 
-  return new Set(
+  const assetIds = new Set(
     state.skippedAssetIds.filter(
       (value): value is string => typeof value === "string",
+    ),
+  );
+  const assetReasons = new Map<string, string>();
+  if (
+    typeof state.skippedAssetReasons === "object" &&
+    state.skippedAssetReasons !== null &&
+    !Array.isArray(state.skippedAssetReasons)
+  ) {
+    for (const [assetId, reason] of Object.entries(state.skippedAssetReasons)) {
+      if (typeof reason === "string" && assetIds.has(assetId)) {
+        assetReasons.set(assetId, reason);
+      }
+    }
+  }
+
+  return {
+    assetIds,
+    assetReasons,
+  };
+}
+
+function buildSortedReasonRecord(
+  reasons: Map<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    [...reasons.entries()].sort(([leftAssetId], [rightAssetId]) =>
+      leftAssetId.localeCompare(rightAssetId),
     ),
   );
 }

--- a/src/mirror/constants.ts
+++ b/src/mirror/constants.ts
@@ -21,15 +21,19 @@ export const MIRROR_ACQUIRE_STATE_OUTPUT_PATH = [
 /**
  * Defines max official index package files shared by the lifecycle pipeline.
  */
-export const MAX_OFFICIAL_INDEX_PACKAGE_FILES = 50;
+export const MAX_OFFICIAL_INDEX_PACKAGE_FILES = 1_000;
 /**
  * Defines max official index file size bytes shared by the lifecycle pipeline.
  */
-export const MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES = 150_000;
+export const MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES = 1_000_000;
+/**
+ * Defines max official index package total bytes shared by the lifecycle pipeline.
+ */
+export const MAX_OFFICIAL_INDEX_PACKAGE_TOTAL_BYTES = 20_000_000;
 /**
  * Defines max github mirror file size bytes shared by the lifecycle pipeline.
  */
-export const MAX_GITHUB_MIRROR_FILE_SIZE_BYTES = 500_000;
+export const MAX_GITHUB_MIRROR_FILE_SIZE_BYTES = 1_000_000;
 /**
  * Defines the allowed github raw allowed origins used by guarded network requests.
  */

--- a/src/official-index.ts
+++ b/src/official-index.ts
@@ -22,19 +22,30 @@ const OFFICIAL_INDEX_ALLOWED_ORIGINS = [
 export async function fetchOfficialIndexPageContent(
   url: string,
 ): Promise<string | null> {
-  const html = await fetchTextWithGuards(url, {
-    allowedOrigins: OFFICIAL_INDEX_ALLOWED_ORIGINS,
-    headers: {
-      "User-Agent": OFFICIAL_INDEX_USER_AGENT,
-    },
-    maxBytes: MAX_OFFICIAL_INDEX_PAGE_BYTES,
-  });
+  const html = await fetchOfficialIndexPageHtml(url);
   if (html === null) {
     return null;
   }
 
   const extractedContent = extractOfficialIndexPageSummary(html, url);
   return extractedContent.length > 0 ? extractedContent : null;
+}
+
+/**
+ * Fetches an official index page and extracts a backing GitHub repository URL
+ * when one is explicitly advertised.
+ */
+export async function fetchOfficialIndexPageRepositoryUrl(
+  url: string,
+): Promise<string | null> {
+  const html = await fetchOfficialIndexPageHtml(url);
+  if (html === null) {
+    return null;
+  }
+
+  return normalizeGitHubRepositoryUrl(
+    extractGitHubUrl(html, extractInstallCommand(html)),
+  );
 }
 
 /**
@@ -51,6 +62,16 @@ export function buildOfficialIndexAssetStatus(
     installEligible: isPromotableOfficialEntry,
     activationEligible: isPromotableOfficialEntry,
   };
+}
+
+async function fetchOfficialIndexPageHtml(url: string): Promise<string | null> {
+  return fetchTextWithGuards(url, {
+    allowedOrigins: OFFICIAL_INDEX_ALLOWED_ORIGINS,
+    headers: {
+      "User-Agent": OFFICIAL_INDEX_USER_AGENT,
+    },
+    maxBytes: MAX_OFFICIAL_INDEX_PAGE_BYTES,
+  });
 }
 
 function extractOfficialIndexPageSummary(html: string, url: string): string {
@@ -240,6 +261,28 @@ function decodeHtmlEntities(value: string): string {
     .replace(/&lt;/gu, "<")
     .replace(/&gt;/gu, ">")
     .replace(/&nbsp;/gu, " ");
+}
+
+function normalizeGitHubRepositoryUrl(url: string | null): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.hostname.toLowerCase() !== "github.com") {
+      return null;
+    }
+
+    const pathParts = parsedUrl.pathname.split("/").filter(Boolean);
+    if (pathParts.length < 2) {
+      return null;
+    }
+
+    return `https://github.com/${pathParts[0]}/${pathParts[1]?.replace(/\.git$/u, "")}`;
+  } catch {
+    return null;
+  }
 }
 
 function escapeRegExp(value: string): string {

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -629,6 +629,186 @@ void test("acquireMirrorArtifacts mirrors official-index packages when commit lo
   }
 });
 
+void test("acquireMirrorArtifacts falls back to later official-index repo candidates when an earlier candidate exceeds policy caps", async (context) => {
+  const entry = buildOfficialIndexAsset("official-index-fallback-candidate");
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+  const oversizedRepoUrl =
+    "https://github.com/cloudflare/cloudflare-skills/tree/main/skills/cloudflare";
+  const oversizedTree = Array.from(
+    { length: MAX_OFFICIAL_INDEX_PACKAGE_FILES + 1 },
+    (_, index) => ({
+      path:
+        index === 0
+          ? "skills/cloudflare/SKILL.md"
+          : `skills/cloudflare/references/oversized-${index}.md`,
+      type: "blob",
+      size: 128,
+      sha: `oversized-sha-${index}`,
+    }),
+  );
+  const fallbackSkillMarkdownContent = Buffer.from(
+    "# Cloudflare fallback\n",
+    "utf8",
+  );
+  const fallbackReadmeContent = Buffer.from("Fallback repo\n", "utf8");
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (
+      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
+    ) {
+      return new Response(createOfficialIndexHtml(oversizedRepoUrl), {
+        status: 200,
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/cloudflare-skills"
+    ) {
+      return Response.json({
+        name: "cloudflare-skills",
+        full_name: "cloudflare/cloudflare-skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/cloudflare-skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "oversized-tree-sha",
+        truncated: false,
+        tree: oversizedTree,
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (requestUrl === "https://api.github.com/repos/cloudflare/skills") {
+      return Response.json({
+        name: "skills",
+        full_name: "cloudflare/skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "fallback-tree-sha",
+        truncated: false,
+        tree: [
+          {
+            path: "skills/cloudflare/SKILL.md",
+            type: "blob",
+            size: fallbackSkillMarkdownContent.byteLength,
+            sha: createGitBlobSha(fallbackSkillMarkdownContent),
+          },
+          {
+            path: "skills/cloudflare/README.md",
+            type: "blob",
+            size: fallbackReadmeContent.byteLength,
+            sha: createGitBlobSha(fallbackReadmeContent),
+          },
+        ],
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/commits/main"
+    ) {
+      return new Response("rate limited", { status: 503 });
+    }
+
+    if (
+      requestUrl ===
+      "https://raw.githubusercontent.com/cloudflare/skills/main/skills/cloudflare/SKILL.md"
+    ) {
+      return new Response(fallbackSkillMarkdownContent, { status: 200 });
+    }
+
+    if (
+      requestUrl ===
+      "https://raw.githubusercontent.com/cloudflare/skills/main/skills/cloudflare/README.md"
+    ) {
+      return new Response(fallbackReadmeContent, { status: 200 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    const policy = buildMirrorPolicy();
+    await writeJsonFile(join(projectRoot, "mirror", "policy.json"), {
+      ...policy,
+      selection: {
+        ...policy.selection,
+        requirePinnedProvenance: true,
+      },
+    });
+
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.deepEqual(state.skippedAssetReasons, {});
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(mirrorIndex[0]?.assetId, "official-index-fallback-candidate");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
 void test("acquireMirrorArtifacts mirrors official-index packages with more than the legacy file-count cap", async (context) => {
   const entry = buildOfficialIndexAsset("official-index-many-files");
   const projectRoot = await createAcquireFixture([entry]);
@@ -978,6 +1158,49 @@ void test("acquireMirrorArtifacts records official-index total-byte cap skips wi
       return new Response("not found", { status: 404 });
     }
 
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/cloudflare-skills"
+    ) {
+      return Response.json({
+        name: "cloudflare-skills",
+        full_name: "cloudflare/cloudflare-skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/cloudflare-skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "owner-tree-sha",
+        truncated: false,
+        tree: [
+          {
+            path: "skills/other-skill/SKILL.md",
+            type: "blob",
+            size: 128,
+            sha: "owner-skill-sha",
+          },
+        ],
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
     throw new Error(`Unexpected URL: ${requestUrl}`);
   };
 
@@ -1076,6 +1299,49 @@ void test("acquireMirrorArtifacts records official-index file-count cap skips wi
 
     if (
       requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/cloudflare-skills"
+    ) {
+      return Response.json({
+        name: "cloudflare-skills",
+        full_name: "cloudflare/cloudflare-skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/cloudflare-skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "owner-tree-sha",
+        truncated: false,
+        tree: [
+          {
+            path: "skills/other-skill/SKILL.md",
+            type: "blob",
+            size: 128,
+            sha: "owner-skill-sha",
+          },
+        ],
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/readme"
     ) {
       return new Response("not found", { status: 404 });
     }

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -17,6 +17,12 @@ import {
 } from "../manifest-validation/mirror.js";
 import { assertMirrorAcquireCheckpoint } from "../mirror/acquire-state.js";
 import { acquireMirrorArtifacts } from "../mirror/acquire.js";
+import {
+  MAX_GITHUB_MIRROR_FILE_SIZE_BYTES,
+  MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
+  MAX_OFFICIAL_INDEX_PACKAGE_FILES,
+  MAX_OFFICIAL_INDEX_PACKAGE_TOTAL_BYTES,
+} from "../mirror/constants.js";
 import type {
   AssetCatalogEntry,
   MirrorAcquireState,
@@ -36,9 +42,11 @@ function createAcquireState(
     remainingCount: 0,
     skippedCount: 0,
     skippedAssetIds: [],
+    skippedAssetReasons: {},
     lastBatchAssetIds: [],
     lastBatchMirroredCount: 0,
     lastBatchSkippedCount: 0,
+    lastBatchSkippedReasons: {},
     terminal: false,
     ...overrides,
   };
@@ -133,9 +141,11 @@ function buildAsset(id: string): AssetCatalogEntry {
   };
 }
 
-function buildGitHubTreeAsset(id: string): AssetCatalogEntry {
+function buildGitHubTreeAsset(
+  id: string,
+  content: Buffer = Buffer.from("# example\n", "utf8"),
+): AssetCatalogEntry {
   const filePath = "agents/example.agent.md";
-  const content = Buffer.from("# example\n", "utf8");
   const blobSha = createGitBlobSha(content);
 
   return {
@@ -266,11 +276,16 @@ function createMaterializer(skippedIds: readonly string[]) {
 
   return async (entry: AssetCatalogEntry) => {
     if (skipped.has(entry.id)) {
-      return null;
+      return {
+        artifact: null,
+        skipReason: "materialize-failed" as const,
+      };
     }
 
     return {
-      content: Buffer.from(`fixture:${entry.id}`, "utf8"),
+      artifact: {
+        content: Buffer.from(`fixture:${entry.id}`, "utf8"),
+      },
     };
   };
 }
@@ -289,6 +304,14 @@ function restoreFetchMockFlag(previousValue: string | undefined): void {
   }
 
   process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = previousValue;
+}
+
+function createOfficialIndexHtml(repoUrl: string): string {
+  return [
+    "<html><body>",
+    `<a href="${repoUrl}">View on GitHub</a>`,
+    "</body></html>",
+  ].join("");
 }
 
 void test("mirror acquire checkpoint throws when persisted state is missing", () => {
@@ -339,9 +362,17 @@ void test("acquireMirrorArtifacts writes terminal incomplete state for all-skip 
     assert.equal(state.mirroredCount, 0);
     assert.equal(state.skippedCount, 2);
     assert.deepEqual(state.skippedAssetIds, ["skip-a", "skip-b"]);
+    assert.deepEqual(state.skippedAssetReasons, {
+      "skip-a": "materialize-failed",
+      "skip-b": "materialize-failed",
+    });
     assert.equal(state.remainingCount, 0);
     assert.equal(state.lastBatchMirroredCount, 0);
     assert.equal(state.lastBatchSkippedCount, 2);
+    assert.deepEqual(state.lastBatchSkippedReasons, {
+      "skip-a": "materialize-failed",
+      "skip-b": "materialize-failed",
+    });
     assert.deepEqual(state.lastBatchAssetIds, ["skip-a", "skip-b"]);
     assert.equal(mirrorIndex.length, 0);
 
@@ -397,8 +428,12 @@ void test("acquireMirrorArtifacts ignores stale persisted skipped ids outside th
   }
 });
 
-void test("acquireMirrorArtifacts mirrors pinned github-tree assets when commit lookup fails but raw fetch verifies", async (context) => {
-  const entry = buildGitHubTreeAsset("github-tree-agent");
+void test("acquireMirrorArtifacts mirrors pinned github-tree assets between legacy and relaxed size caps when commit lookup fails but raw fetch verifies", async (context) => {
+  const largeContent = Buffer.alloc(
+    MAX_GITHUB_MIRROR_FILE_SIZE_BYTES - 200_000,
+    "a",
+  );
+  const entry = buildGitHubTreeAsset("github-tree-agent", largeContent);
   const projectRoot = await createAcquireFixture([entry]);
   const originalFetch = globalThis.fetch;
   const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
@@ -412,7 +447,7 @@ void test("acquireMirrorArtifacts mirrors pinned github-tree assets when commit 
     }
 
     if (requestUrl.startsWith("https://raw.githubusercontent.com/")) {
-      return new Response("# example\n", { status: 200 });
+      return new Response(largeContent, { status: 200 });
     }
 
     throw new Error(`Unexpected URL: ${requestUrl}`);
@@ -594,6 +629,489 @@ void test("acquireMirrorArtifacts mirrors official-index packages when commit lo
   }
 });
 
+void test("acquireMirrorArtifacts mirrors official-index packages with more than the legacy file-count cap", async (context) => {
+  const entry = buildOfficialIndexAsset("official-index-many-files");
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+  const repoUrl =
+    "https://github.com/cloudflare/skills/tree/main/skills/cloudflare";
+  const packageFiles = Array.from({ length: 60 }, (_, index) => {
+    const relativePath =
+      index === 0 ? "SKILL.md" : `references/example-${index}.md`;
+    const content = Buffer.from(`fixture:${relativePath}\n`, "utf8");
+    return {
+      relativePath,
+      path: `skills/cloudflare/${relativePath}`,
+      content,
+    };
+  });
+  const packageContentByPath = new Map(
+    packageFiles.map((file) => [file.path, file.content]),
+  );
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (
+      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
+    ) {
+      return new Response(createOfficialIndexHtml(repoUrl), { status: 200 });
+    }
+
+    if (requestUrl === "https://api.github.com/repos/cloudflare/skills") {
+      return Response.json({
+        name: "skills",
+        full_name: "cloudflare/skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "tree-sha",
+        truncated: false,
+        tree: packageFiles.map((file) => ({
+          path: file.path,
+          type: "blob",
+          size: file.content.byteLength,
+          sha: createGitBlobSha(file.content),
+        })),
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/commits/main"
+    ) {
+      return new Response("rate limited", { status: 503 });
+    }
+
+    const rawPrefix =
+      "https://raw.githubusercontent.com/cloudflare/skills/main/";
+    if (requestUrl.startsWith(rawPrefix)) {
+      const content = packageContentByPath.get(
+        requestUrl.slice(rawPrefix.length),
+      );
+      if (!content) {
+        throw new Error(`Unexpected raw URL: ${requestUrl}`);
+      }
+
+      return new Response(content, { status: 200 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    const policy = buildMirrorPolicy();
+    await writeJsonFile(join(projectRoot, "mirror", "policy.json"), {
+      ...policy,
+      selection: {
+        ...policy.selection,
+        requirePinnedProvenance: true,
+      },
+    });
+
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(mirrorIndex[0]?.assetId, "official-index-many-files");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts mirrors official-index packages with files between legacy and relaxed size caps", async (context) => {
+  const entry = {
+    ...buildOfficialIndexAsset("official-index-large-file"),
+    source: {
+      sourceId: "official-index:figma:figma-use",
+      authorityTier: "official-first-party" as const,
+      sourceKind: "docs" as const,
+      sourcePriority: 100,
+      originUrl: "https://officialskills.sh/figma/skills/figma-use",
+      publisher: "Figma",
+      publisherVerified: true,
+    },
+    install: {
+      method: "official-index-entry" as const,
+      nativeHosts: ["copilot-vscode" as const],
+      manifestEntry: "figma-use",
+    },
+    evidence: {
+      manifestFound: true,
+      readmeFound: true,
+      examplesFound: false,
+      docsLinked: true,
+      lineCount: 1,
+      filePath: "SKILL.md",
+      rootPath: "https://officialskills.sh/figma/skills/figma-use",
+    },
+  };
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+  const repoUrl =
+    "https://github.com/figma/mcp-server-guide/tree/main/skills/figma-use";
+  const skillMarkdownContent = Buffer.from("# Figma Use\n", "utf8");
+  const largeReferenceContent = Buffer.alloc(
+    Math.min(MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES - 100_000, 700_000),
+    "d",
+  );
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (requestUrl === "https://officialskills.sh/figma/skills/figma-use") {
+      return new Response(createOfficialIndexHtml(repoUrl), { status: 200 });
+    }
+
+    if (requestUrl === "https://api.github.com/repos/figma/mcp-server-guide") {
+      return Response.json({
+        name: "mcp-server-guide",
+        full_name: "figma/mcp-server-guide",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/figma/mcp-server-guide",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/figma/mcp-server-guide/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "tree-sha",
+        truncated: false,
+        tree: [
+          {
+            path: "skills/figma-use/SKILL.md",
+            type: "blob",
+            size: skillMarkdownContent.byteLength,
+            sha: createGitBlobSha(skillMarkdownContent),
+          },
+          {
+            path: "skills/figma-use/references/plugin-api-standalone.d.ts",
+            type: "blob",
+            size: largeReferenceContent.byteLength,
+            sha: createGitBlobSha(largeReferenceContent),
+          },
+        ],
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/figma/mcp-server-guide/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/figma/mcp-server-guide/commits/main"
+    ) {
+      return new Response("rate limited", { status: 503 });
+    }
+
+    if (
+      requestUrl ===
+      "https://raw.githubusercontent.com/figma/mcp-server-guide/main/skills/figma-use/SKILL.md"
+    ) {
+      return new Response(skillMarkdownContent, { status: 200 });
+    }
+
+    if (
+      requestUrl ===
+      "https://raw.githubusercontent.com/figma/mcp-server-guide/main/skills/figma-use/references/plugin-api-standalone.d.ts"
+    ) {
+      return new Response(largeReferenceContent, { status: 200 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    const policy = buildMirrorPolicy();
+    await writeJsonFile(join(projectRoot, "mirror", "policy.json"), {
+      ...policy,
+      selection: {
+        ...policy.selection,
+        requirePinnedProvenance: true,
+      },
+    });
+
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(mirrorIndex[0]?.assetId, "official-index-large-file");
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts records official-index total-byte cap skips with reasons", async (context) => {
+  const entry = buildOfficialIndexAsset("official-index-too-large");
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+  const repoUrl =
+    "https://github.com/cloudflare/skills/tree/main/skills/cloudflare";
+  const oversizedFileCount =
+    Math.ceil(
+      MAX_OFFICIAL_INDEX_PACKAGE_TOTAL_BYTES /
+        MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
+    ) + 1;
+  const oversizedTree = Array.from(
+    { length: oversizedFileCount },
+    (_, index) => ({
+      path:
+        index === 0
+          ? "skills/cloudflare/SKILL.md"
+          : `skills/cloudflare/references/large-${index}.md`,
+      type: "blob",
+      size: index === 0 ? 128 : MAX_OFFICIAL_INDEX_FILE_SIZE_BYTES,
+      sha: `sha-${index}`,
+    }),
+  );
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (
+      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
+    ) {
+      return new Response(createOfficialIndexHtml(repoUrl), { status: 200 });
+    }
+
+    if (requestUrl === "https://api.github.com/repos/cloudflare/skills") {
+      return Response.json({
+        name: "skills",
+        full_name: "cloudflare/skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "tree-sha",
+        truncated: false,
+        tree: oversizedTree,
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 0);
+    assert.equal(state.skippedCount, 1);
+    assert.deepEqual(state.skippedAssetIds, ["official-index-too-large"]);
+    assert.deepEqual(state.skippedAssetReasons, {
+      "official-index-too-large": "official-index-package-too-large",
+    });
+    assert.deepEqual(state.lastBatchSkippedReasons, {
+      "official-index-too-large": "official-index-package-too-large",
+    });
+    assert.equal(mirrorIndex.length, 0);
+    assert.throws(
+      () => assertMirrorAcquireCheckpoint(state, "fixture"),
+      /Top skip reasons: official-index-package-too-large \(1\)\./,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts records official-index file-count cap skips with reasons", async (context) => {
+  const entry = buildOfficialIndexAsset("official-index-too-many-files");
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+  const repoUrl =
+    "https://github.com/cloudflare/skills/tree/main/skills/cloudflare";
+  const oversizedTree = Array.from(
+    { length: MAX_OFFICIAL_INDEX_PACKAGE_FILES + 1 },
+    (_, index) => ({
+      path:
+        index === 0
+          ? "skills/cloudflare/SKILL.md"
+          : `skills/cloudflare/references/file-${index}.md`,
+      type: "blob",
+      size: 128,
+      sha: `sha-${index}`,
+    }),
+  );
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (
+      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
+    ) {
+      return new Response(createOfficialIndexHtml(repoUrl), { status: 200 });
+    }
+
+    if (requestUrl === "https://api.github.com/repos/cloudflare/skills") {
+      return Response.json({
+        name: "skills",
+        full_name: "cloudflare/skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "tree-sha",
+        truncated: false,
+        tree: oversizedTree,
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 0);
+    assert.equal(state.skippedCount, 1);
+    assert.deepEqual(state.skippedAssetReasons, {
+      "official-index-too-many-files": "official-index-package-too-many-files",
+    });
+    assert.deepEqual(state.lastBatchSkippedReasons, {
+      "official-index-too-many-files": "official-index-package-too-many-files",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
 void test("acquireMirrorArtifacts treats mirrored overlap ids as mirrored instead of skipped", async () => {
   const entries = [buildAsset("mirror-a")];
   const projectRoot = await createAcquireFixture(entries);
@@ -666,6 +1184,10 @@ void test("acquireMirrorArtifacts continues past skipped first slice and mirrors
     assert.equal(firstState.mirroredCount, 0);
     assert.equal(firstState.skippedCount, 2);
     assert.deepEqual(firstState.skippedAssetIds, ["skip-a", "skip-b"]);
+    assert.deepEqual(firstState.skippedAssetReasons, {
+      "skip-a": "materialize-failed",
+      "skip-b": "materialize-failed",
+    });
     assert.equal(firstState.remainingCount, 1);
     assert.equal(firstState.lastBatchMirroredCount, 0);
     assert.equal(firstState.lastBatchSkippedCount, 2);
@@ -687,6 +1209,10 @@ void test("acquireMirrorArtifacts continues past skipped first slice and mirrors
     assert.equal(secondState.mirroredCount, 1);
     assert.equal(secondState.skippedCount, 2);
     assert.deepEqual(secondState.skippedAssetIds, ["skip-a", "skip-b"]);
+    assert.deepEqual(secondState.skippedAssetReasons, {
+      "skip-a": "materialize-failed",
+      "skip-b": "materialize-failed",
+    });
     assert.equal(secondState.remainingCount, 0);
     assert.equal(secondState.lastBatchMirroredCount, 1);
     assert.equal(secondState.lastBatchSkippedCount, 0);
@@ -724,6 +1250,9 @@ void test("acquireMirrorArtifacts records partial skip and mirror results from o
     assert.equal(state.mirroredCount, 1);
     assert.equal(state.skippedCount, 1);
     assert.deepEqual(state.skippedAssetIds, ["skip-b"]);
+    assert.deepEqual(state.skippedAssetReasons, {
+      "skip-b": "materialize-failed",
+    });
     assert.equal(state.remainingCount, 0);
     assert.equal(state.lastBatchMirroredCount, 1);
     assert.equal(state.lastBatchSkippedCount, 1);

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1090,6 +1090,149 @@ void test("acquireMirrorArtifacts mirrors official-index packages with files bet
   }
 });
 
+void test("acquireMirrorArtifacts falls back to materialize-failed when cap failures are followed by non-cap candidate failures", async (context) => {
+  const entry = buildOfficialIndexAsset(
+    "official-index-cap-then-noncap-failure",
+  );
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+  const repoUrl =
+    "https://github.com/cloudflare/cloudflare-skills/tree/main/skills/cloudflare";
+  const oversizedTree = Array.from(
+    { length: MAX_OFFICIAL_INDEX_PACKAGE_FILES + 1 },
+    (_, index) => ({
+      path:
+        index === 0
+          ? "skills/cloudflare/SKILL.md"
+          : `skills/cloudflare/references/oversized-${index}.md`,
+      type: "blob",
+      size: 128,
+      sha: `oversized-sha-${index}`,
+    }),
+  );
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (
+      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
+    ) {
+      return new Response(createOfficialIndexHtml(repoUrl), { status: 200 });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/cloudflare-skills"
+    ) {
+      return Response.json({
+        name: "cloudflare-skills",
+        full_name: "cloudflare/cloudflare-skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/cloudflare-skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "oversized-tree-sha",
+        truncated: false,
+        tree: oversizedTree,
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/cloudflare-skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (requestUrl === "https://api.github.com/repos/cloudflare/skills") {
+      return Response.json({
+        name: "skills",
+        full_name: "cloudflare/skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "fallback-tree-sha",
+        truncated: false,
+        tree: [
+          {
+            path: "skills/other-skill/SKILL.md",
+            type: "blob",
+            size: 128,
+            sha: "other-skill-sha",
+          },
+        ],
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 0);
+    assert.equal(state.skippedCount, 1);
+    assert.deepEqual(state.skippedAssetIds, [
+      "official-index-cap-then-noncap-failure",
+    ]);
+    assert.deepEqual(state.skippedAssetReasons, {
+      "official-index-cap-then-noncap-failure": "materialize-failed",
+    });
+    assert.deepEqual(state.lastBatchSkippedReasons, {
+      "official-index-cap-then-noncap-failure": "materialize-failed",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
 void test("acquireMirrorArtifacts records official-index total-byte cap skips with reasons", async (context) => {
   const entry = buildOfficialIndexAsset("official-index-too-large");
   const projectRoot = await createAcquireFixture([entry]);
@@ -1183,14 +1326,7 @@ void test("acquireMirrorArtifacts records official-index total-byte cap skips wi
       return Response.json({
         sha: "owner-tree-sha",
         truncated: false,
-        tree: [
-          {
-            path: "skills/other-skill/SKILL.md",
-            type: "blob",
-            size: 128,
-            sha: "owner-skill-sha",
-          },
-        ],
+        tree: oversizedTree,
       });
     }
 
@@ -1328,14 +1464,7 @@ void test("acquireMirrorArtifacts records official-index file-count cap skips wi
       return Response.json({
         sha: "owner-tree-sha",
         truncated: false,
-        tree: [
-          {
-            path: "skills/other-skill/SKILL.md",
-            type: "blob",
-            size: 128,
-            sha: "owner-skill-sha",
-          },
-        ],
+        tree: oversizedTree,
       });
     }
 

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -132,6 +133,73 @@ function buildAsset(id: string): AssetCatalogEntry {
   };
 }
 
+function buildGitHubTreeAsset(id: string): AssetCatalogEntry {
+  const filePath = "agents/example.agent.md";
+  const content = Buffer.from("# example\n", "utf8");
+  const blobSha = createGitBlobSha(content);
+
+  return {
+    ...buildAsset(id),
+    assetKind: "agent",
+    compatibilityMode: "native",
+    source: {
+      sourceId: "github-awesome-copilot",
+      authorityTier: "official-first-party",
+      sourceKind: "repo",
+      sourcePriority: 100,
+      originUrl: `https://github.com/github/awesome-copilot/blob/main/${filePath}`,
+      publisher: "GitHub",
+      publisherVerified: true,
+    },
+    install: {
+      method: "github-tree-metadata",
+      nativeHosts: ["copilot-vscode"],
+      manifestEntry: blobSha,
+      relativePath: filePath,
+    },
+    evidence: {
+      manifestFound: true,
+      readmeFound: true,
+      examplesFound: false,
+      docsLinked: true,
+      lineCount: 1,
+      filePath,
+      rootPath: "https://github.com/github/awesome-copilot",
+    },
+  };
+}
+
+function buildOfficialIndexAsset(id: string): AssetCatalogEntry {
+  return {
+    ...buildAsset(id),
+    assetKind: "skill",
+    compatibilityMode: "native",
+    source: {
+      sourceId: "official-index:cloudflare:cloudflare",
+      authorityTier: "official-first-party",
+      sourceKind: "docs",
+      sourcePriority: 100,
+      originUrl: "https://officialskills.sh/cloudflare/skills/cloudflare",
+      publisher: "Cloudflare",
+      publisherVerified: true,
+    },
+    install: {
+      method: "official-index-entry",
+      nativeHosts: ["copilot-vscode"],
+      manifestEntry: "cloudflare",
+    },
+    evidence: {
+      manifestFound: true,
+      readmeFound: true,
+      examplesFound: false,
+      docsLinked: true,
+      lineCount: 1,
+      filePath: "SKILL.md",
+      rootPath: "https://officialskills.sh/cloudflare/skills/cloudflare",
+    },
+  };
+}
+
 async function createAcquireFixture(
   entries: AssetCatalogEntry[],
 ): Promise<string> {
@@ -205,6 +273,22 @@ function createMaterializer(skippedIds: readonly string[]) {
       content: Buffer.from(`fixture:${entry.id}`, "utf8"),
     };
   };
+}
+
+function createGitBlobSha(content: Buffer): string {
+  return createHash("sha1")
+    .update(`blob ${content.byteLength}\0`)
+    .update(content)
+    .digest("hex");
+}
+
+function restoreFetchMockFlag(previousValue: string | undefined): void {
+  if (previousValue === undefined) {
+    delete process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+    return;
+  }
+
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = previousValue;
 }
 
 void test("mirror acquire checkpoint throws when persisted state is missing", () => {
@@ -309,6 +393,203 @@ void test("acquireMirrorArtifacts ignores stale persisted skipped ids outside th
       ["mirror-a"],
     );
   } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts mirrors pinned github-tree assets when commit lookup fails but raw fetch verifies", async (context) => {
+  const entry = buildGitHubTreeAsset("github-tree-agent");
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (requestUrl.startsWith("https://api.github.com/")) {
+      return new Response("rate limited", { status: 503 });
+    }
+
+    if (requestUrl.startsWith("https://raw.githubusercontent.com/")) {
+      return new Response("# example\n", { status: 200 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    const policy = buildMirrorPolicy();
+    await writeJsonFile(join(projectRoot, "mirror", "policy.json"), {
+      ...policy,
+      selection: {
+        ...policy.selection,
+        requirePinnedProvenance: true,
+      },
+    });
+
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 1);
+    assert.equal(state.lastBatchSkippedCount, 0);
+    assert.deepEqual(state.lastBatchAssetIds, ["github-tree-agent"]);
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(mirrorIndex[0]?.assetId, "github-tree-agent");
+    assert.equal(mirrorIndex[0]?.upstream.commit, undefined);
+    assert.equal(assertMirrorAcquireCheckpoint(state, "fixture"), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts mirrors official-index packages when commit lookup fails but raw files verify", async (context) => {
+  const entry = buildOfficialIndexAsset("official-index-cloudflare");
+  const projectRoot = await createAcquireFixture([entry]);
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  const skillMarkdownContent = Buffer.from("# Cloudflare\n", "utf8");
+  const skillReadmeContent = Buffer.from("See SKILL.md\n", "utf8");
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+
+  globalThis.fetch = async (url) => {
+    const requestUrl = String(url);
+
+    if (
+      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
+    ) {
+      return new Response(
+        [
+          "<html><body>",
+          '<a href="https://github.com/cloudflare/skills/tree/main/skills/cloudflare">View on GitHub</a>',
+          "</body></html>",
+        ].join(""),
+        { status: 200 },
+      );
+    }
+
+    if (requestUrl === "https://api.github.com/repos/cloudflare/skills") {
+      return Response.json({
+        name: "skills",
+        full_name: "cloudflare/skills",
+        description: "fixture",
+        default_branch: "main",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        pushed_at: "2026-01-01T00:00:00.000Z",
+        stargazers_count: 1,
+        language: "Markdown",
+        topics: [],
+        archived: false,
+        html_url: "https://github.com/cloudflare/skills",
+      });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/git/trees/main?recursive=1"
+    ) {
+      return Response.json({
+        sha: "tree-sha",
+        truncated: false,
+        tree: [
+          {
+            path: "cloudflare/SKILL.md",
+            type: "blob",
+            size: skillMarkdownContent.byteLength,
+            sha: createGitBlobSha(skillMarkdownContent),
+          },
+          {
+            path: "cloudflare/README.md",
+            type: "blob",
+            size: skillReadmeContent.byteLength,
+            sha: createGitBlobSha(skillReadmeContent),
+          },
+        ],
+      });
+    }
+
+    if (
+      requestUrl === "https://api.github.com/repos/cloudflare/skills/readme"
+    ) {
+      return new Response("not found", { status: 404 });
+    }
+
+    if (
+      requestUrl ===
+      "https://api.github.com/repos/cloudflare/skills/commits/main"
+    ) {
+      return new Response("rate limited", { status: 503 });
+    }
+
+    if (
+      requestUrl ===
+      "https://raw.githubusercontent.com/cloudflare/skills/main/cloudflare/SKILL.md"
+    ) {
+      return new Response(skillMarkdownContent, { status: 200 });
+    }
+
+    if (
+      requestUrl ===
+      "https://raw.githubusercontent.com/cloudflare/skills/main/cloudflare/README.md"
+    ) {
+      return new Response(skillReadmeContent, { status: 200 });
+    }
+
+    throw new Error(`Unexpected URL: ${requestUrl}`);
+  };
+
+  context.after(() => {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  });
+
+  try {
+    const policy = buildMirrorPolicy();
+    await writeJsonFile(join(projectRoot, "mirror", "policy.json"), {
+      ...policy,
+      selection: {
+        ...policy.selection,
+        requirePinnedProvenance: true,
+      },
+    });
+
+    await acquireMirrorArtifacts(projectRoot, projectRoot, [
+      "--batch-size",
+      "10",
+    ]);
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(mirrorIndex[0]?.assetId, "official-index-cloudflare");
+    assert.equal(mirrorIndex[0]?.upstream.commit, undefined);
+    assert.equal(assertMirrorAcquireCheckpoint(state, "fixture"), true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
     await rm(projectRoot, { force: true, recursive: true });
   }
 });

--- a/src/tests/security-hardening.test.ts
+++ b/src/tests/security-hardening.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import {
   assertAllowedPublicHttpUrl,
   assertAllowedPublicHttpUrlWithDns,
+  createPinnedLookup,
   fetchTextWithGuards,
   type HostnameResolver,
 } from "../lib/http.js";
@@ -41,6 +42,55 @@ void test("mirror file path resolution rejects path traversal", () => {
     () => resolveSafeMirrorFilePath(rawRoot, ""),
     /outside raw root/u,
   );
+});
+
+void test("pinned lookup honors Node all-results callback mode", async () => {
+  const pinnedLookup = createPinnedLookup({
+    address: "203.0.113.10",
+    family: 4,
+  });
+
+  const allResults = await new Promise<
+    Array<{ address: string; family: 4 | 6 }>
+  >((resolve, reject) => {
+    pinnedLookup("example.com", { all: true, hints: 0 }, ((
+      error: Error | null,
+      addresses: Array<{ address: string; family: 4 | 6 }>,
+    ) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(addresses);
+    }) as never);
+  });
+
+  assert.deepEqual(allResults, [{ address: "203.0.113.10", family: 4 }]);
+});
+
+void test("pinned lookup honors Node single-result callback mode", async () => {
+  const pinnedLookup = createPinnedLookup({
+    address: "203.0.113.10",
+    family: 4,
+  });
+
+  const singleResult = await new Promise<{ address: string; family: 4 | 6 }>(
+    (resolve, reject) => {
+      pinnedLookup("example.com", { all: false, hints: 0 }, ((
+        error: Error | null,
+        address: string,
+        family: 4 | 6,
+      ) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve({ address, family });
+      }) as never);
+    },
+  );
+
+  assert.deepEqual(singleResult, { address: "203.0.113.10", family: 4 });
 });
 
 void test("guarded fetches preserve caller abort signals", async (context) => {

--- a/src/types/mirror.ts
+++ b/src/types/mirror.ts
@@ -150,8 +150,10 @@ export interface MirrorAcquireState {
   remainingCount: number;
   skippedCount: number;
   skippedAssetIds: string[];
+  skippedAssetReasons?: Record<string, string>;
   lastBatchAssetIds: string[];
   lastBatchMirroredCount: number;
   lastBatchSkippedCount: number;
+  lastBatchSkippedReasons?: Record<string, string>;
   terminal: boolean;
 }


### PR DESCRIPTION
## Summary
- fix guarded GitHub mirror acquisition so pinned artifacts can still materialize when branch commit lookup is temporarily unavailable but raw content still verifies against the pinned blob SHA
- teach official-index package mirroring to derive the backing GitHub repo from the officialskills page instead of relying only on owner-name repo guesses
- expand the default discovery registry with curated official/community sources and update the docs/changelog/env docs to match

## Why
A real workspace repro on `C:\Projects\Apify\Webhook Debugger and Logger` was skipping GitHub-backed assets en masse. The root cause started in the guarded pinned DNS lookup path (`ERR_INVALID_IP_ADDRESS` from the wrong `lookup(..., { all: true })` callback shape), then continued in mirror acquisition where commit lookup failures were treated as hard-stop skips even when raw pinned content was still fetchable and SHA-verifiable.

## Real repro evidence
`workspace opencode --intent backend` on a temp clone of `Webhook Debugger and Logger`:
- before fixes: `14 mirrored / 163 skipped`
- after pinned lookup + fallback mirroring fixes: `208 mirrored / 2 skipped`

The remaining 2 skips are now a separate official-index packaging-cap policy issue, tracked in `#119`.

## Validation
- `npm run validate`
- `npm run validate:release`
- targeted real workspace repro on `Webhook Debugger and Logger`

Closes #118
Refs #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added default registry sources (GitHub Awesome Copilot Site, ClawHub) and improved official-index/mirror acquisition behavior with more relaxed size limits.

* **Bug Fixes**
  * Fixed GitHub lookup/DNS behavior to avoid invalid IP errors during workspace fetches.

* **Documentation**
  * Expanded GitHub authentication guidance and token recommendations; updated example env comment and clarified default registry composition.

* **Tests**
  * Expanded tests for mirror acquisition and pinned-address DNS lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->