### PR TITLE
feat: add confidence-weighted demand evidence

### DIFF
--- a/src/domains/discovery/demand-profile.ts
+++ b/src/domains/discovery/demand-profile.ts
@@ -8,6 +8,7 @@ import {
 import type { DemandEvidence, DemandProfile } from "../../types.js";
 import {
   collectDemandSignalsForFile,
+  getDemandEvidenceStrength,
   shouldInspectFile,
 } from "./demand-signals.js";
 import {
@@ -35,6 +36,11 @@ export async function buildDemandProfile(
       continue;
     }
 
+    const evidenceStrength = getDemandEvidenceStrength(fileName, filePath);
+    if (evidenceStrength === null) {
+      continue;
+    }
+
     const matchedSignals = await collectDemandSignalsForFile(
       fileName,
       filePath,
@@ -48,6 +54,7 @@ export async function buildDemandProfile(
     evidence.push({
       path: toRelativePosixPath(scanRoot, filePath),
       fileName,
+      evidenceStrength,
       matchedSignals,
     });
   }

--- a/src/domains/discovery/demand-signals.ts
+++ b/src/domains/discovery/demand-signals.ts
@@ -1,5 +1,5 @@
 import { readTextFileOrNull } from "../../files.js";
-import type { DemandSignalSet } from "../../types.js";
+import type { DemandEvidenceStrength, DemandSignalSet } from "../../types.js";
 import {
   collectDetectorSignals,
   isDetectorInspectableFile,
@@ -38,6 +38,13 @@ const YAML_DEPENDENCY_SECTION_NAMES = new Set([
 ]);
 
 const ACTOR_JSON_PATH_PATTERN = /[\\/]\.actor[\\/]actor\.json$/iu;
+const IGNORED_DEMAND_EVIDENCE_PATTERNS = [
+  /(^|[/\\])\.github[/\\]ISSUE_TEMPLATE([/\\]|$)/iu,
+  /(^|[/\\])pull_request_template\.(md|txt)$/iu,
+  /(^|[/\\])(?:changelog|contributing)\.(md|mdx|txt)$/iu,
+  /(^|[/\\])(?:roadmap|implementation-plan|future-improvements)\.(md|mdx|txt)$/iu,
+];
+const WEAK_DEMAND_TEXT_FILE_PATTERN = /\.(md|mdx|rst|adoc|txt)$/iu;
 const LOGGING_TEXT_MARKERS = ["logger", "logging", "debugger", "debug"];
 const MOCKING_TEXT_MARKERS = ["mock", "mocking"];
 const REPLAY_TEXT_MARKERS = ["replay", "forwarding", "forwarder"];
@@ -92,6 +99,10 @@ const INSPECTABLE_FILE_NAMES = new Set([
  * Provides should inspect file for the lifecycle pipeline.
  */
 export function shouldInspectFile(fileName: string, filePath: string): boolean {
+  if (getDemandEvidenceStrength(fileName, filePath) === null) {
+    return false;
+  }
+
   if (isActorJsonFile(fileName, filePath) || fileName === "input_schema.json") {
     return true;
   }
@@ -143,7 +154,12 @@ export async function collectDemandSignalsForFile(
   fileName: string,
   filePath: string,
 ): Promise<DemandSignalSet> {
+  const evidenceStrength = getDemandEvidenceStrength(fileName, filePath);
   const matchedSignals = collectStaticSignals(fileName, filePath);
+
+  if (evidenceStrength === null) {
+    return matchedSignals;
+  }
 
   collectDetectorSignals(fileName, filePath, matchedSignals);
 
@@ -173,7 +189,10 @@ export async function collectDemandSignalsForFile(
     enrichActorJsonSignals(fileContent, matchedSignals);
   }
 
-  if (shouldReadTextForTechnologySignals(fileName)) {
+  if (
+    evidenceStrength !== "weak" &&
+    shouldReadTextForTechnologySignals(fileName)
+  ) {
     enrichGenericTextSignals(
       getTechnologySignalTextContent(fileName, fileContent),
       matchedSignals,
@@ -190,6 +209,55 @@ export function isActorJsonFile(fileName: string, filePath: string): boolean {
   return (
     /^actor\.json$/iu.test(fileName) || ACTOR_JSON_PATH_PATTERN.test(filePath)
   );
+}
+
+/**
+ * Classifies demand evidence strength for the lifecycle pipeline.
+ */
+export function getDemandEvidenceStrength(
+  fileName: string,
+  filePath: string,
+): DemandEvidenceStrength | null {
+  const normalizedPath = filePath.replace(/\\/gu, "/");
+
+  if (
+    IGNORED_DEMAND_EVIDENCE_PATTERNS.some((pattern) =>
+      pattern.test(normalizedPath),
+    )
+  ) {
+    return null;
+  }
+
+  if (
+    isActorJsonFile(fileName, filePath) ||
+    fileName === "input_schema.json" ||
+    isRequirementsFile(fileName, filePath) ||
+    isLockfileName(fileName) ||
+    isLanguageSourceFile(fileName) ||
+    isNugetManifestFile(fileName) ||
+    fileName.endsWith(".sln") ||
+    fileName.endsWith(".tf") ||
+    fileName.endsWith(".tfvars") ||
+    isDockerfileName(fileName) ||
+    isComposeFileName(fileName) ||
+    fileName.startsWith("playwright.config.") ||
+    fileName.startsWith("vitest.config.") ||
+    fileName.startsWith("jest.config.") ||
+    /openapi|swagger/iu.test(fileName) ||
+    INSPECTABLE_FILE_NAMES.has(fileName)
+  ) {
+    return "strong";
+  }
+
+  if (WEAK_DEMAND_TEXT_FILE_PATTERN.test(fileName)) {
+    return "weak";
+  }
+
+  if (isDetectorInspectableFile(fileName, filePath)) {
+    return "medium";
+  }
+
+  return null;
 }
 
 function isRequirementsFile(fileName: string, filePath: string): boolean {

--- a/src/manifest-validation/discovery.ts
+++ b/src/manifest-validation/discovery.ts
@@ -154,6 +154,12 @@ export function assertDemandProfile(
         entryRecord.fileName,
         `${context}.evidence[${index}].fileName`,
       );
+      if (entryRecord.evidenceStrength !== undefined) {
+        assertString(
+          entryRecord.evidenceStrength,
+          `${context}.evidence[${index}].evidenceStrength`,
+        );
+      }
       assertDemandSignalSet(
         entryRecord.matchedSignals,
         `${context}.evidence[${index}].matchedSignals`,

--- a/src/manifest-validation/discovery.ts
+++ b/src/manifest-validation/discovery.ts
@@ -29,6 +29,8 @@ import {
   SOURCE_KINDS,
 } from "./primitives.js";
 
+const DEMAND_EVIDENCE_STRENGTHS = ["strong", "medium", "weak"] as const;
+
 /**
  * Validates unknown data as source registry.
  */
@@ -155,8 +157,9 @@ export function assertDemandProfile(
         `${context}.evidence[${index}].fileName`,
       );
       if (entryRecord.evidenceStrength !== undefined) {
-        assertString(
+        assertLiteral(
           entryRecord.evidenceStrength,
+          DEMAND_EVIDENCE_STRENGTHS,
           `${context}.evidence[${index}].evidenceStrength`,
         );
       }

--- a/src/recommend/commands.ts
+++ b/src/recommend/commands.ts
@@ -315,10 +315,18 @@ function formatMatchedSignals(matches: RecommendationSignalMatch[]): string {
   }
 
   return matches
-    .map(
-      (match) =>
-        `${match.signalType}:${match.term}(w=${match.weight},e=${match.evidenceCount})`,
-    )
+    .map((match) => {
+      const evidenceCounts = match.evidenceStrengthCounts;
+      const evidenceSummary = evidenceCounts
+        ? `,s=${evidenceCounts.strong}/m=${evidenceCounts.medium}/w=${evidenceCounts.weak}`
+        : "";
+      const weightedEvidenceSummary =
+        match.weightedEvidenceCount === undefined
+          ? ""
+          : `,ew=${match.weightedEvidenceCount}`;
+
+      return `${match.signalType}:${match.term}(w=${match.weight},e=${match.evidenceCount}${weightedEvidenceSummary}${evidenceSummary})`;
+    })
     .join(", ");
 }
 

--- a/src/recommend/model.ts
+++ b/src/recommend/model.ts
@@ -1,5 +1,6 @@
 import type {
   AssetCatalogEntry,
+  DemandEvidenceStrength,
   RecommendationScoreBreakdown,
   RecommendationSignalMatch,
   RecommendationSignalType,
@@ -14,6 +15,7 @@ export interface DemandTermContext {
   canonicalTerm: string;
   signalType: RecommendationSignalType;
   evidenceCount: number;
+  evidenceStrengthCounts: Record<DemandEvidenceStrength, number>;
   matchTerms: Set<string>;
 }
 

--- a/src/recommend/signals.ts
+++ b/src/recommend/signals.ts
@@ -114,6 +114,9 @@ export function buildDemandContext(
   };
 }
 
+/**
+ * Creates an empty evidence-strength histogram for one demand term.
+ */
 function createEmptyEvidenceStrengthCounts(
   initialStrength?: DemandEvidenceStrength,
 ): Record<DemandEvidenceStrength, number> {
@@ -124,6 +127,9 @@ function createEmptyEvidenceStrengthCounts(
   };
 }
 
+/**
+ * Collapses evidence-strength counts into a capped weighting bucket.
+ */
 function computeWeightedEvidenceCount(
   evidenceStrengthCounts: Record<DemandEvidenceStrength, number>,
 ): number {

--- a/src/recommend/signals.ts
+++ b/src/recommend/signals.ts
@@ -1,6 +1,7 @@
 import type {
   AssetContextCost,
   AssetKind,
+  DemandEvidenceStrength,
   DemandProfile,
   RecommendationPolicy,
   RecommendationSignalMatch,
@@ -19,9 +20,12 @@ export function collectMatchedSignals(
   return demandContext.terms
     .filter((term) => intersects(searchTerms, term.matchTerms))
     .map((term) => {
+      const weightedEvidenceCount = computeWeightedEvidenceCount(
+        term.evidenceStrengthCounts,
+      );
       const baseWeight =
         policy.scoring.demandSignalWeights[term.signalType] *
-        Math.min(3, term.evidenceCount);
+        weightedEvidenceCount;
       const termMultiplier =
         policy.scoring.demandTermMultipliers[term.canonicalTerm] ?? 1;
 
@@ -30,6 +34,8 @@ export function collectMatchedSignals(
         signalType: term.signalType,
         weight: Math.max(1, Math.round(baseWeight * termMultiplier)),
         evidenceCount: term.evidenceCount,
+        weightedEvidenceCount,
+        evidenceStrengthCounts: { ...term.evidenceStrengthCounts },
       };
     })
     .sort(
@@ -58,7 +64,7 @@ export function buildDemandContext(
   const registerTerm = (
     signalType: RecommendationSignalType,
     rawTerm: string,
-    evidenceIncrement: number,
+    evidenceStrength: DemandEvidenceStrength,
   ): void => {
     const canonicalTerm = canonicalizePhrase(rawTerm, policy);
     const key = `${signalType}:${canonicalTerm}`;
@@ -66,7 +72,8 @@ export function buildDemandContext(
     const existing = demandTermMap.get(key);
 
     if (existing) {
-      existing.evidenceCount += evidenceIncrement;
+      existing.evidenceCount += 1;
+      existing.evidenceStrengthCounts[evidenceStrength] += 1;
       for (const matchTerm of matchTerms) {
         existing.matchTerms.add(matchTerm);
       }
@@ -77,21 +84,21 @@ export function buildDemandContext(
       key,
       canonicalTerm,
       signalType,
-      evidenceCount: evidenceIncrement,
+      evidenceCount: 1,
+      evidenceStrengthCounts:
+        createEmptyEvidenceStrengthCounts(evidenceStrength),
       matchTerms,
     });
   };
 
-  for (const signalType of recommendationSignalTypes()) {
-    for (const rawTerm of demandProfile.signals[signalType]) {
-      registerTerm(signalType, rawTerm, 1);
-    }
-  }
-
   for (const evidence of demandProfile.evidence) {
     for (const signalType of recommendationSignalTypes()) {
       for (const rawTerm of evidence.matchedSignals[signalType]) {
-        registerTerm(signalType, rawTerm, 1);
+        registerTerm(
+          signalType,
+          rawTerm,
+          evidence.evidenceStrength ?? "medium",
+        );
       }
     }
   }
@@ -105,6 +112,34 @@ export function buildDemandContext(
     hasSignals: demandTermMap.size > 0,
     activeDomainGroups: buildActiveDomainGroups(terms, policy),
   };
+}
+
+function createEmptyEvidenceStrengthCounts(
+  initialStrength?: DemandEvidenceStrength,
+): Record<DemandEvidenceStrength, number> {
+  return {
+    strong: initialStrength === "strong" ? 1 : 0,
+    medium: initialStrength === "medium" ? 1 : 0,
+    weak: initialStrength === "weak" ? 1 : 0,
+  };
+}
+
+function computeWeightedEvidenceCount(
+  evidenceStrengthCounts: Record<DemandEvidenceStrength, number>,
+): number {
+  if (evidenceStrengthCounts.strong > 0) {
+    return 3;
+  }
+
+  if (evidenceStrengthCounts.medium > 0) {
+    return Math.min(3, 1 + evidenceStrengthCounts.medium);
+  }
+
+  if (evidenceStrengthCounts.weak > 0) {
+    return 1;
+  }
+
+  return 0;
 }
 
 function buildActiveDomainGroups(

--- a/src/tests/demand-profile.test.ts
+++ b/src/tests/demand-profile.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { shouldInspectFile } from "../domains/discovery/demand-signals.js";
+import {
+  getDemandEvidenceStrength,
+  shouldInspectFile,
+} from "../domains/discovery/demand-signals.js";
 import { buildDemandProfile } from "../discover.js";
 import type { DemandSignalSet } from "../types.js";
 
@@ -25,6 +28,29 @@ void test("mobile project marker files are inspectable", () => {
   ]) {
     assert.equal(shouldInspectFile(fileName, `mobile/${fileName}`), true);
   }
+});
+
+void test("demand evidence strength ignores planning templates and demotes markdown docs", () => {
+  assert.equal(
+    getDemandEvidenceStrength(
+      "feature_request.md",
+      ".github/ISSUE_TEMPLATE/feature_request.md",
+    ),
+    null,
+  );
+  assert.equal(getDemandEvidenceStrength("CHANGELOG.md", "CHANGELOG.md"), null);
+  assert.equal(
+    getDemandEvidenceStrength("README.md", "docs/README.md"),
+    "weak",
+  );
+  assert.equal(
+    getDemandEvidenceStrength("package.json", "package.json"),
+    "strong",
+  );
+  assert.equal(
+    getDemandEvidenceStrength("analysis.ipynb", "notebooks/analysis.ipynb"),
+    "medium",
+  );
 });
 
 const repoFixtures: DemandProfileRepoFixture[] = [
@@ -656,6 +682,68 @@ void test("demand profiles produce meaningful signals for representative repo ar
     } finally {
       await rm(root, { force: true, recursive: true });
     }
+  }
+});
+
+void test("demand profiles ignore planning templates and keep evidence strength visible", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agent-harness-demand-wave-"));
+
+  try {
+    await writeFixtureFiles(root, [
+      {
+        path: "package.json",
+        content: JSON.stringify({
+          dependencies: {
+            apify: "latest",
+            express: "latest",
+          },
+        }),
+      },
+      {
+        path: "README.md",
+        content:
+          "# Workspace\nThis README mentions robotics, pentesting, and game development but should stay weak.\n",
+      },
+      {
+        path: ".github/ISSUE_TEMPLATE/feature_request.md",
+        content:
+          "Please add marketing, robotics, and lead-generation workflows everywhere.\n",
+      },
+      {
+        path: "IMPLEMENTATION-PLAN.md",
+        content:
+          "Future ideas: blockchain, content-creation, realtime-media, and SEO.\n",
+      },
+    ]);
+
+    const profile = await buildDemandProfile(root);
+
+    assert.ok(profile.signals.frameworks.includes("apify"));
+    assert.ok(profile.signals.concerns.includes("automation"));
+    assert.ok(!profile.signals.concerns.includes("robotics"));
+    assert.ok(!profile.signals.concerns.includes("marketing"));
+    assert.ok(
+      !profile.evidence.some((entry) =>
+        entry.path.includes(".github/ISSUE_TEMPLATE/feature_request.md"),
+      ),
+    );
+    assert.ok(
+      !profile.evidence.some((entry) =>
+        entry.path.includes("IMPLEMENTATION-PLAN.md"),
+      ),
+    );
+    assert.equal(
+      profile.evidence.find((entry) => entry.path === "README.md")
+        ?.evidenceStrength,
+      "weak",
+    );
+    assert.equal(
+      profile.evidence.find((entry) => entry.path === "package.json")
+        ?.evidenceStrength,
+      "strong",
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
   }
 });
 

--- a/src/tests/recommend-signals.test.ts
+++ b/src/tests/recommend-signals.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildDemandContext,
+  collectMatchedSignals,
+} from "../recommend/signals.js";
+import type {
+  DemandProfile,
+  RecommendationHostPolicy,
+  RecommendationPolicy,
+} from "../types.js";
+
+void test("recommend signal weighting prefers strong evidence over repeated weak docs", () => {
+  const profile: DemandProfile = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "C:/fixture",
+    summary: {
+      scannedFiles: 3,
+      matchedFiles: 3,
+    },
+    signals: {
+      languages: [],
+      packageManagers: ["npm"],
+      frameworks: ["apify"],
+      concerns: ["integration"],
+      tooling: [],
+    },
+    evidence: [
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: [],
+          packageManagers: ["npm"],
+          frameworks: ["apify"],
+          concerns: [],
+          tooling: [],
+        },
+      },
+      {
+        path: "README.md",
+        fileName: "README.md",
+        evidenceStrength: "weak",
+        matchedSignals: {
+          languages: [],
+          packageManagers: [],
+          frameworks: [],
+          concerns: ["integration"],
+          tooling: [],
+        },
+      },
+      {
+        path: "docs/setup.md",
+        fileName: "setup.md",
+        evidenceStrength: "weak",
+        matchedSignals: {
+          languages: [],
+          packageManagers: [],
+          frameworks: [],
+          concerns: ["integration"],
+          tooling: [],
+        },
+      },
+    ],
+  };
+
+  const policy = buildPolicy();
+  const demandContext = buildDemandContext(profile, policy);
+  const matches = collectMatchedSignals(
+    new Set(["apify", "integration"]),
+    demandContext,
+    policy,
+  );
+
+  const apifyMatch = matches.find((match) => match.term === "apify");
+  const integrationMatch = matches.find(
+    (match) => match.term === "integration",
+  );
+
+  assert.ok(apifyMatch);
+  assert.ok(integrationMatch);
+  assert.equal(apifyMatch.weightedEvidenceCount, 3);
+  assert.deepEqual(apifyMatch.evidenceStrengthCounts, {
+    strong: 1,
+    medium: 0,
+    weak: 0,
+  });
+  assert.equal(integrationMatch.evidenceCount, 2);
+  assert.equal(integrationMatch.weightedEvidenceCount, 1);
+  assert.deepEqual(integrationMatch.evidenceStrengthCounts, {
+    strong: 0,
+    medium: 0,
+    weak: 2,
+  });
+  assert.ok(apifyMatch.weight > integrationMatch.weight);
+});
+
+function buildPolicy(): RecommendationPolicy {
+  const hostPolicy: RecommendationHostPolicy = {
+    recommendationLimit: 20,
+    activationBudget: 20,
+    suggestedBundleId: "test-bundle",
+    fallbackSkillCount: 5,
+    maxPerSourceFamily: 10,
+    maxPerDuplicateGroup: 10,
+    maxPerAssetKind: {},
+    targetAssetKinds: [],
+    targetConcerns: [],
+    suppressedAssetIdPatterns: [],
+    suppressedCapabilityTerms: [],
+    deprioritizedAssetIdPatterns: [],
+    deprioritizedCapabilityTerms: [],
+    sourceSaturationFreeCount: 10,
+    sourceSaturationPenaltyStep: 1,
+  };
+
+  return {
+    schemaVersion: 1,
+    scoring: {
+      demandMatchCap: 20,
+      portfolioFitMultiplier: 10,
+      trustDivisor: 10,
+      sourcePriorityDivisor: 10,
+      authorityWeights: {
+        "official-first-party": 100,
+        "official-marketplace": 80,
+        "official-compatible": 70,
+        "trusted-local": 60,
+        "trusted-community": 40,
+        "unverified-community": 10,
+      },
+      compatibilityWeights: {
+        native: 30,
+        adaptable: 20,
+        partial: 10,
+        "reference-only": 5,
+        incompatible: -100,
+      },
+      costPenalties: { tiny: 0, small: 1, medium: 2, large: 4 },
+      demandSignalWeights: {
+        languages: 1,
+        packageManagers: 1,
+        frameworks: 1,
+        concerns: 1,
+        tooling: 1,
+      },
+      riskLevelPenalties: {
+        low: 0,
+        medium: 1,
+        high: 2,
+      },
+      riskFlagPenalties: {
+        hasHooks: 1,
+        hasExecScripts: 1,
+        requiresNetwork: 1,
+      },
+      freshness: {
+        recentDays: 30,
+        recentBoost: 0,
+        staleDays: 365,
+        stalePenalty: 0,
+        unknownPenalty: 0,
+      },
+      genericCapabilityPenalty: 0,
+      lowFitPenaltyThreshold: 0.25,
+      lowFitPenalty: 5,
+      weakDemandPenalty: 5,
+      outOfDomainGroupPenalty: 5,
+      coverageGainWeight: 0,
+      sourceDiversityBonus: 0,
+      overlapPenalty: 0,
+      demandTermMultipliers: {},
+    },
+    hosts: {
+      "copilot-vscode": hostPolicy,
+      opencode: hostPolicy,
+      shared: hostPolicy,
+      cursor: hostPolicy,
+      zed: hostPolicy,
+      "claude-code": hostPolicy,
+      pi: hostPolicy,
+    },
+    concernKeywordMap: {},
+    taskModeKeywordMap: {},
+    domainKeywordGroups: {},
+    synonyms: {},
+  };
+}

--- a/src/types/discovery.ts
+++ b/src/types/discovery.ts
@@ -95,11 +95,17 @@ export interface DemandSignalSet {
 }
 
 /**
+ * Describes demand evidence strength shared by the lifecycle pipeline.
+ */
+export type DemandEvidenceStrength = "strong" | "medium" | "weak";
+
+/**
  * Describes demand evidence data exchanged by the lifecycle pipeline.
  */
 export interface DemandEvidence {
   path: string;
   fileName: string;
+  evidenceStrength?: DemandEvidenceStrength;
   matchedSignals: DemandSignalSet;
 }
 

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -9,7 +9,11 @@ import type {
   CompatibilityMode,
   HostTarget,
 } from "./core.js";
-import type { DemandProfile, DemandSignalSet } from "./discovery.js";
+import type {
+  DemandEvidenceStrength,
+  DemandProfile,
+  DemandSignalSet,
+} from "./discovery.js";
 
 /**
  * Defines the supported recommendation signal type values.
@@ -153,6 +157,8 @@ export interface RecommendationSignalMatch {
   signalType: RecommendationSignalType;
   weight: number;
   evidenceCount: number;
+  weightedEvidenceCount?: number;
+  evidenceStrengthCounts?: Record<DemandEvidenceStrength, number>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add demand-evidence strength tiers so demand-profile output distinguishes strong, medium, and weak evidence
- ignore issue templates and planning/changelog-style markdown in normal demand profiling
- stop repeated weak markdown evidence from being weighted like strong stack evidence in recommendation matching
- expose weighted evidence details in recommendation explain output and add regression coverage

Closes #131
Closes #132

## Validation
- npm run typecheck
- npm run lint
- npm run format:check
- npm run build
- node --test dist/tests/demand-profile.test.js dist/tests/recommend-signals.test.js
- npm test
- npm run quality:detection
- npm run quality:policy