### PR TITLE
Improve host adapter test path assertions

### DIFF
--- a/src/tests/host-adapters.test.ts
+++ b/src/tests/host-adapters.test.ts
@@ -544,8 +544,19 @@ async function writeJson(filePath: string, value: unknown): Promise<void> {
 }
 
 async function assertPathExists(pathValue: string): Promise<void> {
-  const entry = await stat(pathValue);
-  assert.ok(entry.isDirectory() || entry.isFile());
+  let entry;
+  try {
+    entry = await stat(pathValue);
+  } catch (error) {
+    throw new Error(`expected ${pathValue} to exist`, {
+      cause: error,
+    });
+  }
+
+  assert.ok(
+    entry.isDirectory() || entry.isFile(),
+    `expected ${pathValue} to be a file or directory`,
+  );
 }
 
 function buildAllAssetFixtures(): AssetCatalogEntry[] {


### PR DESCRIPTION
## Summary
- make assertPathExists report the failing path when stat fails
- replace the no-message assertion with an explicit file-or-directory message
- keep the fix scoped to the reviewed helper

## Validation
- npm run validate
- npm run build
- node --test dist/tests/host-adapters.test.js