### PR TITLE
Prepare v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- None yet.
+
+### Changed
+
+- None yet.
+
+### Fixed
+
+- None yet.
+
+## [1.0.2] - 2026-05-08
+
+### Added
+
 - added `AGENT-SETUP-PLAYBOOK.md`, a dedicated dry-run setup guide with a troubleshooting decision tree, asset-action classification guidance, and reusable AI-agent prompts for workspace/host/intention-based setup flows
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ar27111994/agent-harness",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node.js TypeScript CLI for discovering, staging, activating, and wiring reusable AI-agent assets across supported developer hosts.",
   "license": "MIT",
   "author": "ar27111994",


### PR DESCRIPTION
## Summary
- bump package version to 1.0.2
- cut the merged documentation updates into a v1.0.2 changelog entry

## Validation
- npm run validate:release