### PR TITLE
docs: add agent setup playbook

### DIFF
--- a/AGENT-SETUP-PLAYBOOK.md
+++ b/AGENT-SETUP-PLAYBOOK.md
@@ -1,0 +1,315 @@
+# Agent Setup Playbook
+
+This playbook shows how to use `agent-harness` with another AI agent as a dry-run setup operator.
+
+Use it when you want an agent to:
+
+- inspect a workspace
+- explain what `agent-harness` detected
+- preview what would be wired into a host
+- separate safe preview steps from mutating install/apply steps
+- suggest manual follow-up for extensions, plugins, MCP servers, authentication, or host runtime setup
+
+The goal is simple: **dry run first, approve second, apply/install last.**
+
+## When to use this playbook
+
+Use this playbook when:
+
+- recommendations look noisy or surprising
+- you want help choosing a host (`vscode`, `cursor`, `opencode`, `zed`, `claude-code`, `pi`)
+- you want setup help for one or more intents such as `frontend`, `backend`, or `docs`
+- you want an agent to guide setup without immediately mutating your workspace or global host config
+- you want a clean separation between staged/wired assets and native/manual installation steps
+
+## Dry-run workflow
+
+Run this sequence from the target workspace root.
+
+### 1. Check host readiness
+
+```bash
+agent-harness setup doctor --host <host>
+```
+
+Use this to confirm:
+
+- lifecycle host and recommendation host
+- CLI/runtime readiness
+- adapter capabilities
+- any native-install boundary for the selected host
+
+### 2. Build workspace evidence
+
+Use the workspace root so the detector can see the real repo manifests and dependencies.
+
+```bash
+agent-harness discover demand-profile
+agent-harness discover catalog
+agent-harness discover select
+agent-harness discover stats
+agent-harness recommend report
+```
+
+Inspect these files when they exist:
+
+- `discover/output/demand-profile.json`
+- `discover/output/selection-report.json`
+- `discover/output/source-index.json`
+- `discover/output/source-utilization.json`
+- `state/recommendations.json`
+
+### 3. Preview wire-in before any apply step
+
+```bash
+agent-harness wire <host> --preview
+```
+
+Typical preview outputs:
+
+- `activate/<host>/wire-preview-<host>.json`
+- `activate/copilot-vscode/wire-preview-vscode.json` for VS Code / GitHub Copilot
+
+Use the preview to answer:
+
+- which target paths would be touched
+- which assets are only staged vs actually wired
+- which host-specific settings or project-local files are involved
+- whether the host integration looks correct before approval
+
+### 4. Review native install planning separately
+
+Some asset kinds need more than staging/wiring.
+
+Examples:
+
+- VS Code / Cursor extensions may require explicit native install commands.
+- MCP servers may need authentication, secrets, local executables, or runtime config.
+- Plugins and host-specific integrations may need a host CLI, extension provider, or host-side login.
+
+Useful commands:
+
+```bash
+agent-harness install native --host vscode
+agent-harness install native --host vscode --operation verify
+agent-harness install native --host cursor
+agent-harness install native --host cursor --operation verify
+```
+
+Mutating native install or remove actions require `--apply`.
+
+## Decision tree: when recommendations look wrong
+
+Use this before increasing selection breadth or changing policy.
+
+### Step 1: Check demand detection first
+
+Inspect `discover/output/demand-profile.json`.
+
+If the real stack is missing here, fix that first.
+
+Common causes:
+
+- running from the wrong directory
+- manifests excluded by `.gitignore`, `.ignore`, or `.agent-harnessignore`
+- unsupported or weak dependency evidence
+
+### Step 2: Check selection counts second
+
+Inspect `discover/output/selection-report.json`.
+
+- If `selectedCount` is very low, selection filtering may be too strict.
+- If `selectedCount` is already healthy, increasing it is usually the wrong first move.
+
+### Step 3: Check ranking before changing selection
+
+Inspect `state/recommendations.json`.
+
+Use `recommend explain` on both:
+
+- one asset that clearly belongs
+- one asset that looks noisy or off-topic
+
+Example:
+
+```bash
+agent-harness recommend explain --host <host> --asset <asset-id>
+```
+
+If relevant technologies are already detected and selected but weak recommendations still dominate, the problem is usually:
+
+- ranking
+- host policy
+- source weighting
+- overly broad generic signals
+
+### Step 4: Separate recommendation from installation
+
+A recommended asset is not automatically installed.
+
+Check:
+
+- `wire --preview` output
+- native install planning
+- manual runtime prerequisites
+
+A bad outcome can come from correct recommendations plus incomplete runtime setup.
+
+### Step 5: Increase selection count only as a last resort
+
+Do this only when:
+
+- demand detection is correct
+- the selected set genuinely misses relevant candidates
+- source coverage is not the real bottleneck
+
+If the right assets are already present in the selected set, tune ranking or source mix instead of making the pool larger.
+
+## How to classify suggested assets
+
+A good setup review should classify each suggested asset like this:
+
+### Usually handled by the normal lifecycle
+
+- instructions
+- agents
+- skills
+- hooks
+- prompt packs
+- workflows
+
+These are typically staged, activated, and wired by the normal lifecycle for the selected host.
+
+### Usually requires explicit native install
+
+- VS Code extensions
+- Cursor extensions where supported by a compatible CLI/provider
+
+Review first, then use explicit native install commands only after approval.
+
+Examples:
+
+```bash
+agent-harness install native --host vscode --operation install --apply
+agent-harness install native --host cursor --operation install --apply
+```
+
+### Usually requires manual runtime/auth/config follow-up
+
+- MCP servers
+- plugins with external runtime expectations
+- integrations that depend on host login or local executables
+
+These may be staged or referenced correctly while still needing:
+
+- API keys
+- account login
+- executable availability on PATH
+- host-side enablement
+- local config edits outside the harness-managed surface
+
+## Copy-paste prompts for AI agents
+
+### Prompt 1: dry-run operator
+
+```text
+You are setting up agent assets for this workspace with agent-harness.
+
+Workspace root: <workspace-path>
+Host: <vscode|cursor|opencode|zed|claude-code|pi>
+Intent(s): <optional intent list such as frontend, backend, docs>
+
+Use agent-harness as the source of truth and do a dry run first.
+
+Goals:
+1. Inspect host readiness.
+2. Run only non-mutating preview/planning commands first.
+3. Explain what agent-harness detected about this workspace.
+4. Explain which assets are being recommended and why.
+5. Separate staged/wired assets from native/manual installs.
+6. Only suggest apply/install commands after the dry run looks correct.
+
+Required workflow:
+- Run `agent-harness setup doctor --host <host>`.
+- Run the workspace discovery/recommendation flow needed for inspection.
+- Run `agent-harness wire <host> --preview` before any apply.
+- Inspect at least these files when they exist:
+  - `discover/output/demand-profile.json`
+  - `discover/output/selection-report.json`
+  - `state/recommendations.json`
+  - `activate/<host>/wire-preview-<host>.json` or host-equivalent preview output
+- If recommendations look wrong, explain whether the problem is:
+  - demand detection
+  - selection filtering
+  - ranking/policy
+  - source mix
+  - host-native install support
+- For each suggested asset, label it as one of:
+  - already staged/wired by agent-harness
+  - requires explicit native install
+  - requires manual runtime/auth/config follow-up
+- Do not apply changes or install anything unless I explicitly confirm.
+
+When ready, give me:
+- a short diagnosis
+- the exact previewed commands you ran
+- the exact apply/install commands you recommend next
+- any manual steps for extensions, plugins, MCP servers, auth, or host settings
+```
+
+### Prompt 2: approved execution follow-up
+
+```text
+Proceed with the approved agent-harness setup plan for this workspace.
+Use the same workspace root, host, and intents we already reviewed.
+
+Rules:
+- Apply wire changes only after confirming the preview still matches.
+- Use explicit native install commands only for assets that require them.
+- Keep manual/runtime-only steps separate from tool-executed steps.
+- After finishing, summarize:
+  - what was staged
+  - what was wired
+  - what was natively installed
+  - what still needs manual follow-up
+```
+
+## Suggested operator output format
+
+A good agent response after the dry run should usually look like this:
+
+1. **Diagnosis**
+   - what the workspace looks like
+   - whether the issue is detection, selection, ranking, source mix, install support, or manual setup
+2. **Previewed commands**
+   - exact non-mutating commands already run
+3. **Recommended next commands**
+   - exact apply/install commands, clearly marked as mutating
+4. **Manual follow-up**
+   - extensions to review
+   - plugins to enable
+   - MCP auth/config steps
+   - host/runtime prerequisites
+
+## Practical rule of thumb
+
+- **Missing relevant assets entirely** -> investigate detection, source coverage, or selection.
+- **Relevant assets exist but lose to noisy ones** -> investigate ranking, policy, and source weighting.
+- **Assets are recommended but not active in the host** -> inspect wire previews, native install planning, and runtime prerequisites.
+
+## Related commands
+
+```bash
+agent-harness setup doctor --host <host>
+agent-harness discover demand-profile
+agent-harness discover catalog
+agent-harness discover select
+agent-harness discover stats
+agent-harness recommend report
+agent-harness recommend explain --host <host> --asset <asset-id>
+agent-harness wire <host> --preview
+agent-harness wire <host> --apply
+agent-harness install native --host <host>
+agent-harness install native --host <host> --operation verify
+agent-harness install native --host <host> --operation install --apply
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- None yet.
+- added `AGENT-SETUP-PLAYBOOK.md`, a dedicated dry-run setup guide with a troubleshooting decision tree, asset-action classification guidance, and reusable AI-agent prompts for workspace/host/intention-based setup flows
 
 ### Changed
 
-- None yet.
+- README now links the dedicated `AGENT-SETUP-PLAYBOOK.md` guide and documents a preview-first workflow for AI-assisted setup/operator usage
+- README now includes a dry-run troubleshooting decision tree that separates demand detection, selection breadth, ranking/policy, and install/runtime follow-up
 
 ### Fixed
 
-- None yet.
+- documented operator guidance now makes it explicit that increasing selection count should not be the first move when relevant assets already exist in the selected set
 
 ## [1.0.1] - 2026-05-08
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It is built around one generic command surface and a host-adapter model. The lif
 - [Supported hosts](#supported-hosts)
 - [Quick start](#quick-start)
 - [Usage examples](#usage-examples)
+- [Agent setup playbook](./AGENT-SETUP-PLAYBOOK.md)
 - [Command reference](#command-reference)
 - [Host wire-in details](#host-wire-in-details)
 - [Discovery and recommendations](#discovery-and-recommendations)
@@ -81,8 +82,8 @@ Some adapters intentionally reuse another lifecycle host while keeping their own
 | --------------------------- | ---------------------- | ---------------- | ------------------- | --------------------------------------------------- | -------------------------------------------------------------------- |
 | `vscode` / `copilot-vscode` | `copilot`              | `copilot-vscode` | `copilot-vscode`    | `copilot-core`, `community-stable`, `shared-mcp`    | VS Code user settings plus workspace instructions                    |
 | `opencode`                  | `open-code`            | `opencode`       | `opencode`          | `opencode-global`, `community-stable`, `shared-mcp` | project-local `.opencode` overlay and managed links                  |
-| `cursor`                    | —                      | `copilot-vscode` | `cursor`            | `copilot-core`, `community-stable`, `shared-mcp`    | project-local Cursor rules and managed assets                        |
-| `zed`                       | —                      | `opencode`       | `zed`               | `opencode-global`, `community-stable`, `shared-mcp` | project-local `.rules`, `.zed/settings.json`, and managed assets     |
+| `cursor`                    | -                      | `copilot-vscode` | `cursor`            | `copilot-core`, `community-stable`, `shared-mcp`    | project-local Cursor rules and managed assets                        |
+| `zed`                       | -                      | `opencode`       | `zed`               | `opencode-global`, `community-stable`, `shared-mcp` | project-local `.rules`, `.zed/settings.json`, and managed assets     |
 | `claude-code`               | `claude`, `claudecode` | `opencode`       | `claude-code`       | `opencode-global`, `community-stable`, `shared-mcp` | project-local Claude context, rules, skills, and commands            |
 | `pi`                        | `pi-coding-agent`      | `opencode`       | `pi`                | `opencode-global`, `community-stable`               | project-local Pi agent/system context, skills, prompts, and settings |
 
@@ -144,7 +145,7 @@ agent-harness setup doctor --host claude-code
 agent-harness setup doctor --host pi
 ```
 
-`setup doctor` prints each adapter’s lifecycle host, recommendation host, default bundles, runtime executable, advertised capabilities, lifecycle preflight diagnostics, adapter-specific CLI readiness diagnostics, and activated asset prerequisite guidance. Missing optional host CLIs are reported as warnings unless the selected operation requires a writable host-native path or native installer runtime.
+`setup doctor` prints each adapter's lifecycle host, recommendation host, default bundles, runtime executable, advertised capabilities, lifecycle preflight diagnostics, adapter-specific CLI readiness diagnostics, and activated asset prerequisite guidance. Missing optional host CLIs are reported as warnings unless the selected operation requires a writable host-native path or native installer runtime.
 
 ### Run a full workspace pipeline
 
@@ -200,6 +201,20 @@ agent-harness wire claude-code --preview
 ```
 
 Preview output is written under `activate/<host>/` and can be reviewed before `--apply`. Omitting a mode flag is equivalent to `--preview`.
+
+### Use an AI agent as a dry-run setup operator
+
+When you want another agent to operate `agent-harness` for you, start with a dry run before any apply/install step. This keeps workspace mutation, extension installation, and MCP/tool authentication separate from discovery and recommendation review.
+
+For the full playbook, reusable prompts, classification rules, and decision tree, see [`AGENT-SETUP-PLAYBOOK.md`](./AGENT-SETUP-PLAYBOOK.md).
+
+Short version:
+
+- run `agent-harness setup doctor --host <host>` first
+- inspect workspace evidence such as `discover/output/demand-profile.json`, `discover/output/selection-report.json`, and `state/recommendations.json`
+- run `agent-harness wire <host> --preview` before any apply
+- separate staged/wired assets from native installs and manual runtime follow-up
+- only run mutating install/apply commands after the dry run looks correct
 
 ### Apply and reset one host
 
@@ -1057,7 +1072,30 @@ agent-harness discover stats
 agent-harness recommend report
 ```
 
+Use this dry-run decision tree before changing policy or applying installs:
+
+1. **Check demand detection first.** Inspect `discover/output/demand-profile.json`.
+   - If the workspace stack is missing there, fix detection scope first.
+   - Common causes: running from the wrong directory, manifests hidden by `.gitignore`, `.ignore`, or `.agent-harnessignore`, or unsupported dependency evidence.
+2. **Check selection counts second.** Inspect `discover/output/selection-report.json`.
+   - If `selectedCount` is extremely low, then selection filtering may be too strict for that workspace.
+   - If `selectedCount` is already healthy, increasing selection count is usually the wrong first move.
+3. **Check ranking before changing selection.** Inspect `state/recommendations.json` and use `recommend explain` on both a relevant asset and an off-topic asset.
+   - If relevant technologies are present in demand/selection but weak recommendations still dominate, the problem is usually ranking, host policy, or source weighting.
+   - Example: a workspace can correctly detect `apify` and `duckdb`, yet still surface broad official assets if generic documentation/integration signals are overweighted.
+4. **Separate recommendation from installation.** Review `wire --preview` output and native install planning.
+   - A recommended asset is not automatically installed.
+   - Extension installation, MCP auth, runtime executables, and host logins may still need explicit approval or manual follow-up.
+5. **Only increase selection count as a last resort.** Do it when the workspace truly lacks enough relevant candidates after demand detection is correct.
+   - If the right assets are already in the selected set, tune policy or source mix instead of making the candidate pool larger.
+
 `discover select` should reject entries that do not overlap with detected workspace signals. If relevant entries are missing, inspect `discover/output/demand-profile.json` and confirm the workspace manifests are not excluded by `.gitignore`, `.ignore`, or `.agent-harnessignore`.
+
+A practical rule of thumb:
+
+- **Missing relevant assets entirely** → investigate detection, source coverage, or selection.
+- **Relevant assets exist but lose to noisy ones** → investigate ranking, policy, and source weighting.
+- **Assets are recommended but not active in the host** → inspect wire previews, native install planning, and manual runtime prerequisites.
 
 ### GitHub discovery or mirror acquisition is slow or rate-limited
 
@@ -1095,6 +1133,10 @@ Yes. Add a new implementation under `src/host-adapters/`, register it in `src/ho
 
 No. VS Code extension assets can produce metadata and install guidance, but the harness does not silently install marketplace extensions.
 
+### Should I increase selection count when recommendations look wrong?
+
+Usually no. First confirm that demand detection found the real workspace technologies, then inspect whether relevant assets already exist in the selected set. If they do, the problem is more likely ranking, host policy, or source weighting than selection breadth. Increase selection count only when the current selection genuinely omits relevant candidates.
+
 ### Why do Cursor, Zed, Claude Code, and Pi reuse lifecycle hosts?
 
 They can reuse compatible install and activation package layouts while keeping independent recommendation policies and native project-local wire behavior.
@@ -1127,12 +1169,12 @@ Known boundaries:
 
 ## Related documentation
 
-- `CHANGELOG.md` — release notes
-- `SECURITY.md` — vulnerability reporting and supported-version policy
-- `Roadmap.md` — gap analysis and long-range direction
-- `IMPLEMENTATION-PLAN.md` — milestone-oriented execution plan
-- `FUTURE-IMPROVEMENTS.md` — follow-up ideas and architectural extensions
-- `CONTRIBUTING.md` — contribution workflow and hygiene
+- `CHANGELOG.md` - release notes
+- `AGENT-SETUP-PLAYBOOK.md` - dry-run setup workflow, decision tree, and reusable agent prompts for workspace/host asset setup
+- `Roadmap.md` - gap analysis and long-range direction
+- `IMPLEMENTATION-PLAN.md` - milestone-oriented execution plan
+- `FUTURE-IMPROVEMENTS.md` - follow-up ideas and architectural extensions
+- `CONTRIBUTING.md` - contribution workflow and hygiene
 
 ## Sponsor
 


### PR DESCRIPTION
## Summary
- add a dedicated Agent Setup Playbook for dry-run-first AI-assisted setup flows
- document the preview-first troubleshooting decision tree in the README
- record the docs changes under Unreleased in the changelog
 
## Validation\n- npm run validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup playbook with dry-run workflow guidance and troubleshooting decision tree
  * Enhanced README with expanded host compatibility details and improved usage examples
  * Introduced AI agent integration workflow section with structured guidance and reusable prompts
  * Expanded dry-run troubleshooting with step-by-step decision steps for recommendation evaluation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->