### PR TITLE
feat: summarize recommendation evaluation quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- None yet.
+- recommendation fixture evaluation now records aggregate quality metrics, including top-rank reason mix, top-rank confidence mix, broad-fallback frequency, and local-availability frequency
 
 ### Changed
 
-- None yet.
+- README now documents the layered confidence model, explain-output reason classes, and how to read `recommend evaluate` as a precision-vs-fallback signal instead of only a pass/fail check
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ npm run recommend:update
 ```
 
 Omitting the recommendation subcommand defaults to `report`.
+`recommend evaluate` now ends with an aggregate summary so you can spot whether a fixture suite is being carried by exact-stack wins, weak-only generic matches, or broad fallback behavior.
 
 Explain a specific recommendation:
 
@@ -813,6 +814,30 @@ Recommendation scoring considers:
 - duplicate groups
 - per-host caps and budgets
 
+### Layered confidence model
+
+The recommendation pipeline now follows a stricter evidence hierarchy instead of treating repeated docs noise like runtime truth:
+
+- **Strong evidence**: manifests, lockfiles, imports, framework/runtime/config files
+- **Medium evidence**: deploy/config conventions, generated artifacts, directory conventions
+- **Weak evidence**: README/docs/examples
+- **Ignored by default**: issue templates, changelogs, roadmaps, planning docs
+
+That evidence feeds a ranking ladder:
+
+- `fit:exact-stack` → exact dependency/framework/runtime matches
+- `fit:ecosystem` → narrower ecosystem-adjacent matches
+- `fit:generic-concern` → broad concern overlap like testing/docs/backend
+- `coverage-gap-fill` → coverage-driven fallback signal when host coverage goals still need help; in evaluation summaries it is counted as a broad fallback only when no stronger exact/ecosystem fit is carrying the top slot
+
+`recommend explain` surfaces these reasons directly, along with matched-signal evidence counts and whether an asset was shown for actual workspace fit or only because it was already available locally:
+
+- `recommendation basis: workspace-fit | local-availability`
+- `available locally: yes | no`
+- `matched signals: ... s=<strong>/m=<medium>/w=<weak>`
+
+If a narrow repo shows a lot of `fit:generic-concern` or `coverage-gap-fill` winners, that is a signal to inspect policy breadth or source mix before increasing selection counts.
+
 The legacy `discover/recommendation-policy.json` path is still accepted as a fallback when only the older monolithic policy file exists.
 
 ### Quality and policy coverage
@@ -829,7 +854,7 @@ npm run validate:recommendations
 - `quality:detection` checks representative archetype fixtures and reports precision/recall-style metrics.
 - `quality:policy` verifies detector-emitted terms are represented in recommendation policy maps and writes draft suggestions for human review.
 - `benchmark:scan` enforces scan budget expectations.
-- `validate:recommendations` evaluates golden recommendation fixtures.
+- `validate:recommendations` evaluates golden recommendation fixtures and prints aggregate quality signals such as top-rank reason mix, top-rank confidence mix, broad-fallback frequency, and local-availability frequency.
 
 ## Environment variables
 

--- a/src/recommend/commands.ts
+++ b/src/recommend/commands.ts
@@ -5,19 +5,13 @@ import { getOptionValue } from "../lib/cli-options.js";
 import { assertRecommendationReport } from "../manifest-validation.js";
 import { buildRecommendationFixtures } from "../recommend-fixtures.js";
 import { EVALUATION_FILE_PATH, REPORT_FILE_PATH } from "./constants.js";
+import { buildRecommendationEvaluationResult } from "./evaluation.js";
 import { getRecommendationHosts, isRecommendationHost } from "./hosts.js";
 import { loadRecommendationPolicy } from "./policy.js";
-import {
-  buildRecommendationReport,
-  writeRecommendationReport,
-} from "./report.js";
+import { writeRecommendationReport } from "./report.js";
 import type { RecommendationHost } from "./hosts.js";
 import type {
-  RecommendationEvaluationCheck,
-  RecommendationEvaluationExpectation,
-  RecommendationEvaluationFixture,
   RecommendationEvaluationResult,
-  RecommendationPolicy,
   RecommendationReport,
   RecommendationScoreBreakdown,
   RecommendationSignalMatch,
@@ -137,12 +131,8 @@ async function evaluateRecommendationFixtures(
   const shouldWrite = args.includes("--write");
   const policy = await loadRecommendationPolicy(projectRoot);
   const fixtures = buildRecommendationFixtures();
-  const results = fixtures.map((fixture) => evaluateFixture(fixture, policy));
-  const evaluationResult: RecommendationEvaluationResult = {
-    schemaVersion: 1,
-    generatedAt: new Date().toISOString(),
-    fixtures: results,
-  };
+  const evaluationResult: RecommendationEvaluationResult =
+    buildRecommendationEvaluationResult(fixtures, policy);
 
   if (shouldWrite) {
     await writeJsonFile(
@@ -152,7 +142,7 @@ async function evaluateRecommendationFixtures(
   }
 
   let hasFailures = false;
-  for (const result of results) {
+  for (const result of evaluationResult.fixtures) {
     console.log(
       `${result.passed ? "PASS" : "FAIL"} ${result.id}: ${result.description}`,
     );
@@ -165,6 +155,22 @@ async function evaluateRecommendationFixtures(
       hasFailures = true;
     }
   }
+
+  const { summary } = evaluationResult;
+  console.log("Summary:");
+  console.log(
+    `  fixtures: ${summary.passedFixtureCount}/${summary.fixtureCount} passed (${summary.failedFixtureCount} failed)`,
+  );
+  console.log(`  evaluated hosts: ${summary.evaluatedHostCount}`);
+  console.log(
+    `  top reason mix: exact=${summary.topReasonCounts.exactStack}, ecosystem=${summary.topReasonCounts.ecosystem}, generic=${summary.topReasonCounts.genericConcern}, none=${summary.topReasonCounts.none}`,
+  );
+  console.log(
+    `  top confidence: medium-or-strong=${summary.topConfidenceCounts.mediumOrStrong}, weak-only=${summary.topConfidenceCounts.weakOnly}, none=${summary.topConfidenceCounts.none}`,
+  );
+  console.log(
+    `  broad fallback tops: ${summary.broadFallbackTopCount}, local-availability tops: ${summary.localAvailabilityTopCount}`,
+  );
 
   return hasFailures ? 1 : 0;
 }
@@ -204,111 +210,6 @@ async function printRecommendationPolicy(
       pretty ? 2 : undefined,
     ),
   );
-}
-
-function evaluateFixture(
-  fixture: RecommendationEvaluationFixture,
-  policy: RecommendationPolicy,
-): RecommendationEvaluationResult["fixtures"][number] {
-  const report = buildRecommendationReport(
-    fixture.catalogEntries,
-    fixture.demandProfile,
-    policy,
-  );
-  const checks = fixture.expectations.flatMap((expectation) =>
-    evaluateExpectation(expectation, report),
-  );
-
-  return {
-    id: fixture.id,
-    description: fixture.description,
-    passed: checks.every((check) => check.passed),
-    checks,
-  };
-}
-
-function evaluateExpectation(
-  expectation: RecommendationEvaluationExpectation,
-  report: RecommendationReport,
-): RecommendationEvaluationCheck[] {
-  const entries = report.topByHost[expectation.host] ?? [];
-  const hostSummary = report.hostSummaries[expectation.host];
-  const bundle = report.suggestedBundles.find(
-    (entry) => entry.host === expectation.host,
-  );
-  const checks: RecommendationEvaluationCheck[] = [];
-
-  checks.push({
-    name: `${expectation.host}-bundle-budget`,
-    passed: Boolean(
-      bundle && bundle.estimatedPromptWeight <= hostSummary.activationBudget,
-    ),
-    details: bundle
-      ? `bundle weight ${bundle.estimatedPromptWeight}/${hostSummary.activationBudget}`
-      : "missing bundle",
-  });
-
-  for (const requiredAssetId of expectation.requiredAssetIds ?? []) {
-    const present = entries.some((entry) => entry.assetId === requiredAssetId);
-    checks.push({
-      name: `${expectation.host}-requires-${requiredAssetId}`,
-      passed: present,
-      details: present ? "present" : `missing from ${expectation.host}`,
-    });
-  }
-
-  for (const requiredKind of expectation.requiredAssetKinds ?? []) {
-    const actualCount = entries.filter(
-      (entry) => entry.assetKind === requiredKind.assetKind,
-    ).length;
-    checks.push({
-      name: `${expectation.host}-kind-${requiredKind.assetKind}`,
-      passed: actualCount >= requiredKind.minimum,
-      details: `found ${actualCount}, required ${requiredKind.minimum}`,
-    });
-  }
-
-  if (expectation.maxPerSourceFamily !== undefined) {
-    const topSourceFamilyCount = Math.max(
-      0,
-      ...Object.values(hostSummary.bySourceFamily),
-    );
-    checks.push({
-      name: `${expectation.host}-source-diversity`,
-      passed: topSourceFamilyCount <= expectation.maxPerSourceFamily,
-      details: `largest source family count ${topSourceFamilyCount}, expected <= ${expectation.maxPerSourceFamily}`,
-    });
-  }
-
-  for (const concern of expectation.requiredConcerns ?? []) {
-    const actualCount = hostSummary.byConcern[concern] ?? 0;
-    checks.push({
-      name: `${expectation.host}-concern-${concern}`,
-      passed: actualCount > 0,
-      details: actualCount > 0 ? `present ${actualCount} times` : "missing",
-    });
-  }
-
-  for (const pair of expectation.rankedAbove ?? []) {
-    const higherRank =
-      entries.find((entry) => entry.assetId === pair.higherAssetId)?.rank ??
-      null;
-    const lowerRank =
-      entries.find((entry) => entry.assetId === pair.lowerAssetId)?.rank ??
-      null;
-    const passed =
-      higherRank !== null && lowerRank !== null && higherRank < lowerRank;
-    checks.push({
-      name: `${expectation.host}-rank-${pair.higherAssetId}-above-${pair.lowerAssetId}`,
-      passed,
-      details:
-        higherRank === null || lowerRank === null
-          ? `missing ranks higher=${higherRank ?? "absent"} lower=${lowerRank ?? "absent"}`
-          : `higher rank ${higherRank}, lower rank ${lowerRank}`,
-    });
-  }
-
-  return checks;
 }
 
 function formatMatchedSignals(matches: RecommendationSignalMatch[]): string {
@@ -357,6 +258,6 @@ function printRecommendHelp(): void {
   console.log(`recommend commands:
   report    Recompute the recommendation report using the external policy (default)
   explain   Explain why an asset ranked for a host
-  evaluate  Run golden recommendation fixtures (use --write to persist results)
+  evaluate  Run golden recommendation fixtures and print quality summary metrics (use --write to persist results)
   policy:print  Print the merged effective policy (--host <host> to scope)`);
 }

--- a/src/recommend/evaluation.ts
+++ b/src/recommend/evaluation.ts
@@ -195,6 +195,7 @@ function evaluateExpectation(
 ): RecommendationEvaluationCheck[] {
   const entries = report.topByHost[expectation.host] ?? [];
   const hostSummary = report.hostSummaries[expectation.host];
+  const activationBudget = hostSummary?.activationBudget ?? 0;
   const bundle = report.suggestedBundles.find(
     (entry) => entry.host === expectation.host,
   );
@@ -202,11 +203,9 @@ function evaluateExpectation(
 
   checks.push({
     name: `${expectation.host}-bundle-budget`,
-    passed: Boolean(
-      bundle && bundle.estimatedPromptWeight <= hostSummary.activationBudget,
-    ),
+    passed: Boolean(bundle && bundle.estimatedPromptWeight <= activationBudget),
     details: bundle
-      ? `bundle weight ${bundle.estimatedPromptWeight}/${hostSummary.activationBudget}`
+      ? `bundle weight ${bundle.estimatedPromptWeight}/${activationBudget}`
       : "missing bundle",
   });
 
@@ -233,7 +232,7 @@ function evaluateExpectation(
   if (expectation.maxPerSourceFamily !== undefined) {
     const topSourceFamilyCount = Math.max(
       0,
-      ...Object.values(hostSummary.bySourceFamily),
+      ...Object.values(hostSummary?.bySourceFamily ?? {}),
     );
     checks.push({
       name: `${expectation.host}-source-diversity`,
@@ -243,7 +242,7 @@ function evaluateExpectation(
   }
 
   for (const concern of expectation.requiredConcerns ?? []) {
-    const actualCount = hostSummary.byConcern[concern] ?? 0;
+    const actualCount = hostSummary?.byConcern?.[concern] ?? 0;
     checks.push({
       name: `${expectation.host}-concern-${concern}`,
       passed: actualCount > 0,

--- a/src/recommend/evaluation.ts
+++ b/src/recommend/evaluation.ts
@@ -1,0 +1,274 @@
+import { buildRecommendationReport } from "./report.js";
+import type {
+  RecommendationEntry,
+  RecommendationEvaluationCheck,
+  RecommendationEvaluationExpectation,
+  RecommendationEvaluationFixture,
+  RecommendationEvaluationFixtureResult,
+  RecommendationEvaluationHostSummary,
+  RecommendationEvaluationResult,
+  RecommendationEvaluationSummary,
+  RecommendationEvaluationTopConfidence,
+  RecommendationPolicy,
+  RecommendationReport,
+} from "../types.js";
+
+/**
+ * Builds a persisted recommendation evaluation result for the provided fixtures.
+ */
+export function buildRecommendationEvaluationResult(
+  fixtures: RecommendationEvaluationFixture[],
+  policy: RecommendationPolicy,
+): RecommendationEvaluationResult {
+  const fixtureResults = fixtures.map((fixture) =>
+    evaluateFixture(fixture, policy),
+  );
+
+  return {
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    summary: buildRecommendationEvaluationSummary(fixtureResults),
+    fixtures: fixtureResults,
+  };
+}
+
+/**
+ * Builds aggregate quality metrics for evaluated fixtures.
+ */
+export function buildRecommendationEvaluationSummary(
+  fixtureResults: RecommendationEvaluationFixtureResult[],
+): RecommendationEvaluationSummary {
+  const hostSummaries = fixtureResults.flatMap(
+    (fixture) => fixture.hostSummaries,
+  );
+  const topReasonCounts: RecommendationEvaluationSummary["topReasonCounts"] = {
+    exactStack: 0,
+    ecosystem: 0,
+    genericConcern: 0,
+    none: 0,
+  };
+  const topConfidenceCounts: RecommendationEvaluationSummary["topConfidenceCounts"] =
+    {
+      mediumOrStrong: 0,
+      weakOnly: 0,
+      none: 0,
+    };
+
+  for (const hostSummary of hostSummaries) {
+    const topReasonBucket = getTopReasonBucket(hostSummary);
+    topReasonCounts[topReasonBucket] += 1;
+
+    if (hostSummary.topConfidence === "medium-or-strong") {
+      topConfidenceCounts.mediumOrStrong += 1;
+    } else if (hostSummary.topConfidence === "weak-only") {
+      topConfidenceCounts.weakOnly += 1;
+    } else {
+      topConfidenceCounts.none += 1;
+    }
+  }
+
+  return {
+    fixtureCount: fixtureResults.length,
+    passedFixtureCount: fixtureResults.filter((fixture) => fixture.passed)
+      .length,
+    failedFixtureCount: fixtureResults.filter((fixture) => !fixture.passed)
+      .length,
+    evaluatedHostCount: hostSummaries.length,
+    topReasonCounts,
+    broadFallbackTopCount: hostSummaries.filter((hostSummary) =>
+      isBroadFallbackTopRecommendation(hostSummary),
+    ).length,
+    localAvailabilityTopCount: hostSummaries.filter(
+      (hostSummary) =>
+        hostSummary.topRecommendationBasis === "local-availability",
+    ).length,
+    topConfidenceCounts,
+  };
+}
+
+function evaluateFixture(
+  fixture: RecommendationEvaluationFixture,
+  policy: RecommendationPolicy,
+): RecommendationEvaluationFixtureResult {
+  const report = buildRecommendationReport(
+    fixture.catalogEntries,
+    fixture.demandProfile,
+    policy,
+  );
+  const checks = fixture.expectations.flatMap((expectation) =>
+    evaluateExpectation(expectation, report),
+  );
+
+  return {
+    id: fixture.id,
+    description: fixture.description,
+    passed: checks.every((check) => check.passed),
+    checks,
+    hostSummaries: buildFixtureHostSummaries(fixture.expectations, report),
+  };
+}
+
+function buildFixtureHostSummaries(
+  expectations: RecommendationEvaluationExpectation[],
+  report: RecommendationReport,
+): RecommendationEvaluationHostSummary[] {
+  const hosts = [
+    ...new Set(expectations.map((expectation) => expectation.host)),
+  ];
+
+  return hosts.map((host) =>
+    buildHostSummary(host, report.topByHost[host] ?? []),
+  );
+}
+
+function buildHostSummary(
+  host: RecommendationEvaluationHostSummary["host"],
+  entries: RecommendationEntry[],
+): RecommendationEvaluationHostSummary {
+  const topEntry = entries[0];
+
+  return {
+    host,
+    topAssetId: topEntry?.assetId ?? null,
+    topReasons: topEntry?.reasons ?? [],
+    topRecommendationBasis: topEntry?.recommendationBasis ?? null,
+    topAvailableLocally: topEntry?.availableLocally ?? false,
+    topConfidence: classifyTopRecommendationConfidence(topEntry),
+    topCoverageTags: topEntry?.coverageTags ?? [],
+  };
+}
+
+/**
+ * Classifies how strong the top recommendation's matched evidence appears.
+ */
+export function classifyTopRecommendationConfidence(
+  entry: RecommendationEntry | undefined,
+): RecommendationEvaluationTopConfidence {
+  if (!entry || entry.matchedSignals.length === 0) {
+    return "none";
+  }
+
+  const hasMediumOrStrongEvidence = entry.matchedSignals.some((match) => {
+    const evidenceCounts = match.evidenceStrengthCounts;
+    return Boolean(
+      (evidenceCounts?.strong ?? 0) > 0 || (evidenceCounts?.medium ?? 0) > 0,
+    );
+  });
+
+  return hasMediumOrStrongEvidence ? "medium-or-strong" : "weak-only";
+}
+
+function getTopReasonBucket(
+  hostSummary: RecommendationEvaluationHostSummary,
+): keyof RecommendationEvaluationSummary["topReasonCounts"] {
+  if (hostSummary.topReasons.includes("fit:exact-stack")) {
+    return "exactStack";
+  }
+
+  if (hostSummary.topReasons.includes("fit:ecosystem")) {
+    return "ecosystem";
+  }
+
+  if (hostSummary.topReasons.includes("fit:generic-concern")) {
+    return "genericConcern";
+  }
+
+  return "none";
+}
+
+function isBroadFallbackTopRecommendation(
+  hostSummary: RecommendationEvaluationHostSummary,
+): boolean {
+  if (!hostSummary.topReasons.includes("coverage-gap-fill")) {
+    return false;
+  }
+
+  return (
+    !hostSummary.topReasons.includes("fit:exact-stack") &&
+    !hostSummary.topReasons.includes("fit:ecosystem")
+  );
+}
+
+function evaluateExpectation(
+  expectation: RecommendationEvaluationExpectation,
+  report: RecommendationReport,
+): RecommendationEvaluationCheck[] {
+  const entries = report.topByHost[expectation.host] ?? [];
+  const hostSummary = report.hostSummaries[expectation.host];
+  const bundle = report.suggestedBundles.find(
+    (entry) => entry.host === expectation.host,
+  );
+  const checks: RecommendationEvaluationCheck[] = [];
+
+  checks.push({
+    name: `${expectation.host}-bundle-budget`,
+    passed: Boolean(
+      bundle && bundle.estimatedPromptWeight <= hostSummary.activationBudget,
+    ),
+    details: bundle
+      ? `bundle weight ${bundle.estimatedPromptWeight}/${hostSummary.activationBudget}`
+      : "missing bundle",
+  });
+
+  for (const requiredAssetId of expectation.requiredAssetIds ?? []) {
+    const present = entries.some((entry) => entry.assetId === requiredAssetId);
+    checks.push({
+      name: `${expectation.host}-requires-${requiredAssetId}`,
+      passed: present,
+      details: present ? "present" : `missing from ${expectation.host}`,
+    });
+  }
+
+  for (const requiredKind of expectation.requiredAssetKinds ?? []) {
+    const actualCount = entries.filter(
+      (entry) => entry.assetKind === requiredKind.assetKind,
+    ).length;
+    checks.push({
+      name: `${expectation.host}-kind-${requiredKind.assetKind}`,
+      passed: actualCount >= requiredKind.minimum,
+      details: `found ${actualCount}, required ${requiredKind.minimum}`,
+    });
+  }
+
+  if (expectation.maxPerSourceFamily !== undefined) {
+    const topSourceFamilyCount = Math.max(
+      0,
+      ...Object.values(hostSummary.bySourceFamily),
+    );
+    checks.push({
+      name: `${expectation.host}-source-diversity`,
+      passed: topSourceFamilyCount <= expectation.maxPerSourceFamily,
+      details: `largest source family count ${topSourceFamilyCount}, expected <= ${expectation.maxPerSourceFamily}`,
+    });
+  }
+
+  for (const concern of expectation.requiredConcerns ?? []) {
+    const actualCount = hostSummary.byConcern[concern] ?? 0;
+    checks.push({
+      name: `${expectation.host}-concern-${concern}`,
+      passed: actualCount > 0,
+      details: actualCount > 0 ? `present ${actualCount} times` : "missing",
+    });
+  }
+
+  for (const pair of expectation.rankedAbove ?? []) {
+    const higherRank =
+      entries.find((entry) => entry.assetId === pair.higherAssetId)?.rank ??
+      null;
+    const lowerRank =
+      entries.find((entry) => entry.assetId === pair.lowerAssetId)?.rank ??
+      null;
+    const passed =
+      higherRank !== null && lowerRank !== null && higherRank < lowerRank;
+    checks.push({
+      name: `${expectation.host}-rank-${pair.higherAssetId}-above-${pair.lowerAssetId}`,
+      passed,
+      details:
+        higherRank === null || lowerRank === null
+          ? `missing ranks higher=${higherRank ?? "absent"} lower=${lowerRank ?? "absent"}`
+          : `higher rank ${higherRank}, lower rank ${lowerRank}`,
+    });
+  }
+
+  return checks;
+}

--- a/src/tests/recommend-evaluation.test.ts
+++ b/src/tests/recommend-evaluation.test.ts
@@ -86,6 +86,15 @@ void test("top recommendation confidence distinguishes medium-or-strong, weak-on
   assert.equal(
     classifyTopRecommendationConfidence(
       createRecommendationEntry({
+        matchedSignals: [],
+      }),
+    ),
+    "none",
+  );
+
+  assert.equal(
+    classifyTopRecommendationConfidence(
+      createRecommendationEntry({
         matchedSignals: [
           {
             signalType: "frameworks",
@@ -96,6 +105,28 @@ void test("top recommendation confidence distinguishes medium-or-strong, weak-on
             evidenceStrengthCounts: {
               strong: 1,
               medium: 0,
+              weak: 0,
+            },
+          },
+        ],
+      }),
+    ),
+    "medium-or-strong",
+  );
+
+  assert.equal(
+    classifyTopRecommendationConfidence(
+      createRecommendationEntry({
+        matchedSignals: [
+          {
+            signalType: "frameworks",
+            term: "fastapi",
+            weight: 4,
+            evidenceCount: 1,
+            weightedEvidenceCount: 2,
+            evidenceStrengthCounts: {
+              strong: 0,
+              medium: 1,
               weak: 0,
             },
           },

--- a/src/tests/recommend-evaluation.test.ts
+++ b/src/tests/recommend-evaluation.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildRecommendationEvaluationSummary,
+  classifyTopRecommendationConfidence,
+} from "../recommend/evaluation.js";
+import type {
+  RecommendationEntry,
+  RecommendationEvaluationFixtureResult,
+} from "../types.js";
+
+void test("recommend evaluation summary tracks top-rank quality signals", () => {
+  const summary = buildRecommendationEvaluationSummary([
+    createFixtureResult({
+      id: "exact-fixture",
+      passed: true,
+      hostSummaries: [
+        {
+          host: "copilot-vscode",
+          topAssetId: "exact-asset",
+          topReasons: ["fit:exact-stack"],
+          topRecommendationBasis: "workspace-fit",
+          topAvailableLocally: false,
+          topConfidence: "medium-or-strong",
+          topCoverageTags: ["integration"],
+        },
+      ],
+    }),
+    createFixtureResult({
+      id: "fallback-fixture",
+      passed: false,
+      hostSummaries: [
+        {
+          host: "cursor",
+          topAssetId: "generic-asset",
+          topReasons: ["fit:generic-concern", "coverage-gap-fill"],
+          topRecommendationBasis: "local-availability",
+          topAvailableLocally: true,
+          topConfidence: "weak-only",
+          topCoverageTags: ["docs"],
+        },
+      ],
+    }),
+    createFixtureResult({
+      id: "empty-fixture",
+      passed: true,
+      hostSummaries: [
+        {
+          host: "zed",
+          topAssetId: null,
+          topReasons: [],
+          topRecommendationBasis: null,
+          topAvailableLocally: false,
+          topConfidence: "none",
+          topCoverageTags: [],
+        },
+      ],
+    }),
+  ]);
+
+  assert.deepEqual(summary, {
+    fixtureCount: 3,
+    passedFixtureCount: 2,
+    failedFixtureCount: 1,
+    evaluatedHostCount: 3,
+    topReasonCounts: {
+      exactStack: 1,
+      ecosystem: 0,
+      genericConcern: 1,
+      none: 1,
+    },
+    broadFallbackTopCount: 1,
+    localAvailabilityTopCount: 1,
+    topConfidenceCounts: {
+      mediumOrStrong: 1,
+      weakOnly: 1,
+      none: 1,
+    },
+  });
+});
+
+void test("top recommendation confidence distinguishes medium-or-strong, weak-only, and none", () => {
+  assert.equal(classifyTopRecommendationConfidence(undefined), "none");
+
+  assert.equal(
+    classifyTopRecommendationConfidence(
+      createRecommendationEntry({
+        matchedSignals: [
+          {
+            signalType: "frameworks",
+            term: "apify",
+            weight: 6,
+            evidenceCount: 1,
+            weightedEvidenceCount: 3,
+            evidenceStrengthCounts: {
+              strong: 1,
+              medium: 0,
+              weak: 0,
+            },
+          },
+        ],
+      }),
+    ),
+    "medium-or-strong",
+  );
+
+  assert.equal(
+    classifyTopRecommendationConfidence(
+      createRecommendationEntry({
+        matchedSignals: [
+          {
+            signalType: "concerns",
+            term: "docs",
+            weight: 1,
+            evidenceCount: 2,
+            weightedEvidenceCount: 1,
+            evidenceStrengthCounts: {
+              strong: 0,
+              medium: 0,
+              weak: 2,
+            },
+          },
+        ],
+      }),
+    ),
+    "weak-only",
+  );
+});
+
+function createFixtureResult(
+  overrides: Partial<RecommendationEvaluationFixtureResult> &
+    Pick<
+      RecommendationEvaluationFixtureResult,
+      "id" | "passed" | "hostSummaries"
+    >,
+): RecommendationEvaluationFixtureResult {
+  return {
+    id: overrides.id,
+    description: overrides.description ?? overrides.id,
+    passed: overrides.passed,
+    checks: overrides.checks ?? [],
+    hostSummaries: overrides.hostSummaries,
+  };
+}
+
+function createRecommendationEntry(
+  overrides: Partial<RecommendationEntry>,
+): RecommendationEntry {
+  return {
+    assetId: overrides.assetId ?? "asset",
+    host: overrides.host ?? "copilot-vscode",
+    rank: overrides.rank ?? 1,
+    score: overrides.score ?? 10,
+    reasons: overrides.reasons ?? [],
+    assetKind: overrides.assetKind,
+    sourceId: overrides.sourceId ?? "fixture-source",
+    sourceFamily: overrides.sourceFamily ?? "fixture",
+    availableLocally: overrides.availableLocally ?? false,
+    recommendationBasis: overrides.recommendationBasis ?? "workspace-fit",
+    contextSizeClass: overrides.contextSizeClass ?? "tiny",
+    estimatedPromptWeight: overrides.estimatedPromptWeight ?? 1,
+    duplicateGroup: overrides.duplicateGroup,
+    selectionStage: "top-by-host",
+    coverageTags: overrides.coverageTags ?? [],
+    taskModes: overrides.taskModes ?? [],
+    matchedSignals: overrides.matchedSignals ?? [],
+    scoreBreakdown: overrides.scoreBreakdown ?? {
+      authority: 0,
+      compatibility: 0,
+      portfolioFit: 0,
+      trust: 0,
+      sourcePriority: 0,
+      demand: 0,
+      hostPreference: 0,
+      coverage: 0,
+      diversity: 0,
+      freshness: 0,
+      costPenalty: 0,
+      riskPenalty: 0,
+      negativePenalty: 0,
+      redundancyPenalty: 0,
+      budgetPenalty: 0,
+      total: 10,
+    },
+  };
+}

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -294,15 +294,66 @@ export interface RecommendationEvaluationCheck {
 }
 
 /**
+ * Describes top-recommendation confidence classes surfaced by fixture evaluation.
+ */
+export type RecommendationEvaluationTopConfidence =
+  | "medium-or-strong"
+  | "weak-only"
+  | "none";
+
+/**
+ * Describes the top recommendation observed for one evaluated host.
+ */
+export interface RecommendationEvaluationHostSummary {
+  host: HostTarget;
+  topAssetId: string | null;
+  topReasons: string[];
+  topRecommendationBasis: RecommendationBasis | null;
+  topAvailableLocally: boolean;
+  topConfidence: RecommendationEvaluationTopConfidence;
+  topCoverageTags: string[];
+}
+
+/**
+ * Describes one evaluated fixture result.
+ */
+export interface RecommendationEvaluationFixtureResult {
+  id: string;
+  description: string;
+  passed: boolean;
+  checks: RecommendationEvaluationCheck[];
+  hostSummaries: RecommendationEvaluationHostSummary[];
+}
+
+/**
+ * Describes aggregate quality metrics for the recommendation evaluation suite.
+ */
+export interface RecommendationEvaluationSummary {
+  fixtureCount: number;
+  passedFixtureCount: number;
+  failedFixtureCount: number;
+  evaluatedHostCount: number;
+  topReasonCounts: {
+    exactStack: number;
+    ecosystem: number;
+    genericConcern: number;
+    none: number;
+  };
+  broadFallbackTopCount: number;
+  localAvailabilityTopCount: number;
+  topConfidenceCounts: {
+    mediumOrStrong: number;
+    weakOnly: number;
+    none: number;
+  };
+}
+
+/**
  * Describes recommendation evaluation result data exchanged by the lifecycle pipeline.
  */
 export interface RecommendationEvaluationResult {
   schemaVersion: number;
   generatedAt: string;
-  fixtures: Array<{
-    id: string;
-    description: string;
-    passed: boolean;
-    checks: RecommendationEvaluationCheck[];
-  }>;
+  summary: RecommendationEvaluationSummary;
+  fixtures: RecommendationEvaluationFixtureResult[];
 }


### PR DESCRIPTION
## Summary
- add a dedicated recommendation evaluation module with persisted fixture/host quality summaries
- make recommend evaluating print aggregate top-rank reason/confidence/fallback metrics instead of only pass/fail output
- document the layered confidence model and evaluation summary semantics in the README and changelog

## Testing
- npm run format:check
- npm run build
- node --test dist/tests/recommend-evaluation.test.js
- npm run validate:recommendations
- npm test

Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `recommend evaluate` command now outputs aggregate quality summary metrics, including top-rank reason mix, confidence composition, broad-fallback frequency, and local-availability frequency.

* **Documentation**
  * README expanded with layered confidence model explanation, output reason class definitions, and guidance for interpreting `recommend evaluate` results as precision-vs-fallback signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->