### PR TITLE
feat: tighten recommendation stack-fit ranking

### DIFF
--- a/src/recommend/candidates.ts
+++ b/src/recommend/candidates.ts
@@ -7,6 +7,7 @@ import {
   collectMatchedSignals,
   computeOutOfDomainPenalty,
   normalizePhrase,
+  shouldEnforceConcernTarget,
 } from "./signals.js";
 import type {
   AssetCatalogEntry,
@@ -61,6 +62,12 @@ export function buildCandidateRecommendation(
   demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): CandidateRecommendation | null {
+  const capabilitySearchTerms = buildSearchTerms(
+    [entry.id, entry.displayName, ...entry.capabilities],
+    policy,
+  );
+  const genericToolingTerms = buildGenericToolingTerms(policy);
+  const wrapperLikeTerms = buildSearchTerms([...WRAPPER_LIKE_TERMS], policy);
   const searchTerms = buildSearchTerms(
     [
       entry.id,
@@ -83,7 +90,12 @@ export function buildCandidateRecommendation(
     demandContext,
     policy,
   );
-  const matchQuality = analyzeMatchQuality(matchedSignals, searchTerms, policy);
+  const matchQuality = analyzeMatchQuality(
+    matchedSignals,
+    capabilitySearchTerms,
+    wrapperLikeTerms,
+    genericToolingTerms,
+  );
   const coverageTags = buildCoverageTags(searchTerms, matchedSignals, policy);
   const taskModes = buildTaskModes(
     searchTerms,
@@ -178,10 +190,14 @@ export function buildCandidateRecommendation(
 
 function analyzeMatchQuality(
   matchedSignals: RecommendationSignalMatch[],
-  searchTerms: Set<string>,
-  policy: RecommendationPolicy,
+  capabilitySearchTerms: Set<string>,
+  wrapperLikeTerms: Set<string>,
+  genericToolingTerms: Set<string>,
 ): MatchQuality {
-  const exactnessEligible = !isWrapperLikeAsset(searchTerms);
+  const exactnessEligible = !isWrapperLikeAsset(
+    capabilitySearchTerms,
+    wrapperLikeTerms,
+  );
   let exactStackWeight = 0;
   let ecosystemWeight = 0;
   let genericConcernWeight = 0;
@@ -198,7 +214,7 @@ function analyzeMatchQuality(
 
       if (
         match.signalType === "tooling" &&
-        isSpecificToolingSignal(match.term, policy)
+        isSpecificToolingSignal(match.term, genericToolingTerms)
       ) {
         exactStackWeight += match.weight;
         continue;
@@ -226,9 +242,12 @@ function analyzeMatchQuality(
   };
 }
 
-function isWrapperLikeAsset(searchTerms: Set<string>): boolean {
-  for (const term of searchTerms) {
-    if (WRAPPER_LIKE_TERMS.has(term)) {
+function isWrapperLikeAsset(
+  capabilitySearchTerms: Set<string>,
+  wrapperLikeTerms: Set<string>,
+): boolean {
+  for (const term of capabilitySearchTerms) {
+    if (wrapperLikeTerms.has(term)) {
       return true;
     }
   }
@@ -236,28 +255,23 @@ function isWrapperLikeAsset(searchTerms: Set<string>): boolean {
   return false;
 }
 
-function isSpecificToolingSignal(
-  term: string,
-  policy: RecommendationPolicy,
-): boolean {
-  const normalizedTerm = normalizePhrase(term);
-  if (GENERIC_CAPABILITY_TERMS.has(normalizedTerm)) {
-    return false;
-  }
+function buildGenericToolingTerms(policy: RecommendationPolicy): Set<string> {
+  const genericToolingTerms = new Set<string>(GENERIC_CAPABILITY_TERMS);
 
   for (const [concern, keywords] of Object.entries(policy.concernKeywordMap)) {
-    if (normalizePhrase(concern) === normalizedTerm) {
-      return false;
-    }
-
-    if (
-      keywords.some((keyword) => normalizePhrase(keyword) === normalizedTerm)
-    ) {
-      return false;
+    for (const term of buildSearchTerms([concern, ...keywords], policy)) {
+      genericToolingTerms.add(term);
     }
   }
 
-  return true;
+  return genericToolingTerms;
+}
+
+function isSpecificToolingSignal(
+  term: string,
+  genericToolingTerms: Set<string>,
+): boolean {
+  return !genericToolingTerms.has(normalizePhrase(term));
 }
 
 function computePortfolioFitBonus(matchQuality: MatchQuality): number {
@@ -281,19 +295,6 @@ function computeDemandExactnessBonus(matchQuality: MatchQuality): number {
   }
 
   return 0;
-}
-
-function shouldEnforceConcernTarget(
-  concern: string,
-  demandContext: DemandContext,
-): boolean {
-  return demandContext.terms.some(
-    (term) =>
-      term.signalType === "concerns" &&
-      term.canonicalTerm === concern &&
-      (term.evidenceStrengthCounts.strong > 0 ||
-        term.evidenceStrengthCounts.medium > 0),
-  );
 }
 
 function computeHostDeprioritizationPenalty(
@@ -343,7 +344,7 @@ function computeHostPreference(
   for (const target of hostPolicy.targetConcerns) {
     if (
       coverageTags.includes(target.concern) &&
-      shouldEnforceConcernTarget(target.concern, demandContext)
+      shouldEnforceConcernTarget(target.concern, demandContext, policy)
     ) {
       score += Math.max(1, Math.round(target.weight / 2));
     }

--- a/src/recommend/candidates.ts
+++ b/src/recommend/candidates.ts
@@ -17,6 +17,25 @@ import type {
 import type { RecommendationHost } from "./hosts.js";
 import type { CandidateRecommendation, DemandContext } from "./model.js";
 
+const WRAPPER_LIKE_TERMS = new Set([
+  "config",
+  "docs",
+  "json",
+  "knowledge",
+  "reference",
+  "scenario",
+  "wrapper",
+  "yaml",
+  "yml",
+]);
+
+interface MatchQuality {
+  exactStackWeight: number;
+  ecosystemWeight: number;
+  genericConcernWeight: number;
+  hasOnlyGenericConcernMatch: boolean;
+}
+
 /**
  * Provides compute entry preselection score for the lifecycle pipeline.
  */
@@ -64,6 +83,7 @@ export function buildCandidateRecommendation(
     demandContext,
     policy,
   );
+  const matchQuality = analyzeMatchQuality(matchedSignals, searchTerms, policy);
   const coverageTags = buildCoverageTags(searchTerms, matchedSignals, policy);
   const taskModes = buildTaskModes(
     searchTerms,
@@ -88,19 +108,27 @@ export function buildCandidateRecommendation(
   const breakdown: RecommendationScoreBreakdown = {
     authority: policy.scoring.authorityWeights[entry.source.authorityTier],
     compatibility: policy.scoring.compatibilityWeights[entry.compatibilityMode],
-    portfolioFit: Math.round(
-      (entry.fit.portfolioFit * 0.7 + entry.fit.hostFit * 0.3) *
-        policy.scoring.portfolioFitMultiplier,
-    ),
+    portfolioFit:
+      Math.round(
+        (entry.fit.portfolioFit * 0.7 + entry.fit.hostFit * 0.3) *
+          policy.scoring.portfolioFitMultiplier,
+      ) + computePortfolioFitBonus(matchQuality),
     trust: Math.round(entry.trust.score / policy.scoring.trustDivisor),
     sourcePriority: Math.round(
       entry.source.sourcePriority / policy.scoring.sourcePriorityDivisor,
     ),
     demand: Math.min(
       policy.scoring.demandMatchCap,
-      matchedSignals.reduce((total, match) => total + match.weight, 0),
+      matchedSignals.reduce((total, match) => total + match.weight, 0) +
+        computeDemandExactnessBonus(matchQuality),
     ),
-    hostPreference: computeHostPreference(entry, host, coverageTags, policy),
+    hostPreference: computeHostPreference(
+      entry,
+      host,
+      coverageTags,
+      demandContext,
+      policy,
+    ),
     coverage: 0,
     diversity: 0,
     freshness: computeFreshnessScore(entry, policy),
@@ -119,6 +147,7 @@ export function buildCandidateRecommendation(
         entry,
         searchTerms,
         matchedSignals,
+        matchQuality,
         demandContext,
         policy,
       ) + hostDeprioritizationPenalty,
@@ -136,9 +165,135 @@ export function buildCandidateRecommendation(
     taskModes,
     matchedSignals,
     duplicateGroup,
-    reasons: buildBaseReasons(entry, matchedSignals, coverageTags, taskModes),
+    reasons: buildBaseReasons(
+      entry,
+      matchedSignals,
+      coverageTags,
+      taskModes,
+      matchQuality,
+    ),
     breakdown,
   };
+}
+
+function analyzeMatchQuality(
+  matchedSignals: RecommendationSignalMatch[],
+  searchTerms: Set<string>,
+  policy: RecommendationPolicy,
+): MatchQuality {
+  const exactnessEligible = !isWrapperLikeAsset(searchTerms);
+  let exactStackWeight = 0;
+  let ecosystemWeight = 0;
+  let genericConcernWeight = 0;
+
+  for (const match of matchedSignals) {
+    if (exactnessEligible) {
+      if (
+        match.signalType === "frameworks" ||
+        match.signalType === "packageManagers"
+      ) {
+        exactStackWeight += match.weight;
+        continue;
+      }
+
+      if (
+        match.signalType === "tooling" &&
+        isSpecificToolingSignal(match.term, policy)
+      ) {
+        exactStackWeight += match.weight;
+        continue;
+      }
+    }
+
+    if (match.signalType === "languages") {
+      ecosystemWeight += match.weight;
+      continue;
+    }
+
+    if (match.signalType === "concerns") {
+      genericConcernWeight += match.weight;
+    }
+  }
+
+  return {
+    exactStackWeight,
+    ecosystemWeight,
+    genericConcernWeight,
+    hasOnlyGenericConcernMatch:
+      genericConcernWeight > 0 &&
+      exactStackWeight === 0 &&
+      ecosystemWeight === 0,
+  };
+}
+
+function isWrapperLikeAsset(searchTerms: Set<string>): boolean {
+  for (const term of searchTerms) {
+    if (WRAPPER_LIKE_TERMS.has(term)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isSpecificToolingSignal(
+  term: string,
+  policy: RecommendationPolicy,
+): boolean {
+  const normalizedTerm = normalizePhrase(term);
+  if (GENERIC_CAPABILITY_TERMS.has(normalizedTerm)) {
+    return false;
+  }
+
+  for (const [concern, keywords] of Object.entries(policy.concernKeywordMap)) {
+    if (normalizePhrase(concern) === normalizedTerm) {
+      return false;
+    }
+
+    if (
+      keywords.some((keyword) => normalizePhrase(keyword) === normalizedTerm)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function computePortfolioFitBonus(matchQuality: MatchQuality): number {
+  if (matchQuality.exactStackWeight > 0) {
+    return matchQuality.exactStackWeight * 3 + matchQuality.ecosystemWeight;
+  }
+
+  if (matchQuality.ecosystemWeight > 0) {
+    return matchQuality.ecosystemWeight;
+  }
+
+  return 0;
+}
+
+function computeDemandExactnessBonus(matchQuality: MatchQuality): number {
+  if (matchQuality.exactStackWeight > 0) {
+    return (
+      matchQuality.exactStackWeight * 2 +
+      Math.round(matchQuality.ecosystemWeight / 2)
+    );
+  }
+
+  return 0;
+}
+
+function shouldEnforceConcernTarget(
+  concern: string,
+  demandContext: DemandContext,
+): boolean {
+  return demandContext.terms.some(
+    (term) =>
+      term.signalType === "concerns" &&
+      term.canonicalTerm === concern &&
+      (term.evidenceStrengthCounts.strong > 0 ||
+        term.evidenceStrengthCounts.medium > 0),
+  );
 }
 
 function computeHostDeprioritizationPenalty(
@@ -173,6 +328,7 @@ function computeHostPreference(
   entry: AssetCatalogEntry,
   host: RecommendationHost,
   coverageTags: string[],
+  demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): number {
   const hostPolicy = policy.hosts[host];
@@ -185,7 +341,10 @@ function computeHostPreference(
   }
 
   for (const target of hostPolicy.targetConcerns) {
-    if (coverageTags.includes(target.concern)) {
+    if (
+      coverageTags.includes(target.concern) &&
+      shouldEnforceConcernTarget(target.concern, demandContext)
+    ) {
       score += Math.max(1, Math.round(target.weight / 2));
     }
   }
@@ -197,6 +356,7 @@ function computeNegativePenalty(
   entry: AssetCatalogEntry,
   searchTerms: Set<string>,
   matchedSignals: RecommendationSignalMatch[],
+  matchQuality: MatchQuality,
   demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): number {
@@ -217,6 +377,9 @@ function computeNegativePenalty(
   );
   if (specificTerms.length < 3) {
     penalty += policy.scoring.genericCapabilityPenalty;
+  }
+  if (matchQuality.hasOnlyGenericConcernMatch) {
+    penalty += Math.max(2, policy.scoring.genericCapabilityPenalty);
   }
 
   return penalty;
@@ -247,6 +410,7 @@ function buildBaseReasons(
   matchedSignals: RecommendationSignalMatch[],
   coverageTags: string[],
   taskModes: string[],
+  matchQuality: MatchQuality,
 ): string[] {
   const reasons = [
     `authority:${entry.source.authorityTier}`,
@@ -265,6 +429,14 @@ function buildBaseReasons(
 
   for (const taskMode of taskModes.slice(0, 3)) {
     reasons.push(`mode:${taskMode}`);
+  }
+
+  if (matchQuality.exactStackWeight > 0) {
+    reasons.push("fit:exact-stack");
+  } else if (matchQuality.ecosystemWeight > 0) {
+    reasons.push("fit:ecosystem");
+  } else if (matchQuality.genericConcernWeight > 0) {
+    reasons.push("fit:generic-concern");
   }
 
   return reasons;

--- a/src/recommend/selection.ts
+++ b/src/recommend/selection.ts
@@ -3,6 +3,7 @@ import {
   buildCandidateRecommendation,
   computeEntryPreselectionScore,
 } from "./candidates.js";
+import { shouldEnforceConcernTarget } from "./signals.js";
 
 import type {
   AssetCatalogEntry,
@@ -130,7 +131,7 @@ function preserveRequiredCoverageCandidates(
   }
 
   for (const target of hostPolicy.targetConcerns) {
-    if (!shouldEnforceConcernTarget(target.concern, demandContext)) {
+    if (!shouldEnforceConcernTarget(target.concern, demandContext, policy)) {
       continue;
     }
 
@@ -154,19 +155,6 @@ function preserveRequiredCoverageCandidates(
   }
 
   return selected.slice(0, effectiveLimit).sort(compareScoredCandidates);
-}
-
-function shouldEnforceConcernTarget(
-  concern: string,
-  demandContext: DemandContext,
-): boolean {
-  return demandContext.terms.some(
-    (term) =>
-      term.signalType === "concerns" &&
-      term.canonicalTerm === concern &&
-      (term.evidenceStrengthCounts.strong > 0 ||
-        term.evidenceStrengthCounts.medium > 0),
-  );
 }
 
 function preserveMinimumCandidates(
@@ -389,7 +377,7 @@ function computeCoverageGain(
   }
 
   for (const target of hostPolicy.targetConcerns) {
-    if (!shouldEnforceConcernTarget(target.concern, demandContext)) {
+    if (!shouldEnforceConcernTarget(target.concern, demandContext, policy)) {
       continue;
     }
 

--- a/src/recommend/selection.ts
+++ b/src/recommend/selection.ts
@@ -56,6 +56,7 @@ export function buildTopRecommendationsForHost(
   const candidates = preserveRequiredCoverageCandidates(
     scoredCandidates,
     host,
+    demandContext,
     policy,
     getHostPreselectionLimit(host, policy),
   )
@@ -66,7 +67,12 @@ export function buildTopRecommendationsForHost(
         left.entry.id.localeCompare(right.entry.id),
     );
 
-  const selectedCandidates = selectCandidatesForHost(host, candidates, policy);
+  const selectedCandidates = selectCandidatesForHost(
+    host,
+    candidates,
+    demandContext,
+    policy,
+  );
 
   return selectedCandidates.map((candidate, index) => ({
     assetId: candidate.entry.id,
@@ -104,6 +110,7 @@ function preserveRequiredCoverageCandidates(
     preselectionScore: number;
   }>,
   host: RecommendationHost,
+  demandContext: DemandContext,
   policy: RecommendationPolicy,
   limit: number,
 ): Array<{ candidate: CandidateRecommendation; preselectionScore: number }> {
@@ -123,6 +130,10 @@ function preserveRequiredCoverageCandidates(
   }
 
   for (const target of hostPolicy.targetConcerns) {
+    if (!shouldEnforceConcernTarget(target.concern, demandContext)) {
+      continue;
+    }
+
     preserveMinimumCandidates(
       scoredCandidates,
       preserved,
@@ -143,6 +154,19 @@ function preserveRequiredCoverageCandidates(
   }
 
   return selected.slice(0, effectiveLimit).sort(compareScoredCandidates);
+}
+
+function shouldEnforceConcernTarget(
+  concern: string,
+  demandContext: DemandContext,
+): boolean {
+  return demandContext.terms.some(
+    (term) =>
+      term.signalType === "concerns" &&
+      term.canonicalTerm === concern &&
+      (term.evidenceStrengthCounts.strong > 0 ||
+        term.evidenceStrengthCounts.medium > 0),
+  );
 }
 
 function preserveMinimumCandidates(
@@ -215,6 +239,7 @@ function isEntryCompatibleWithRecommendationHost(
 function selectCandidatesForHost(
   host: RecommendationHost,
   candidates: CandidateRecommendation[],
+  demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): CandidateRecommendation[] {
   const hostPolicy = policy.hosts[host];
@@ -238,6 +263,7 @@ function selectCandidatesForHost(
         candidate,
         selectionState,
         hostPolicy,
+        demandContext,
         policy,
         false,
       );
@@ -283,6 +309,7 @@ function selectCandidatesForHost(
       candidate,
       selectionState,
       hostPolicy,
+      demandContext,
       policy,
       true,
     );
@@ -299,6 +326,7 @@ function scoreCandidateAgainstSelection(
   candidate: CandidateRecommendation,
   selectionState: SelectionState,
   hostPolicy: RecommendationPolicy["hosts"][RecommendationHost],
+  demandContext: DemandContext,
   policy: RecommendationPolicy,
   relaxed: boolean,
 ): DynamicScore {
@@ -306,6 +334,7 @@ function scoreCandidateAgainstSelection(
     candidate,
     selectionState,
     hostPolicy,
+    demandContext,
     policy,
   );
   const diversity =
@@ -345,6 +374,7 @@ function computeCoverageGain(
   candidate: CandidateRecommendation,
   selectionState: SelectionState,
   hostPolicy: RecommendationPolicy["hosts"][RecommendationHost],
+  demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): number {
   let score = 0;
@@ -359,6 +389,10 @@ function computeCoverageGain(
   }
 
   for (const target of hostPolicy.targetConcerns) {
+    if (!shouldEnforceConcernTarget(target.concern, demandContext)) {
+      continue;
+    }
+
     if (
       candidate.coverageTags.includes(target.concern) &&
       (selectionState.coverageTagCounts[target.concern] ?? 0) < target.minimum

--- a/src/recommend/signals.ts
+++ b/src/recommend/signals.ts
@@ -115,6 +115,26 @@ export function buildDemandContext(
 }
 
 /**
+ * Determines whether a host concern target has medium/strong supporting demand
+ * evidence after canonicalizing the requested concern through policy synonyms.
+ */
+export function shouldEnforceConcernTarget(
+  concern: string,
+  demandContext: DemandContext,
+  policy: RecommendationPolicy,
+): boolean {
+  const canonicalConcern = canonicalizePhrase(concern, policy);
+
+  return demandContext.terms.some(
+    (term) =>
+      term.signalType === "concerns" &&
+      term.canonicalTerm === canonicalConcern &&
+      (term.evidenceStrengthCounts.strong > 0 ||
+        term.evidenceStrengthCounts.medium > 0),
+  );
+}
+
+/**
  * Creates an empty evidence-strength histogram for one demand term.
  */
 function createEmptyEvidenceStrengthCounts(

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { buildTopRecommendationsForHost } from "../recommend/selection.js";
+import { buildDemandContext } from "../recommend/signals.js";
 import { buildSuggestedBundle } from "../recommend/summary.js";
 import type {
   AssetCatalogEntry,
+  DemandProfile,
   RecommendationEntry,
   RecommendationPolicy,
 } from "../types.js";
@@ -85,6 +87,160 @@ void test("suggested bundle skips over-budget first recommendation", () => {
   assert.equal(bundle.estimatedPromptWeight, 3);
 });
 
+void test("exact stack matches outrank generic concern overlap", () => {
+  const policy = buildPolicy();
+  policy.concernKeywordMap = {
+    backend: ["backend"],
+    integration: ["integration"],
+    testing: ["testing"],
+  };
+
+  const demandContext = buildDemandContext(
+    createDemandProfile([
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: ["javascript"],
+          packageManagers: ["npm"],
+          frameworks: ["apify"],
+          concerns: [],
+          tooling: ["npm:apify"],
+        },
+      },
+      {
+        path: "README.md",
+        fileName: "README.md",
+        evidenceStrength: "weak",
+        matchedSignals: {
+          languages: [],
+          packageManagers: [],
+          frameworks: [],
+          concerns: ["backend", "integration", "testing"],
+          tooling: [],
+        },
+      },
+    ]),
+    policy,
+  );
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    [
+      buildCatalogEntry("generic-backend", "skill", 95, {
+        capabilities: ["skill", "backend", "integration", "testing"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+      buildCatalogEntry("apify-exact", "skill", 55, {
+        capabilities: ["skill", "apify", "npm:apify"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+    ],
+    demandContext,
+    policy,
+  );
+
+  assert.equal(recommendations[0]?.assetId, "apify-exact");
+  assert.ok(recommendations[0]?.reasons.includes("fit:exact-stack"));
+});
+
+void test("wrapper-like assets do not claim exact-stack fit from generic aliases", () => {
+  const policy = buildPolicy();
+  policy.synonyms = { apify: ["automation"] };
+  policy.concernKeywordMap = { automation: ["automation"] };
+
+  const demandContext = buildDemandContext(
+    createDemandProfile([
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: [],
+          packageManagers: [],
+          frameworks: ["apify"],
+          concerns: ["automation"],
+          tooling: [],
+        },
+      },
+    ]),
+    policy,
+  );
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    [
+      buildCatalogEntry("scenario-wrapper", "skill", 80, {
+        capabilities: ["skill", "scenario", "automation", "yaml"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+    ],
+    demandContext,
+    policy,
+  );
+
+  assert.ok(!recommendations[0]?.reasons.includes("fit:exact-stack"));
+  assert.ok(recommendations[0]?.reasons.includes("fit:generic-concern"));
+});
+
+void test("weak-only concern demand does not force coverage-gap fill", () => {
+  const policy = buildPolicy({
+    recommendationLimit: 1,
+    targetConcerns: [{ concern: "backend", minimum: 1, weight: 200 }],
+  });
+  policy.concernKeywordMap = { backend: ["backend"] };
+
+  const demandContext = buildDemandContext(
+    createDemandProfile([
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: [],
+          packageManagers: ["npm"],
+          frameworks: ["apify"],
+          concerns: [],
+          tooling: ["npm:apify"],
+        },
+      },
+      {
+        path: "README.md",
+        fileName: "README.md",
+        evidenceStrength: "weak",
+        matchedSignals: {
+          languages: [],
+          packageManagers: [],
+          frameworks: [],
+          concerns: ["backend"],
+          tooling: [],
+        },
+      },
+    ]),
+    policy,
+  );
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    [
+      buildCatalogEntry("generic-backend", "skill", 95, {
+        capabilities: ["skill", "backend"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+      buildCatalogEntry("apify-exact", "skill", 55, {
+        capabilities: ["skill", "apify", "npm:apify"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+    ],
+    demandContext,
+    policy,
+  );
+
+  assert.equal(recommendations[0]?.assetId, "apify-exact");
+  assert.ok(!recommendations[0]?.reasons.includes("coverage-gap-fill"));
+});
+
 function buildPolicy(
   overrides: Partial<RecommendationPolicy["hosts"]["copilot-vscode"]> = {},
 ): RecommendationPolicy {
@@ -163,7 +319,12 @@ function buildCatalogEntry(
   id: string,
   assetKind: AssetCatalogEntry["assetKind"],
   sourcePriority: number,
-  options: { duplicateGroup?: string; sourceId?: string } = {},
+  options: {
+    capabilities?: string[];
+    duplicateGroup?: string;
+    fit?: { portfolioFit: number; hostFit: number };
+    sourceId?: string;
+  } = {},
 ): AssetCatalogEntry {
   const sourceId = options.sourceId ?? id;
   return {
@@ -182,7 +343,7 @@ function buildCatalogEntry(
       publisherVerified: false,
     },
     trust: { score: sourcePriority, signals: [] },
-    capabilities: [assetKind, id],
+    capabilities: options.capabilities ?? [assetKind, id],
     install: { method: "local-file" },
     evidence: {
       manifestFound: true,
@@ -202,7 +363,7 @@ function buildCatalogEntry(
       requiresNetwork: false,
     },
     contextCost: { sizeClass: "tiny", estimatedPromptWeight: 1 },
-    fit: { portfolioFit: 1, hostFit: 1 },
+    fit: options.fit ?? { portfolioFit: 1, hostFit: 1 },
     dedupe: {
       duplicateGroup: options.duplicateGroup,
       candidateRankHint: "test",
@@ -261,5 +422,27 @@ function createEmptyDemandContext() {
     terms: [],
     hasSignals: false,
     activeDomainGroups: new Set<string>(),
+  };
+}
+
+function createDemandProfile(
+  evidence: DemandProfile["evidence"],
+): DemandProfile {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    scanRoot: "C:/fixture",
+    summary: {
+      scannedFiles: evidence.length,
+      matchedFiles: evidence.length,
+    },
+    signals: {
+      languages: [],
+      packageManagers: [],
+      frameworks: [],
+      concerns: [],
+      tooling: [],
+    },
+    evidence,
   };
 }

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -147,7 +147,7 @@ void test("exact stack matches outrank generic concern overlap", () => {
 
 void test("wrapper-like assets do not claim exact-stack fit from generic aliases", () => {
   const policy = buildPolicy();
-  policy.synonyms = { apify: ["automation"] };
+  policy.synonyms = { apify: ["automation"], documentation: ["docs"] };
   policy.concernKeywordMap = { automation: ["automation"] };
 
   const demandContext = buildDemandContext(
@@ -172,7 +172,7 @@ void test("wrapper-like assets do not claim exact-stack fit from generic aliases
     "copilot-vscode",
     [
       buildCatalogEntry("scenario-wrapper", "skill", 80, {
-        capabilities: ["skill", "scenario", "automation", "yaml"],
+        capabilities: ["skill", "scenario", "automation", "docs"],
         fit: { portfolioFit: 0.55, hostFit: 1 },
       }),
     ],
@@ -182,6 +182,90 @@ void test("wrapper-like assets do not claim exact-stack fit from generic aliases
 
   assert.ok(!recommendations[0]?.reasons.includes("fit:exact-stack"));
   assert.ok(recommendations[0]?.reasons.includes("fit:generic-concern"));
+});
+
+void test("path tokens do not block exact-stack fit", () => {
+  const policy = buildPolicy();
+
+  const demandContext = buildDemandContext(
+    createDemandProfile([
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: [],
+          packageManagers: ["npm"],
+          frameworks: ["apify"],
+          concerns: [],
+          tooling: ["npm:apify"],
+        },
+      },
+    ]),
+    policy,
+  );
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    [
+      buildCatalogEntry("apify-helper", "skill", 80, {
+        capabilities: ["skill", "apify", "npm:apify"],
+        evidenceFilePath: "docs/reference.yaml",
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+        installRelativePath: "config/package.json",
+      }),
+    ],
+    demandContext,
+    policy,
+  );
+
+  assert.ok(recommendations[0]?.reasons.includes("fit:exact-stack"));
+});
+
+void test("canonicalized concern targets still enforce coverage goals", () => {
+  const policy = buildPolicy({
+    recommendationLimit: 1,
+    targetConcerns: [{ concern: "backend", minimum: 1, weight: 200 }],
+  });
+  policy.concernKeywordMap = { backend: ["backend"] };
+  policy.synonyms = { "node-backend": ["backend"] };
+
+  const demandContext = buildDemandContext(
+    createDemandProfile([
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: [],
+          packageManagers: [],
+          frameworks: [],
+          concerns: ["backend"],
+          tooling: [],
+        },
+      },
+    ]),
+    policy,
+  );
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    [
+      buildCatalogEntry("other-skill", "skill", 100, {
+        capabilities: ["skill", "testing"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+      buildCatalogEntry("backend-skill", "skill", 10, {
+        capabilities: ["skill", "backend"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+    ],
+    demandContext,
+    policy,
+  );
+
+  assert.equal(recommendations[0]?.assetId, "backend-skill");
+  assert.ok(recommendations[0]?.reasons.includes("coverage-gap-fill"));
 });
 
 void test("weak-only concern demand does not force coverage-gap fill", () => {
@@ -322,7 +406,9 @@ function buildCatalogEntry(
   options: {
     capabilities?: string[];
     duplicateGroup?: string;
+    evidenceFilePath?: string;
     fit?: { portfolioFit: number; hostFit: number };
+    installRelativePath?: string;
     sourceId?: string;
   } = {},
 ): AssetCatalogEntry {
@@ -344,12 +430,16 @@ function buildCatalogEntry(
     },
     trust: { score: sourcePriority, signals: [] },
     capabilities: options.capabilities ?? [assetKind, id],
-    install: { method: "local-file" },
+    install: {
+      method: "local-file",
+      relativePath: options.installRelativePath,
+    },
     evidence: {
       manifestFound: true,
       readmeFound: true,
       examplesFound: false,
       docsLinked: true,
+      filePath: options.evidenceFilePath,
     },
     maintenance: {
       lastUpdated: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- make exact stack matches outrank broad generic concern overlap during recommendation ranking
- gate host concern coverage goals on medium/strong evidence instead of weak-only demand
- stop wrapper/reference-style assets from claiming exact-stack fit via generic alias expansion

## Validation
- npm run format:check
- npm run build
- node --test dist/tests/recommendation-selection.test.js
- npm run validate:recommendations

## Issues
- refs #133
- refs #134
- refs #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved match-quality analysis for recommendations, adding explicit fit tags (exact-stack / ecosystem / generic-concern)
  * Demand-context aware scoring and host preference weighting to better prioritize relevant matches
  * Concern-enforcement gating so coverage and preservation respect signal strength

* **Tests**
  * Expanded tests validating exact-stack ranking, wrapper/tooling distinctions, and richer demand-context behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->