### PR TITLE
Harden v1.0.3 release audit regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-05-10
+
 ### Added
 
 - structured host-native file payload support so assets can synthesize documented OpenCode, Cursor, Zed, Claude Code, and Pi config surfaces when explicit native payloads are present
@@ -22,6 +24,9 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - active documentation no longer frames primary usage and troubleshooting around removed wrapper binaries instead of the supported `agent-harness` CLI surface
+- AI enrichment validators now accept nullable fingerprint hashes for disabled/skipped artifact fingerprints during explicit opt-out and other non-completed flows
+- Zed and Pi native reset cleanup now removes empty managed parent directories instead of leaving empty host metadata folders behind
+- demand discovery now prioritizes root manifests under scan-budget pressure and ignores `.agent`, `.dart_tool`, and `.specify` metadata directories by default so real-workspace detection is less distorted by tool metadata
 
 ## [1.0.2] - 2026-05-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ar27111994/agent-harness",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Node.js TypeScript CLI for discovering, staging, activating, and wiring reusable AI-agent assets across supported developer hosts.",
   "license": "MIT",
   "author": "ar27111994",

--- a/src/files.ts
+++ b/src/files.ts
@@ -22,6 +22,7 @@ const FILE_STAT_CONCURRENCY = 16;
  * Defines default ignored directory names shared by the lifecycle pipeline.
  */
 export const DEFAULT_IGNORED_DIRECTORY_NAMES = new Set([
+  ".agent",
   ".git",
   ".idea",
   ".next",
@@ -30,8 +31,10 @@ export const DEFAULT_IGNORED_DIRECTORY_NAMES = new Set([
   ".agent-harness",
   ".claude",
   ".cursor",
+  ".dart_tool",
   ".opencode",
   ".pi",
+  ".specify",
   ".zed",
   "activate",
   "build",
@@ -620,6 +623,7 @@ async function collectFilesFromDirectory(
   const collectedFiles: string[] = [];
   const fileEntries: Array<{ entryPath: string; relativeEntryPath: string }> =
     [];
+  const directoryEntries: Array<{ entryPath: string }> = [];
 
   for (const entry of entries) {
     if (telemetry.truncated) {
@@ -645,21 +649,7 @@ async function collectFilesFromDirectory(
         continue;
       }
 
-      if (depth + 1 > budgetOptions.maxDepth) {
-        telemetry.truncationReason ??= "max-depth";
-        continue;
-      }
-
-      const nestedFiles = await collectFilesFromDirectory(
-        rootPath,
-        entryPath,
-        ignoredDirectoryNames,
-        ignorePatterns,
-        budgetOptions,
-        telemetry,
-        depth + 1,
-      );
-      collectedFiles.push(...nestedFiles);
+      directoryEntries.push({ entryPath });
       continue;
     }
 
@@ -711,6 +701,28 @@ async function collectFilesFromDirectory(
     }
 
     collectedFiles.push(fileStat.entryPath);
+  }
+
+  for (const directoryEntry of directoryEntries) {
+    if (telemetry.truncated) {
+      break;
+    }
+
+    if (depth + 1 > budgetOptions.maxDepth) {
+      telemetry.truncationReason ??= "max-depth";
+      continue;
+    }
+
+    const nestedFiles = await collectFilesFromDirectory(
+      rootPath,
+      directoryEntry.entryPath,
+      ignoredDirectoryNames,
+      ignorePatterns,
+      budgetOptions,
+      telemetry,
+      depth + 1,
+    );
+    collectedFiles.push(...nestedFiles);
   }
 
   return collectedFiles;

--- a/src/host-adapters/native-wire.ts
+++ b/src/host-adapters/native-wire.ts
@@ -1,5 +1,5 @@
-import { rename } from "node:fs/promises";
-import { join } from "node:path";
+import { readdir, rename } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 
 import {
   ensureDirectory,
@@ -910,6 +910,7 @@ async function resetNativeHost(
       );
       await removeManagedZedSettings(
         join(workspaceRoot, ".zed", "settings.json"),
+        workspaceRoot,
       );
       return;
     case "claude-code":
@@ -969,6 +970,27 @@ async function resetNativeHost(
       );
       await removeManagedPiSettings(
         join(workspaceRoot, ".pi", "settings.json"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "extensions"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "packages"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "skills"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "prompts"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi"),
+        workspaceRoot,
       );
       return;
   }
@@ -1005,6 +1027,7 @@ async function cleanupFailedNativeHostApply(
       );
       await removeManagedZedSettings(
         join(workspaceRoot, ".zed", "settings.json"),
+        workspaceRoot,
       );
       return;
     case "claude-code":
@@ -1064,6 +1087,27 @@ async function cleanupFailedNativeHostApply(
       );
       await removeManagedPiSettings(
         join(workspaceRoot, ".pi", "settings.json"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "extensions"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "packages"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "skills"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi", "prompts"),
+        workspaceRoot,
+      );
+      await removeEmptyParentDirectories(
+        join(workspaceRoot, ".pi"),
+        workspaceRoot,
       );
       return;
   }
@@ -1229,7 +1273,10 @@ function describeJsonValue(value: unknown): string {
   return value === null ? "null" : typeof value;
 }
 
-async function removeManagedZedSettings(filePath: string): Promise<void> {
+async function removeManagedZedSettings(
+  filePath: string,
+  workspaceRoot: string,
+): Promise<void> {
   const existingValue = await readJsonFileOrNull<unknown>(filePath);
   const settings = asJsonObject(existingValue);
   if (!settings) {
@@ -1248,7 +1295,7 @@ async function removeManagedZedSettings(filePath: string): Promise<void> {
     delete settings.agent;
   }
 
-  await writeOrRemoveJsonFile(filePath, settings);
+  await writeOrRemoveJsonFile(filePath, settings, workspaceRoot);
 }
 
 async function upsertManagedPiSettings(filePath: string): Promise<void> {
@@ -1265,7 +1312,10 @@ async function upsertManagedPiSettings(filePath: string): Promise<void> {
   await writeOrRemoveJsonFile(filePath, settings);
 }
 
-async function removeManagedPiSettings(filePath: string): Promise<void> {
+async function removeManagedPiSettings(
+  filePath: string,
+  workspaceRoot: string,
+): Promise<void> {
   const existingValue = await readJsonFileOrNull<unknown>(filePath);
   const settings = asJsonObject(existingValue);
   if (!settings) {
@@ -1278,19 +1328,54 @@ async function removeManagedPiSettings(filePath: string): Promise<void> {
   ]);
   delete settings.agentHarness;
 
-  await writeOrRemoveJsonFile(filePath, settings);
+  await writeOrRemoveJsonFile(filePath, settings, workspaceRoot);
 }
 
 async function writeOrRemoveJsonFile(
   filePath: string,
   value: JsonObject,
+  cleanupRoot?: string,
 ): Promise<void> {
   if (Object.keys(value).length === 0) {
     await removePath(filePath);
+    if (cleanupRoot) {
+      await removeEmptyParentDirectories(dirname(filePath), cleanupRoot);
+    }
     return;
   }
 
   await writeJsonFile(filePath, value);
+}
+
+async function removeEmptyParentDirectories(
+  startDirectory: string,
+  stopDirectory: string,
+): Promise<void> {
+  const boundary = resolve(stopDirectory);
+  let currentDirectory = resolve(startDirectory);
+
+  while (currentDirectory !== boundary) {
+    let entries: string[];
+    try {
+      entries = await readdir(currentDirectory);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+
+    if (entries.length > 0) {
+      return;
+    }
+
+    await removePath(currentDirectory);
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      return;
+    }
+    currentDirectory = parentDirectory;
+  }
 }
 
 function buildManagedInstructionLines(options: {

--- a/src/host-adapters/native-wire.ts
+++ b/src/host-adapters/native-wire.ts
@@ -1,5 +1,5 @@
-import { readdir, rename } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { readdir, rename, rmdir } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import {
   ensureDirectory,
@@ -1353,6 +1353,16 @@ async function removeEmptyParentDirectories(
 ): Promise<void> {
   const boundary = resolve(stopDirectory);
   let currentDirectory = resolve(startDirectory);
+  const relativeToBoundary = relative(boundary, currentDirectory);
+
+  if (
+    /^(?:\.\.)(?:[\\/]|$)/u.test(relativeToBoundary) ||
+    isAbsolute(relativeToBoundary)
+  ) {
+    throw new Error(
+      `Expected directory '${toPosixPath(currentDirectory)}' to be within cleanup boundary '${toPosixPath(boundary)}'.`,
+    );
+  }
 
   while (currentDirectory !== boundary) {
     let entries: string[];
@@ -1369,7 +1379,20 @@ async function removeEmptyParentDirectories(
       return;
     }
 
-    await removePath(currentDirectory);
+    try {
+      await rmdir(currentDirectory);
+    } catch (error) {
+      const errorCode = (error as NodeJS.ErrnoException).code;
+      if (
+        errorCode === "ENOENT" ||
+        errorCode === "ENOTEMPTY" ||
+        errorCode === "EEXIST"
+      ) {
+        return;
+      }
+      throw error;
+    }
+
     const parentDirectory = dirname(currentDirectory);
     if (parentDirectory === currentDirectory) {
       return;

--- a/src/manifest-validation/discovery.ts
+++ b/src/manifest-validation/discovery.ts
@@ -31,6 +31,14 @@ import {
   SOURCE_KINDS,
 } from "./primitives.js";
 
+function assertNullableString(value: unknown, context: string): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  assertString(value, context);
+}
+
 const DEMAND_EVIDENCE_STRENGTHS = ["strong", "medium", "weak"] as const;
 const HOST_NATIVE_CONFIG_HOST_KEYS = [
   "opencode",
@@ -374,15 +382,13 @@ export function assertAiEnrichmentInput(
     record.fingerprints,
     `${context}.fingerprints`,
   );
-  assertMaybeString(
+  assertNullableString(
     fingerprints.demandProfileSha256,
     `${context}.fingerprints.demandProfileSha256`,
-    false,
   );
-  assertMaybeString(
+  assertNullableString(
     fingerprints.selectedCatalogSha256,
     `${context}.fingerprints.selectedCatalogSha256`,
-    false,
   );
   assertString(
     fingerprints.configSha256,
@@ -503,15 +509,13 @@ export function assertAiEnrichmentReport(
     record.fingerprints,
     `${context}.fingerprints`,
   );
-  assertMaybeString(
+  assertNullableString(
     fingerprints.demandProfileSha256,
     `${context}.fingerprints.demandProfileSha256`,
-    false,
   );
-  assertMaybeString(
+  assertNullableString(
     fingerprints.selectedCatalogSha256,
     `${context}.fingerprints.selectedCatalogSha256`,
-    false,
   );
   assertString(
     fingerprints.configSha256,

--- a/src/tests/ai-enrichment.test.ts
+++ b/src/tests/ai-enrichment.test.ts
@@ -69,6 +69,48 @@ void test("ai enrichment input artifact applies limits and redactions", () => {
   assert.equal(input.fingerprints.configSha256, "config-sha");
 });
 
+void test("ai enrichment validators accept nullable fingerprint hashes", () => {
+  const config = loadRuntimeConfig({
+    HOME: "/home/tester",
+    AGENT_HARNESS_AI_ENRICHMENT_MODE: "manual",
+  }).aiEnrichment;
+  const input = buildAiEnrichmentInputArtifact({
+    config,
+    demandProfile: buildDemandProfile(),
+    demandProfileHash: null,
+    selectedCatalogHash: null,
+    selectedEntries: [],
+    trigger: "after-workspace",
+    explicit: false,
+    interactive: false,
+    ci: false,
+    configHash: "config-sha",
+  });
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    enabled: false,
+    mode: input.mode,
+    trigger: input.trigger,
+    explicit: input.explicit,
+    interactive: input.interactive,
+    ci: input.ci,
+    providerOrigin: input.providerOrigin,
+    model: input.model,
+    status: "skipped" as const,
+    inputSha256: input.fingerprints.inputSha256,
+    fingerprints: {
+      demandProfileSha256: null,
+      selectedCatalogSha256: null,
+      configSha256: input.fingerprints.configSha256,
+    },
+    reason: "AI enrichment was explicitly disabled for this run.",
+  };
+
+  assert.doesNotThrow(() => assertAiEnrichmentInput(input, "input"));
+  assert.doesNotThrow(() => assertAiEnrichmentReport(report, "report"));
+});
+
 void test("explicit ai enrichment writes a disabled artifact when config is missing", async () => {
   const root = await mkdtemp(join(tmpdir(), "agent-harness-ai-enrichment-"));
 

--- a/src/tests/demand-profile.test.ts
+++ b/src/tests/demand-profile.test.ts
@@ -813,6 +813,11 @@ void test("demand profiles ignore agent metadata directories by default", async 
         content:
           "Document deepeval, pytest, pyyaml, and google-genai for AI research workflows.\n",
       },
+      {
+        path: ".dart_tool/some_meta.txt",
+        content:
+          "Ignore kotlin gradle metadata and pytest-like markers from generated files.\n",
+      },
     ]);
 
     const profile = await buildDemandProfile(root);
@@ -820,9 +825,14 @@ void test("demand profiles ignore agent metadata directories by default", async 
     assert.ok(profile.signals.languages.includes("dart"));
     assert.ok(profile.signals.frameworks.includes("flutter"));
     assert.ok(!profile.signals.languages.includes("python"));
+    assert.ok(!profile.signals.languages.includes("kotlin"));
+    assert.ok(!profile.signals.packageManagers.includes("gradle"));
     assert.ok(!profile.signals.tooling.includes("pypi:deepeval"));
     assert.ok(
       !profile.evidence.some((entry) => entry.path.startsWith(".agent/")),
+    );
+    assert.ok(
+      !profile.evidence.some((entry) => entry.path.startsWith(".dart_tool/")),
     );
   } finally {
     await rm(root, { force: true, recursive: true });

--- a/src/tests/demand-profile.test.ts
+++ b/src/tests/demand-profile.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
+import { clearRuntimeConfigForTests } from "../config/runtime.js";
 import {
   getDemandEvidenceStrength,
   shouldInspectFile,
@@ -741,6 +742,87 @@ void test("demand profiles ignore planning templates and keep evidence strength 
       profile.evidence.find((entry) => entry.path === "package.json")
         ?.evidenceStrength,
       "strong",
+    );
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+void test("demand profiles prioritize root manifests before nested docs when scan budgets truncate", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agent-harness-demand-priority-"));
+  const previousMaxBytes = process.env.AGENT_HARNESS_SCAN_MAX_BYTES;
+
+  try {
+    process.env.AGENT_HARNESS_SCAN_MAX_BYTES = "4096";
+    clearRuntimeConfigForTests();
+
+    await writeFixtureFiles(root, [
+      {
+        path: "pubspec.yaml",
+        content:
+          "name: interact_note\ndependencies:\n  flutter:\n    sdk: flutter\n  firebase_core: ^3.0.0\ndev_dependencies:\n  flutter_test:\n    sdk: flutter\n",
+      },
+      {
+        path: "agent-docs/skills/doc-1/SKILL.md",
+        content: `${"# Skill\n"}${"docs \n".repeat(1500)}`,
+      },
+      {
+        path: "agent-docs/skills/doc-2/SKILL.md",
+        content: `${"# Skill\n"}${"research \n".repeat(1500)}`,
+      },
+    ]);
+
+    const profile = await buildDemandProfile(root);
+
+    assert.equal(profile.summary.scanTruncated, true);
+    assert.ok(profile.signals.languages.includes("dart"));
+    assert.ok(profile.signals.frameworks.includes("flutter"));
+    assert.ok(profile.signals.packageManagers.includes("pub"));
+    assert.ok(
+      profile.evidence.some((entry) => entry.path === "pubspec.yaml"),
+      "expected pubspec.yaml evidence to survive truncation",
+    );
+  } finally {
+    if (previousMaxBytes === undefined) {
+      delete process.env.AGENT_HARNESS_SCAN_MAX_BYTES;
+    } else {
+      process.env.AGENT_HARNESS_SCAN_MAX_BYTES = previousMaxBytes;
+    }
+    clearRuntimeConfigForTests();
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+void test("demand profiles ignore agent metadata directories by default", async () => {
+  const root = await mkdtemp(join(tmpdir(), "agent-harness-demand-ignore-"));
+
+  try {
+    await writeFixtureFiles(root, [
+      {
+        path: "pubspec.yaml",
+        content:
+          "name: interact_note\ndependencies:\n  flutter:\n    sdk: flutter\n",
+      },
+      {
+        path: ".agent/skills/python-docs/SKILL.md",
+        content:
+          "# Python docs\nUse deepeval, pytest, and google-genai for AI research workflows.\n",
+      },
+      {
+        path: ".specify/extensions/python-docs/README.md",
+        content:
+          "Document deepeval, pytest, pyyaml, and google-genai for AI research workflows.\n",
+      },
+    ]);
+
+    const profile = await buildDemandProfile(root);
+
+    assert.ok(profile.signals.languages.includes("dart"));
+    assert.ok(profile.signals.frameworks.includes("flutter"));
+    assert.ok(!profile.signals.languages.includes("python"));
+    assert.ok(!profile.signals.tooling.includes("pypi:deepeval"));
+    assert.ok(
+      !profile.evidence.some((entry) => entry.path.startsWith(".agent/")),
     );
   } finally {
     await rm(root, { force: true, recursive: true });

--- a/src/tests/host-adapters.test.ts
+++ b/src/tests/host-adapters.test.ts
@@ -843,6 +843,9 @@ void test("native adapters synthesize structured host config surfaces and reset 
       workspaceRoot: sharedWorkspaceRoot,
       mode: "reset",
     });
+    await assert.rejects(stat(join(sharedWorkspaceRoot, ".zed")), {
+      code: "ENOENT",
+    });
 
     const claudeAdapter = resolveHostAdapter("claude-code");
     assert.ok(claudeAdapter);


### PR DESCRIPTION
## Summary
- fix audit-found AI enrichment artifact validation and native reset cleanup regressions
- prioritize root manifests in demand scanning and ignore more tool-metadata directories by default
- add regression coverage for scan-budget manifest survival and metadata-directory suppression

## Validation
- npm run validate:release
- real host checks (including serial Zed wire/reset verification)
- Gemini-backed discover full --ai-enrich against copied real workspaces

## Follow-up
- Leaves issue #166 open for the remaining real-workspace selection-quality gap on Flutter projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Additional metadata directories (.agent, .dart_tool, .specify) are ignored by default during scans; root manifests are prioritized under scan-budget pressure.

* **Bug Fixes**
  * Native host reset/cleanup now removes empty managed parent directories after cleanup.

* **Tests**
  * Added tests for nullable fingerprint validation and for ignoring metadata directories during scanning.

* **Chores**
  * Release/version updated and changelog entry added.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/agent-harness/pull/167)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->