### PR TITLE
Prepare v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to this project will be documented in this file.
 
 - None yet.
 
+## [1.0.1] - 2026-05-08
+
+### Changed
+
+- made the Release workflow rerun-safe for manual `workflow_dispatch` runs so already-published versions skip duplicate publish steps instead of failing noisy follow-up checks
+- normalized the `Unreleased` changelog section headings to keep post-release changelog structure consistent
+
+### Fixed
+
+- `official-index-entry` mirror acquisition now falls back to structured official-index page content when repo-backed package materialization fails for non-cap reasons, which unblocks the real `InterActNote` + OpenCode workspace flow that previously stopped on Flutter-related `materialize-failed` skips
+- official-index HTML entity decoding now unescapes ampersands last, preventing double-decoding of values like `&amp;quot;`
+
 ## [1.0.0] - 2026-05-01
 
 ### Added in 1.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ar27111994/agent-harness",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Node.js TypeScript CLI for discovering, staging, activating, and wiring reusable AI-agent assets across supported developer hosts.",
   "license": "MIT",
   "author": "ar27111994",


### PR DESCRIPTION
## Summary
- bump package metadata from `1.0.0` to `1.0.1`
- add a `1.0.1` changelog entry for the post-`v1.0.0` release workflow and official-index fixes
- keep `Unreleased` reset to empty placeholders

## Validation
- npm run validate:release
- real smoke rerun: `node dist/cli.js --state-root .agent-harness-opencode-v101check workspace opencode` against `C:\Projects\InterActNote`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML entity decoding to prevent double-unescaping issues
  * Improved reliability of official-index mirror acquisition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->