### PR TITLE
Fallback to official-index page content

### DIFF
--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -32,6 +32,7 @@ import {
 } from "../manifest-validation.js";
 import {
   fetchOfficialIndexPageContent,
+  fetchOfficialIndexPageInfo,
   fetchOfficialIndexPageRepositoryUrl,
 } from "../official-index.js";
 import type {
@@ -468,7 +469,19 @@ async function materializeOfficialIndexPackage(
     return { artifact: null };
   }
 
-  for (const repoUrl of await buildOfficialIndexRepoUrlCandidates(entry, owner)) {
+  const officialIndexPage = await fetchOfficialIndexPageInfo(
+    entry.source.originUrl,
+  );
+  officialIndexRepoUrlCache.set(
+    entry.source.originUrl,
+    officialIndexPage.repositoryUrl,
+  );
+
+  for (const repoUrl of await buildOfficialIndexRepoUrlCandidates(
+    entry,
+    owner,
+    officialIndexPage.repositoryUrl,
+  )) {
     const snapshot = await fetchGitHubRepoSnapshotByRepoUrl({
       repoUrl,
       projectRoot,
@@ -581,10 +594,8 @@ async function materializeOfficialIndexPackage(
     };
   }
 
-  if (sawNonCapFailure) {
-    const referenceContent = await fetchOfficialIndexPageContent(
-      entry.source.originUrl,
-    );
+  if (sawNonCapFailure && officialIndexPage.content !== null) {
+    const referenceContent = officialIndexPage.content;
     if (referenceContent !== null) {
       return {
         artifact: {
@@ -603,12 +614,15 @@ async function materializeOfficialIndexPackage(
 async function buildOfficialIndexRepoUrlCandidates(
   entry: AssetCatalogEntry,
   owner: string,
+  resolvedOfficialIndexRepoUrl?: string | null,
 ): Promise<string[]> {
-  let officialIndexRepoUrl = officialIndexRepoUrlCache.get(
-    entry.source.originUrl,
-  );
+  let officialIndexRepoUrl =
+    resolvedOfficialIndexRepoUrl ?? officialIndexRepoUrlCache.get(entry.source.originUrl);
 
-  if (!officialIndexRepoUrlCache.has(entry.source.originUrl)) {
+  if (
+    resolvedOfficialIndexRepoUrl === undefined &&
+    !officialIndexRepoUrlCache.has(entry.source.originUrl)
+  ) {
     officialIndexRepoUrl = await fetchOfficialIndexPageRepositoryUrl(
       entry.source.originUrl,
     );

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -581,6 +581,19 @@ async function materializeOfficialIndexPackage(
     };
   }
 
+  if (sawNonCapFailure) {
+    const referenceContent = await fetchOfficialIndexPageContent(
+      entry.source.originUrl,
+    );
+    if (referenceContent !== null) {
+      return {
+        artifact: {
+          content: Buffer.from(referenceContent, "utf8"),
+        },
+      };
+    }
+  }
+
   return {
     artifact: null,
     skipReason: sawNonCapFailure ? undefined : capSkipReason,

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -595,14 +595,11 @@ async function materializeOfficialIndexPackage(
   }
 
   if (sawNonCapFailure && officialIndexPage.content !== null) {
-    const referenceContent = officialIndexPage.content;
-    if (referenceContent !== null) {
-      return {
-        artifact: {
-          content: Buffer.from(referenceContent, "utf8"),
-        },
-      };
-    }
+    return {
+      artifact: {
+        content: Buffer.from(officialIndexPage.content, "utf8"),
+      },
+    };
   }
 
   return {
@@ -617,7 +614,8 @@ async function buildOfficialIndexRepoUrlCandidates(
   resolvedOfficialIndexRepoUrl?: string | null,
 ): Promise<string[]> {
   let officialIndexRepoUrl =
-    resolvedOfficialIndexRepoUrl ?? officialIndexRepoUrlCache.get(entry.source.originUrl);
+    resolvedOfficialIndexRepoUrl ??
+    officialIndexRepoUrlCache.get(entry.source.originUrl);
 
   if (
     resolvedOfficialIndexRepoUrl === undefined &&

--- a/src/official-index.ts
+++ b/src/official-index.ts
@@ -17,18 +17,38 @@ const OFFICIAL_INDEX_ALLOWED_ORIGINS = [
 ] as const;
 
 /**
+ * Fetches an official index page once and extracts the structured fallback
+ * summary plus any advertised backing GitHub repository URL.
+ */
+export async function fetchOfficialIndexPageInfo(url: string): Promise<{
+  content: string | null;
+  repositoryUrl: string | null;
+}> {
+  const html = await fetchOfficialIndexPageHtml(url);
+  if (html === null) {
+    return {
+      content: null,
+      repositoryUrl: null,
+    };
+  }
+
+  const extractedContent = extractOfficialIndexPageSummary(html, url);
+  const installCommand = extractInstallCommand(html);
+  return {
+    content: extractedContent.length > 0 ? extractedContent : null,
+    repositoryUrl: normalizeGitHubRepositoryUrl(
+      extractGitHubUrl(html, installCommand),
+    ),
+  };
+}
+
+/**
  * Fetches official index page content with the configured runtime safeguards.
  */
 export async function fetchOfficialIndexPageContent(
   url: string,
 ): Promise<string | null> {
-  const html = await fetchOfficialIndexPageHtml(url);
-  if (html === null) {
-    return null;
-  }
-
-  const extractedContent = extractOfficialIndexPageSummary(html, url);
-  return extractedContent.length > 0 ? extractedContent : null;
+  return (await fetchOfficialIndexPageInfo(url)).content;
 }
 
 /**
@@ -38,14 +58,7 @@ export async function fetchOfficialIndexPageContent(
 export async function fetchOfficialIndexPageRepositoryUrl(
   url: string,
 ): Promise<string | null> {
-  const html = await fetchOfficialIndexPageHtml(url);
-  if (html === null) {
-    return null;
-  }
-
-  return normalizeGitHubRepositoryUrl(
-    extractGitHubUrl(html, extractInstallCommand(html)),
-  );
+  return (await fetchOfficialIndexPageInfo(url)).repositoryUrl;
 }
 
 /**

--- a/src/official-index.ts
+++ b/src/official-index.ts
@@ -254,13 +254,13 @@ function cleanHtmlText(value: string): string | null {
 
 function decodeHtmlEntities(value: string): string {
   return value
-    .replace(/&amp;/gu, "&")
     .replace(/&quot;/gu, '"')
     .replace(/&#x27;/gu, "'")
     .replace(/&#39;/gu, "'")
     .replace(/&lt;/gu, "<")
     .replace(/&gt;/gu, ">")
-    .replace(/&nbsp;/gu, " ");
+    .replace(/&nbsp;/gu, " ")
+    .replace(/&amp;/gu, "&");
 }
 
 function normalizeGitHubRepositoryUrl(url: string | null): string | null {

--- a/src/official-index.ts
+++ b/src/official-index.ts
@@ -32,13 +32,15 @@ export async function fetchOfficialIndexPageInfo(url: string): Promise<{
     };
   }
 
-  const extractedContent = extractOfficialIndexPageSummary(html, url);
   const installCommand = extractInstallCommand(html);
+  const githubUrl = extractGitHubUrl(html, installCommand);
+  const extractedContent = extractOfficialIndexPageSummary(html, url, {
+    installCommand,
+    githubUrl,
+  });
   return {
     content: extractedContent.length > 0 ? extractedContent : null,
-    repositoryUrl: normalizeGitHubRepositoryUrl(
-      extractGitHubUrl(html, installCommand),
-    ),
+    repositoryUrl: normalizeGitHubRepositoryUrl(githubUrl),
   };
 }
 
@@ -87,11 +89,18 @@ async function fetchOfficialIndexPageHtml(url: string): Promise<string | null> {
   });
 }
 
-function extractOfficialIndexPageSummary(html: string, url: string): string {
+function extractOfficialIndexPageSummary(
+  html: string,
+  url: string,
+  options: {
+    installCommand?: string | null;
+    githubUrl?: string | null;
+  } = {},
+): string {
   const title = extractTitle(html);
   const description = extractMetaDescription(html);
-  const installCommand = extractInstallCommand(html);
-  const githubUrl = extractGitHubUrl(html, installCommand);
+  const installCommand = options.installCommand ?? extractInstallCommand(html);
+  const githubUrl = options.githubUrl ?? extractGitHubUrl(html, installCommand);
   const skillSummary = extractSectionParagraph("What This Skill Does", html);
   const whyItHelps = extractWhyItHelps(html);
   const useCases = extractSectionListItems("When to use it", html);

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -1236,6 +1236,22 @@ void test("acquireMirrorArtifacts falls back to official-index page content when
     assert.equal(
       mirrorIndex[0]?.assetId,
       "official-index-cap-then-noncap-failure",
+    );
+
+    const mirroredContent = await readFile(
+      join(
+        projectRoot,
+        "mirror",
+        "raw",
+        mirrorIndex[0]?.mirrorId ?? "",
+        "content.txt",
+      ),
+      "utf8",
+    );
+    assert.ok(mirroredContent.includes(`**Official Page**: ${originUrl}`));
+    assert.match(
+      mirroredContent,
+      /\*\*GitHub\*\*: https:\/\/github\.com\/cloudflare\/cloudflare-skills\/tree\/main\/skills\/cloudflare/u,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1091,9 +1091,22 @@ void test("acquireMirrorArtifacts mirrors official-index packages with files bet
 });
 
 void test("acquireMirrorArtifacts falls back to official-index page content when cap failures are followed by non-cap candidate failures", async (context) => {
-  const entry = buildOfficialIndexAsset(
+  const originUrl =
+    "https://officialskills.sh/cloudflare/skills/cloudflare?cap-then-noncap=1";
+  const baseEntry = buildOfficialIndexAsset(
     "official-index-cap-then-noncap-failure",
   );
+  const entry = {
+    ...baseEntry,
+    source: {
+      ...baseEntry.source,
+      originUrl,
+    },
+    evidence: {
+      ...baseEntry.evidence,
+      rootPath: originUrl,
+    },
+  };
   const projectRoot = await createAcquireFixture([entry]);
   const originalFetch = globalThis.fetch;
   const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
@@ -1116,9 +1129,7 @@ void test("acquireMirrorArtifacts falls back to official-index page content when
   globalThis.fetch = async (url) => {
     const requestUrl = String(url);
 
-    if (
-      requestUrl === "https://officialskills.sh/cloudflare/skills/cloudflare"
-    ) {
+    if (requestUrl === originUrl) {
       return new Response(createOfficialIndexHtml(repoUrl), { status: 200 });
     }
 

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1090,7 +1090,7 @@ void test("acquireMirrorArtifacts mirrors official-index packages with files bet
   }
 });
 
-void test("acquireMirrorArtifacts falls back to materialize-failed when cap failures are followed by non-cap candidate failures", async (context) => {
+void test("acquireMirrorArtifacts falls back to official-index page content when cap failures are followed by non-cap candidate failures", async (context) => {
   const entry = buildOfficialIndexAsset(
     "official-index-cap-then-noncap-failure",
   );
@@ -1213,19 +1213,19 @@ void test("acquireMirrorArtifacts falls back to materialize-failed when cap fail
     ]);
 
     const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
 
     assert.equal(state.terminal, true);
-    assert.equal(state.mirroredCount, 0);
-    assert.equal(state.skippedCount, 1);
-    assert.deepEqual(state.skippedAssetIds, [
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.skippedAssetIds, []);
+    assert.deepEqual(state.skippedAssetReasons, {});
+    assert.deepEqual(state.lastBatchSkippedReasons, {});
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(
+      mirrorIndex[0]?.assetId,
       "official-index-cap-then-noncap-failure",
-    ]);
-    assert.deepEqual(state.skippedAssetReasons, {
-      "official-index-cap-then-noncap-failure": "materialize-failed",
-    });
-    assert.deepEqual(state.lastBatchSkippedReasons, {
-      "official-index-cap-then-noncap-failure": "materialize-failed",
-    });
+    );
   } finally {
     globalThis.fetch = originalFetch;
     restoreFetchMockFlag(previousFetchMockFlag);

--- a/src/tests/official-index.test.ts
+++ b/src/tests/official-index.test.ts
@@ -5,6 +5,43 @@ import { join } from "node:path";
 import test from "node:test";
 
 import { harvestOfficialSkillIndexes } from "../domains/discovery/official-index-harvester.js";
+import { fetchOfficialIndexPageContent } from "../official-index.js";
+
+void test("official index page content does not double-decode escaped entities", async (context) => {
+  const originalFetch = globalThis.fetch;
+  const previousFetchMockFlag = process.env.AGENT_HARNESS_TEST_FETCH_MOCKS;
+  process.env.AGENT_HARNESS_TEST_FETCH_MOCKS = "1";
+
+  try {
+    globalThis.fetch = async () =>
+      new Response(
+        [
+          "<html><head>",
+          "<title>Cloudflare/cloudflare — Agent Skills | officialskills.sh</title>",
+          '<meta name="description" content="Keeps &amp;quot;quoted&amp;quot; guidance intact." />',
+          "</head><body>",
+          "<section><h2>What This Skill Does</h2><p>Preserves &amp;quot;quoted&amp;quot; examples.</p></section>",
+          "npx skills add https://github.com/cloudflare/skills --skill cloudflare",
+          "</body></html>",
+        ].join(""),
+        { status: 200 },
+      );
+    context.after(() => {
+      globalThis.fetch = originalFetch;
+      restoreFetchMockFlag(previousFetchMockFlag);
+    });
+
+    const content = await fetchOfficialIndexPageContent(
+      "https://officialskills.sh/cloudflare/skills/cloudflare",
+    );
+
+    assert.match(content ?? "", /&quot;quoted&quot;/u);
+    assert.doesNotMatch(content ?? "", /"quoted"/u);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreFetchMockFlag(previousFetchMockFlag);
+  }
+});
 
 void test("official index repo extraction respects checked-in owner allowlist", async (context) => {
   const projectRoot = await mkdtemp(


### PR DESCRIPTION
## Summary
- fall back to official-index page content when repo-based materialization fails for non-cap reasons
- make the fallback regression test independent from module-scope official-index URL cache reuse and assert the mirrored fallback content is really used
- avoid double-decoding official-index HTML entities by decoding ampersands last
- fixes #128
- fixes #127

## Validation
- npm run build
- node --test dist/tests/mirror-acquire-state.test.js dist/tests/official-index.test.js
- npm run validate
- real repro rerun: `node dist/cli.js --state-root .agent-harness-opencode-fixcheck workspace opencode` in `C:\Projects\InterActNote`
- canonical root refresh: copied the verified state into `C:\Projects\InterActNote\.agent-harness`, regenerated install/activate, and reapplied `wire opencode --apply`
