### PR TITLE
feat: separate local availability from recommendation fit

### DIFF
--- a/src/manifest-validation/recommendation.ts
+++ b/src/manifest-validation/recommendation.ts
@@ -7,6 +7,7 @@ import type {
 import {
   ASSET_KINDS,
   assertArray,
+  assertBoolean,
   assertHostTarget,
   assertLiteral,
   assertMaybeArray,
@@ -78,6 +79,15 @@ export function assertRecommendationReport(
         assertString(
           entryRecord.sourceFamily,
           `${context}.topByHost.${host}[${index}].sourceFamily`,
+        );
+        assertBoolean(
+          entryRecord.availableLocally,
+          `${context}.topByHost.${host}[${index}].availableLocally`,
+        );
+        assertLiteral(
+          entryRecord.recommendationBasis,
+          ["workspace-fit", "local-availability"],
+          `${context}.topByHost.${host}[${index}].recommendationBasis`,
         );
         assertLiteral(
           entryRecord.contextSizeClass,

--- a/src/manifest-validation/recommendation.ts
+++ b/src/manifest-validation/recommendation.ts
@@ -80,15 +80,30 @@ export function assertRecommendationReport(
           entryRecord.sourceFamily,
           `${context}.topByHost.${host}[${index}].sourceFamily`,
         );
-        assertBoolean(
-          entryRecord.availableLocally,
-          `${context}.topByHost.${host}[${index}].availableLocally`,
-        );
-        assertLiteral(
-          entryRecord.recommendationBasis,
-          ["workspace-fit", "local-availability"],
-          `${context}.topByHost.${host}[${index}].recommendationBasis`,
-        );
+        if (
+          Object.prototype.hasOwnProperty.call(entryRecord, "availableLocally")
+        ) {
+          assertBoolean(
+            entryRecord.availableLocally,
+            `${context}.topByHost.${host}[${index}].availableLocally`,
+          );
+        } else {
+          entryRecord.availableLocally = false;
+        }
+        if (
+          Object.prototype.hasOwnProperty.call(
+            entryRecord,
+            "recommendationBasis",
+          )
+        ) {
+          assertLiteral(
+            entryRecord.recommendationBasis,
+            ["workspace-fit", "local-availability"],
+            `${context}.topByHost.${host}[${index}].recommendationBasis`,
+          );
+        } else {
+          entryRecord.recommendationBasis = "workspace-fit";
+        }
         assertLiteral(
           entryRecord.contextSizeClass,
           [...CONTEXT_COST_CLASSES],

--- a/src/recommend-fixtures.ts
+++ b/src/recommend-fixtures.ts
@@ -1,3 +1,4 @@
+import { isPublisherVerifiedForAuthorityTier } from "./source-metadata.js";
 import type {
   AssetCatalogEntry,
   AssetKind,
@@ -612,13 +613,6 @@ function createDemandProfile(
   };
 }
 
-function isFixturePublisherVerified(authorityTier: AuthorityTier): boolean {
-  return (
-    authorityTier !== "trusted-community" &&
-    authorityTier !== "unverified-community"
-  );
-}
-
 function createAsset(
   id: string,
   options: FixtureAssetOptions,
@@ -636,7 +630,7 @@ function createAsset(
       sourcePriority: options.sourcePriority ?? 80,
       originUrl: `https://example.com/${options.sourceId}/${id}`,
       publisher: options.publisher,
-      publisherVerified: isFixturePublisherVerified(
+      publisherVerified: isPublisherVerifiedForAuthorityTier(
         options.authorityTier ?? "trusted-community",
       ),
     },

--- a/src/recommend-fixtures.ts
+++ b/src/recommend-fixtures.ts
@@ -6,6 +6,7 @@ import type {
   DemandProfile,
   HostTarget,
   RecommendationEvaluationFixture,
+  SourceKind,
 } from "./types.js";
 
 const FIXTURE_UPDATED_AT = new Date(
@@ -26,6 +27,8 @@ interface FixtureAssetOptions {
   estimatedPromptWeight?: number;
   portfolioFit?: number;
   hostFit?: number;
+  sourceKind?: SourceKind;
+  sourcePriority?: number;
   trustScore?: number;
 }
 
@@ -37,6 +40,7 @@ export function buildRecommendationFixtures(): RecommendationEvaluationFixture[]
     buildBackendIntegrationFixture(),
     buildFrontendQualityFixture(),
     buildInfraSecurityFixture(),
+    buildLocalAvailabilitySeparationFixture(),
     buildSharedExecutableBiasFixture(),
     buildSharedSourceSaturationFixture(),
   ];
@@ -323,6 +327,86 @@ function buildInfraSecurityFixture(): RecommendationEvaluationFixture {
   };
 }
 
+function buildLocalAvailabilitySeparationFixture(): RecommendationEvaluationFixture {
+  return {
+    schemaVersion: 1,
+    id: "local-availability-separation",
+    description:
+      "Local assets should stay visible for convenience without outranking stronger workspace-fit recommendations.",
+    demandProfile: createDemandProfile({
+      frameworks: ["react", "frontend"],
+      concerns: ["frontend", "testing"],
+      tooling: ["typescript", "playwright", "node"],
+    }),
+    catalogEntries: [
+      createAsset("official-react-guidance", {
+        assetKind: "instruction",
+        hosts: ["copilot-vscode"],
+        capabilities: ["react", "frontend", "typescript", "testing"],
+        sourceId: "ui-foundation",
+        publisher: "ui-foundation",
+        authorityTier: "official-first-party",
+      }),
+      createAsset("local-generic-toolkit", {
+        assetKind: "skill",
+        hosts: ["copilot-vscode"],
+        capabilities: ["automation", "workflow", "assistant", "docs"],
+        sourceId: "local-cursor-config",
+        publisher: "local",
+        authorityTier: "trusted-local",
+        sourceKind: "local-directory",
+        sourcePriority: 100,
+      }),
+      createAsset("local-react-snippets", {
+        assetKind: "skill",
+        hosts: ["copilot-vscode"],
+        capabilities: ["react", "frontend", "typescript", "component"],
+        sourceId: "local-cursor-config",
+        publisher: "local",
+        authorityTier: "trusted-local",
+        sourceKind: "local-directory",
+        sourcePriority: 100,
+      }),
+      createAsset("community-react-testing", {
+        assetKind: "skill",
+        hosts: ["copilot-vscode"],
+        capabilities: ["react", "frontend", "playwright", "testing"],
+        sourceId: "qa-lab",
+        publisher: "qa-lab",
+      }),
+    ],
+    expectations: [
+      {
+        host: "copilot-vscode",
+        requiredAssetIds: [
+          "official-react-guidance",
+          "local-react-snippets",
+          "community-react-testing",
+        ],
+        requiredAssetKinds: [
+          { assetKind: "instruction", minimum: 1 },
+          { assetKind: "skill", minimum: 2 },
+        ],
+        requiredConcerns: ["frontend", "testing"],
+        rankedAbove: [
+          {
+            higherAssetId: "official-react-guidance",
+            lowerAssetId: "local-generic-toolkit",
+          },
+          {
+            higherAssetId: "community-react-testing",
+            lowerAssetId: "local-generic-toolkit",
+          },
+          {
+            higherAssetId: "local-react-snippets",
+            lowerAssetId: "local-generic-toolkit",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function buildSharedExecutableBiasFixture(): RecommendationEvaluationFixture {
   return {
     schemaVersion: 1,
@@ -541,8 +625,8 @@ function createAsset(
     source: {
       sourceId: options.sourceId,
       authorityTier: options.authorityTier ?? "trusted-community",
-      sourceKind: "repo",
-      sourcePriority: 80,
+      sourceKind: options.sourceKind ?? "repo",
+      sourcePriority: options.sourcePriority ?? 80,
       originUrl: `https://example.com/${options.sourceId}/${id}`,
       publisher: options.publisher,
       publisherVerified:

--- a/src/recommend-fixtures.ts
+++ b/src/recommend-fixtures.ts
@@ -334,7 +334,7 @@ function buildLocalAvailabilitySeparationFixture(): RecommendationEvaluationFixt
     description:
       "Local assets should stay visible for convenience without outranking stronger workspace-fit recommendations.",
     demandProfile: createDemandProfile({
-      frameworks: ["react", "frontend"],
+      frameworks: ["react"],
       concerns: ["frontend", "testing"],
       tooling: ["typescript", "playwright", "node"],
     }),
@@ -612,6 +612,13 @@ function createDemandProfile(
   };
 }
 
+function isFixturePublisherVerified(authorityTier: AuthorityTier): boolean {
+  return (
+    authorityTier !== "trusted-community" &&
+    authorityTier !== "unverified-community"
+  );
+}
+
 function createAsset(
   id: string,
   options: FixtureAssetOptions,
@@ -629,8 +636,9 @@ function createAsset(
       sourcePriority: options.sourcePriority ?? 80,
       originUrl: `https://example.com/${options.sourceId}/${id}`,
       publisher: options.publisher,
-      publisherVerified:
-        (options.authorityTier ?? "trusted-community") !== "trusted-community",
+      publisherVerified: isFixturePublisherVerified(
+        options.authorityTier ?? "trusted-community",
+      ),
     },
     trust: {
       score: options.trustScore ?? 82,

--- a/src/recommend/candidates.ts
+++ b/src/recommend/candidates.ts
@@ -420,7 +420,7 @@ function computeNegativePenalty(
     penalty += Math.max(2, policy.scoring.genericCapabilityPenalty);
   }
 
-  if (availableLocally && recommendationBasis === "local-availability") {
+  if (recommendationBasis === "local-availability") {
     penalty += Math.max(
       policy.scoring.weakDemandPenalty,
       policy.scoring.genericCapabilityPenalty + 4,

--- a/src/recommend/candidates.ts
+++ b/src/recommend/candidates.ts
@@ -11,6 +11,7 @@ import {
 } from "./signals.js";
 import type {
   AssetCatalogEntry,
+  RecommendationBasis,
   RecommendationPolicy,
   RecommendationScoreBreakdown,
   RecommendationSignalMatch,
@@ -96,6 +97,11 @@ export function buildCandidateRecommendation(
     wrapperLikeTerms,
     genericToolingTerms,
   );
+  const availableLocally = isLocallyAvailable(entry);
+  const recommendationBasis = determineRecommendationBasis(
+    availableLocally,
+    matchQuality,
+  );
   const coverageTags = buildCoverageTags(searchTerms, matchedSignals, policy);
   const taskModes = buildTaskModes(
     searchTerms,
@@ -160,6 +166,8 @@ export function buildCandidateRecommendation(
         searchTerms,
         matchedSignals,
         matchQuality,
+        availableLocally,
+        recommendationBasis,
         demandContext,
         policy,
       ) + hostDeprioritizationPenalty,
@@ -173,6 +181,8 @@ export function buildCandidateRecommendation(
     entry,
     host,
     sourceFamily: deriveSourceFamily(entry),
+    availableLocally,
+    recommendationBasis,
     coverageTags,
     taskModes,
     matchedSignals,
@@ -183,6 +193,8 @@ export function buildCandidateRecommendation(
       coverageTags,
       taskModes,
       matchQuality,
+      availableLocally,
+      recommendationBasis,
     ),
     breakdown,
   };
@@ -274,6 +286,29 @@ function isSpecificToolingSignal(
   return !genericToolingTerms.has(normalizePhrase(term));
 }
 
+function isLocallyAvailable(entry: AssetCatalogEntry): boolean {
+  return (
+    entry.source.authorityTier === "trusted-local" ||
+    entry.source.sourceKind === "local-directory" ||
+    entry.source.sourceKind === "local-manifest"
+  );
+}
+
+function determineRecommendationBasis(
+  availableLocally: boolean,
+  matchQuality: MatchQuality,
+): RecommendationBasis {
+  if (
+    availableLocally &&
+    matchQuality.exactStackWeight === 0 &&
+    matchQuality.ecosystemWeight === 0
+  ) {
+    return "local-availability";
+  }
+
+  return "workspace-fit";
+}
+
 function computePortfolioFitBonus(matchQuality: MatchQuality): number {
   if (matchQuality.exactStackWeight > 0) {
     return matchQuality.exactStackWeight * 3 + matchQuality.ecosystemWeight;
@@ -358,6 +393,8 @@ function computeNegativePenalty(
   searchTerms: Set<string>,
   matchedSignals: RecommendationSignalMatch[],
   matchQuality: MatchQuality,
+  availableLocally: boolean,
+  recommendationBasis: RecommendationBasis,
   demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): number {
@@ -381,6 +418,13 @@ function computeNegativePenalty(
   }
   if (matchQuality.hasOnlyGenericConcernMatch) {
     penalty += Math.max(2, policy.scoring.genericCapabilityPenalty);
+  }
+
+  if (availableLocally && recommendationBasis === "local-availability") {
+    penalty += Math.max(
+      policy.scoring.weakDemandPenalty,
+      policy.scoring.genericCapabilityPenalty + 4,
+    );
   }
 
   return penalty;
@@ -412,6 +456,8 @@ function buildBaseReasons(
   coverageTags: string[],
   taskModes: string[],
   matchQuality: MatchQuality,
+  availableLocally: boolean,
+  recommendationBasis: RecommendationBasis,
 ): string[] {
   const reasons = [
     `authority:${entry.source.authorityTier}`,
@@ -439,6 +485,11 @@ function buildBaseReasons(
   } else if (matchQuality.genericConcernWeight > 0) {
     reasons.push("fit:generic-concern");
   }
+
+  if (availableLocally) {
+    reasons.push("availability:local");
+  }
+  reasons.push(`basis:${recommendationBasis}`);
 
   return reasons;
 }

--- a/src/recommend/commands.ts
+++ b/src/recommend/commands.ts
@@ -106,6 +106,8 @@ async function explainRecommendation(
     lines.push(`  score: ${entry.score}`);
     lines.push(`  asset kind: ${entry.assetKind ?? "unknown"}`);
     lines.push(`  source: ${entry.sourceId} (${entry.sourceFamily})`);
+    lines.push(`  recommendation basis: ${entry.recommendationBasis}`);
+    lines.push(`  available locally: ${entry.availableLocally ? "yes" : "no"}`);
     lines.push(
       `  prompt weight: ${entry.estimatedPromptWeight} (${entry.contextSizeClass})`,
     );

--- a/src/recommend/model.ts
+++ b/src/recommend/model.ts
@@ -1,6 +1,7 @@
 import type {
   AssetCatalogEntry,
   DemandEvidenceStrength,
+  RecommendationBasis,
   RecommendationScoreBreakdown,
   RecommendationSignalMatch,
   RecommendationSignalType,
@@ -35,6 +36,8 @@ export interface CandidateRecommendation {
   entry: AssetCatalogEntry;
   host: RecommendationHost;
   sourceFamily: string;
+  availableLocally: boolean;
+  recommendationBasis: RecommendationBasis;
   coverageTags: string[];
   taskModes: string[];
   matchedSignals: RecommendationSignalMatch[];

--- a/src/recommend/selection.ts
+++ b/src/recommend/selection.ts
@@ -84,6 +84,8 @@ export function buildTopRecommendationsForHost(
     assetKind: candidate.entry.assetKind,
     sourceId: candidate.entry.source.sourceId,
     sourceFamily: candidate.sourceFamily,
+    availableLocally: candidate.availableLocally,
+    recommendationBasis: candidate.recommendationBasis,
     contextSizeClass: candidate.entry.contextCost.sizeClass,
     estimatedPromptWeight: candidate.entry.contextCost.estimatedPromptWeight,
     duplicateGroup: candidate.duplicateGroup,

--- a/src/source-metadata.ts
+++ b/src/source-metadata.ts
@@ -1,0 +1,13 @@
+import type { AuthorityTier } from "./types.js";
+
+/**
+ * Determines whether an authority tier should be treated as publisher-verified.
+ */
+export function isPublisherVerifiedForAuthorityTier(
+  authorityTier: AuthorityTier,
+): boolean {
+  return (
+    authorityTier !== "trusted-community" &&
+    authorityTier !== "unverified-community"
+  );
+}

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { buildTopRecommendationsForHost } from "../recommend/selection.js";
 import { buildDemandContext } from "../recommend/signals.js";
 import { buildSuggestedBundle } from "../recommend/summary.js";
+import { isPublisherVerifiedForAuthorityTier } from "../source-metadata.js";
 import type {
   AssetCatalogEntry,
   DemandProfile,
@@ -467,15 +468,6 @@ function buildPolicy(
   };
 }
 
-function isTestPublisherVerified(
-  authorityTier: AssetCatalogEntry["source"]["authorityTier"],
-): boolean {
-  return (
-    authorityTier !== "trusted-community" &&
-    authorityTier !== "unverified-community"
-  );
-}
-
 function buildCatalogEntry(
   id: string,
   assetKind: AssetCatalogEntry["assetKind"],
@@ -507,7 +499,7 @@ function buildCatalogEntry(
       sourcePriority,
       originUrl: `https://example.com/${id}`,
       publisher: sourceId,
-      publisherVerified: isTestPublisherVerified(authorityTier),
+      publisherVerified: isPublisherVerifiedForAuthorityTier(authorityTier),
     },
     trust: {
       score: sourcePriority,

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -467,6 +467,15 @@ function buildPolicy(
   };
 }
 
+function isTestPublisherVerified(
+  authorityTier: AssetCatalogEntry["source"]["authorityTier"],
+): boolean {
+  return (
+    authorityTier !== "trusted-community" &&
+    authorityTier !== "unverified-community"
+  );
+}
+
 function buildCatalogEntry(
   id: string,
   assetKind: AssetCatalogEntry["assetKind"],
@@ -483,6 +492,8 @@ function buildCatalogEntry(
   } = {},
 ): AssetCatalogEntry {
   const sourceId = options.sourceId ?? id;
+  const authorityTier = options.authorityTier ?? "trusted-community";
+
   return {
     id,
     displayName: id,
@@ -491,17 +502,16 @@ function buildCatalogEntry(
     compatibilityMode: "native",
     source: {
       sourceId,
-      authorityTier: options.authorityTier ?? "trusted-community",
+      authorityTier,
       sourceKind: options.sourceKind ?? "repo",
       sourcePriority,
       originUrl: `https://example.com/${id}`,
       publisher: sourceId,
-      publisherVerified:
-        (options.authorityTier ?? "trusted-community") !== "trusted-community",
+      publisherVerified: isTestPublisherVerified(authorityTier),
     },
     trust: {
       score: sourcePriority,
-      signals: [`authority:${options.authorityTier ?? "trusted-community"}`],
+      signals: [`authority:${authorityTier}`],
     },
     capabilities: options.capabilities ?? [assetKind, id],
     install: {

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -268,6 +268,74 @@ void test("canonicalized concern targets still enforce coverage goals", () => {
   assert.ok(recommendations[0]?.reasons.includes("coverage-gap-fill"));
 });
 
+void test("local availability is surfaced separately from workspace fit", () => {
+  const policy = buildPolicy();
+  policy.concernKeywordMap = {
+    frontend: ["frontend"],
+    testing: ["testing"],
+  };
+
+  const demandContext = buildDemandContext(
+    createDemandProfile([
+      {
+        path: "package.json",
+        fileName: "package.json",
+        evidenceStrength: "strong",
+        matchedSignals: {
+          languages: ["typescript"],
+          packageManagers: [],
+          frameworks: ["react"],
+          concerns: ["frontend", "testing"],
+          tooling: ["playwright"],
+        },
+      },
+    ]),
+    policy,
+  );
+
+  const recommendations = buildTopRecommendationsForHost(
+    "copilot-vscode",
+    [
+      buildCatalogEntry("local-generic-toolkit", "skill", 100, {
+        authorityTier: "trusted-local",
+        capabilities: ["skill", "automation", "workflow", "docs"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+        sourceId: "local-cursor-config",
+        sourceKind: "local-directory",
+      }),
+      buildCatalogEntry("community-react-testing", "skill", 45, {
+        capabilities: ["skill", "react", "frontend", "playwright"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+      }),
+      buildCatalogEntry("local-react-snippets", "skill", 95, {
+        authorityTier: "trusted-local",
+        capabilities: ["skill", "react", "frontend", "typescript"],
+        fit: { portfolioFit: 0.55, hostFit: 1 },
+        sourceId: "local-cursor-config",
+        sourceKind: "local-directory",
+      }),
+    ],
+    demandContext,
+    policy,
+  );
+
+  assert.equal(recommendations[0]?.assetId, "local-react-snippets");
+
+  const localGeneric = recommendations.find(
+    (entry) => entry.assetId === "local-generic-toolkit",
+  );
+  assert.equal(localGeneric?.availableLocally, true);
+  assert.equal(localGeneric?.recommendationBasis, "local-availability");
+  assert.ok(localGeneric?.reasons.includes("availability:local"));
+  assert.ok(localGeneric?.reasons.includes("basis:local-availability"));
+
+  const localExact = recommendations.find(
+    (entry) => entry.assetId === "local-react-snippets",
+  );
+  assert.equal(localExact?.availableLocally, true);
+  assert.equal(localExact?.recommendationBasis, "workspace-fit");
+});
+
 void test("weak-only concern demand does not force coverage-gap fill", () => {
   const policy = buildPolicy({
     recommendationLimit: 1,
@@ -404,12 +472,14 @@ function buildCatalogEntry(
   assetKind: AssetCatalogEntry["assetKind"],
   sourcePriority: number,
   options: {
+    authorityTier?: AssetCatalogEntry["source"]["authorityTier"];
     capabilities?: string[];
     duplicateGroup?: string;
     evidenceFilePath?: string;
     fit?: { portfolioFit: number; hostFit: number };
     installRelativePath?: string;
     sourceId?: string;
+    sourceKind?: AssetCatalogEntry["source"]["sourceKind"];
   } = {},
 ): AssetCatalogEntry {
   const sourceId = options.sourceId ?? id;
@@ -421,14 +491,18 @@ function buildCatalogEntry(
     compatibilityMode: "native",
     source: {
       sourceId,
-      authorityTier: "trusted-community",
-      sourceKind: "repo",
+      authorityTier: options.authorityTier ?? "trusted-community",
+      sourceKind: options.sourceKind ?? "repo",
       sourcePriority,
       originUrl: `https://example.com/${id}`,
       publisher: sourceId,
-      publisherVerified: false,
+      publisherVerified:
+        (options.authorityTier ?? "trusted-community") !== "trusted-community",
     },
-    trust: { score: sourcePriority, signals: [] },
+    trust: {
+      score: sourcePriority,
+      signals: [`authority:${options.authorityTier ?? "trusted-community"}`],
+    },
     capabilities: options.capabilities ?? [assetKind, id],
     install: {
       method: "local-file",
@@ -480,6 +554,8 @@ function buildRecommendationEntry(
     assetKind: "skill",
     sourceId: "test",
     sourceFamily: "test",
+    availableLocally: false,
+    recommendationBasis: "workspace-fit",
     contextSizeClass: "tiny",
     estimatedPromptWeight,
     selectionStage: "top-by-host",

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -184,6 +184,12 @@ export interface RecommendationScoreBreakdown {
 }
 
 /**
+ * Defines whether a recommendation is present because it fits the workspace or
+ * because it is already available locally for convenience.
+ */
+export type RecommendationBasis = "workspace-fit" | "local-availability";
+
+/**
  * Describes recommendation entry data exchanged by the lifecycle pipeline.
  */
 export interface RecommendationEntry {
@@ -195,6 +201,8 @@ export interface RecommendationEntry {
   assetKind?: AssetKind;
   sourceId: string;
   sourceFamily: string;
+  availableLocally: boolean;
+  recommendationBasis: RecommendationBasis;
   contextSizeClass: AssetContextCost["sizeClass"];
   estimatedPromptWeight: number;
   duplicateGroup?: string;


### PR DESCRIPTION
## Summary
- separate local availability from workspace-fit recommendation output
- demote locally available assets when they only surface as convenience rather than strong workspace fit
- expose local availability and recommendation basis in report/explain output and add a regression fixture for this bias

## Validation
- npm run format:check
- npm run build
- node --test dist/tests/recommendation-selection.test.js
- npm run validate:recommendations
- npm test

## Issues
- refs #135
- contributes to #136
- refs #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `recommend explain` command now displays additional details for each asset: whether it's available locally and the basis for the recommendation (workspace-fit or local-availability).

* **Improvements**
  * Enhanced recommendation ranking to better distinguish and appropriately classify assets based on local availability versus workspace fit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->