### PR TITLE
Fix release audit discovery regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - source-sync now reruns finite indexed sources from the beginning on completed passes, evicts entries that disappeared upstream after a fresh complete sync, and keeps append-only cursors resumable for feed-style registries
 - install refresh now blocks ambiguous multi-bundle mirror conflicts instead of silently picking the last seen mirror id, and refresh report validation now checks nested fingerprint/native-install payloads
-- guarded HTTP body timeouts now cancel active readers before surfacing timeout failures, demand-context session intent signals still apply when no demand profile is available, and `discover breadth` now provides a first-class recall-first discovery command for widening the candidate pool before ranking
+- guarded HTTP body timeouts now cancel active readers before surfacing timeout failures, demand-context session intent signals still apply when no demand profile is available, `discover breadth` now provides a first-class recall-first discovery command for widening the candidate pool before ranking, and `stage` is now the clearer preferred lifecycle term with `install` retained as a supported alias
 
 ### Fixed
 
 - JSONL state reads now tolerate ENOENT races during streaming, rethrow non-ENOENT stream failures correctly, and JSONL writes replace existing destinations reliably on Windows while avoiding repeated chunk byte-length rescans
-- discovery catalog generation now buckets indexed entries by source once, trusted-local demand gating no longer lets concern-only phrases reject trusted-local guidance, source-sync avoids pruning indexed entries after transient zero-observation complete runs, and source-utilization fallback coverage matches source kind defaults
-- README and `AGENT-SETUP-PLAYBOOK.md` now consistently mark lifecycle artifact paths as state-root-relative and distinguish state-root lifecycle output from workspace-local host files
-- added scenario-specific playbooks for discovery breadth, AI enrichment, asset refresh/update, and recommendation policy tuning so both manual setup and agent-operated setup can follow the same verified workflows
+- discovery catalog generation now buckets indexed entries by source once, avoids stack-overflowing on very large indexed source populations, trusted-local demand gating no longer lets concern-only phrases reject trusted-local guidance, source-sync avoids pruning indexed entries after transient zero-observation complete runs, and source-utilization fallback coverage matches source kind defaults
+- README and `AGENT-SETUP-PLAYBOOK.md` now consistently mark lifecycle artifact paths as state-root-relative, distinguish state-root lifecycle output from workspace-local host files, and clarify the real lifecycle ordering plus the bounded meaning of the stage/install phase
+- added scenario-specific playbooks for discovery breadth, AI enrichment, asset refresh/update, and recommendation policy tuning so both manual setup and agent-operated setup can follow the same verified workflows, and the workspace pipeline now runs indexed discovery sync before catalog/recommendation so one-shot host flows use the same broadened discovery universe
 - `.env.example` keeps install refresh policy comments adjacent to the policy key, recommendation-report coverage now documents validator defaulting side effects, and install refresh due-only coverage asserts the persisted schedule state is left untouched when a run is skipped
 
 ## [1.0.3] - 2026-05-10

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ It is built around one generic command surface and a host-adapter model. The lif
 1. Scans a target workspace to infer demand signals.
 2. Loads configured and generated discovery sources.
 3. Harvests candidate agent assets from local sources, source packs, documentation sources, package registries, and marketplace references.
-4. Mirrors selected assets into reproducible local artifacts.
-5. Installs mirrored assets into lifecycle-host package stores.
-6. Executes explicit host-native install/verify/remove operations where an adapter supports them.
-7. Recomputes ranked recommendations from selected catalog entries.
+4. Recomputes ranked recommendations from selected catalog entries.
+5. Mirrors the bounded selected asset set into reproducible local artifacts.
+6. Stages mirrored bundle assets into lifecycle-host package stores.
+7. Executes explicit host-native install/verify/remove operations where an adapter supports them.
 8. Activates ranked assets into host runtime views.
 9. Wires the activated assets into a target workspace through a selected host adapter.
 
@@ -59,15 +59,17 @@ The goal is to make high-quality reusable agent context portable across tools wi
 
 The project intentionally separates these stages:
 
-| Stage       | Purpose                                                                                              | Typical output                                      |
-| ----------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `discover`  | Build demand profiles, source indexes, catalogs, selections, and source-utilization reports.         | `discover/output/`, `discover/catalog.assets.jsonl` |
-| `mirror`    | Build mirror plans, bundle locks, raw artifact caches, quarantine data, and audit records.           | `mirror/`                                           |
-| `install`   | Stage mirrored packages, reconcile generations, and explicitly run supported host-native installers. | `install/`, `state/install/`                        |
-| `recommend` | Rank assets per recommendation host using policy, demand signals, trust, cost, diversity, and caps.  | `state/recommendations.json`                        |
-| `activate`  | Materialize active runtime views for lifecycle hosts from installed packages and recommendations.    | `activate/`                                         |
-| `wire`      | Preview by default, or explicitly apply/reset host-specific workspace integration.                   | host-specific files plus wire plans                 |
-| `workspace` | Run the end-to-end lifecycle for a selected host and then apply wire-in.                             | full pipeline output                                |
+| Stage       | Purpose                                                                                                 | Typical output                                      |
+| ----------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `discover`  | Build demand profiles, source indexes, catalogs, selections, and source-utilization reports.            | `discover/output/`, `discover/catalog.assets.jsonl` |
+| `recommend` | Rank assets per recommendation host using policy, demand signals, trust, cost, diversity, and caps.     | `state/recommendations.json`                        |
+| `mirror`    | Build mirror plans, bundle locks, raw artifact caches, quarantine data, and audit records.              | `mirror/`                                           |
+| `stage`     | Stage mirrored bundle assets, reconcile generations, and explicitly run supported host-native installs. | `install/`, `state/install/`                        |
+| `activate`  | Materialize active runtime views for lifecycle hosts from staged packages and recommendations.          | `activate/`                                         |
+| `wire`      | Preview by default, or explicitly apply/reset host-specific workspace integration.                      | host-specific files plus wire plans                 |
+| `workspace` | Run the end-to-end lifecycle for a selected host and then apply wire-in.                                | full pipeline output                                |
+
+`stage` is the clearer mental model for this phase: the harness stages a bounded mirrored bundle subset into its managed lifecycle store. The CLI still accepts `install` as an alias because host-native install/verify/remove operations also live in that command group.
 
 Two host concepts are important:
 
@@ -457,7 +459,7 @@ agent-harness quarantine reject --asset <asset-id> --reason "unsafe prompt or ex
 
 Mirror acquisition routes high-risk or prompt-injection-like community assets into quarantine. Install and activation skip quarantined assets until an explicit review approves them as `approved-with-warning`.
 
-### Install
+### Stage / install
 
 ```bash
 npm run install:bundle
@@ -467,16 +469,16 @@ node ./dist/cli.js install native --host vscode --operation install --apply
 node ./dist/cli.js install native --host vscode --operation remove --apply
 node ./dist/cli.js install native --host cursor
 node ./dist/cli.js install native --host cursor --operation verify
-node ./dist/cli.js install refresh --host copilot-vscode
-node ./dist/cli.js install refresh --host copilot-vscode --apply
-node ./dist/cli.js install refresh --host copilot-vscode --due-only
+node ./dist/cli.js stage refresh --host copilot-vscode
+node ./dist/cli.js stage refresh --host copilot-vscode --apply
+node ./dist/cli.js stage refresh --host copilot-vscode --due-only
 npm run install:reconcile
 npm run install:reset
 ```
 
-`install native` plans by default. Mutating install/remove operations require `--apply`; verify is non-mutating. VS Code and Cursor extension assets are installed through adapter-owned VS Code-style extension providers and results are written to `state/install/native-extensions.json`.
+`stage` is the preferred lifecycle term here: the harness stages a bounded mirrored bundle subset into its managed store, while `install native` remains the explicit host-facing install boundary. Mutating install/remove operations require `--apply`; verify is non-mutating. VS Code and Cursor extension assets are installed through adapter-owned VS Code-style extension providers and results are written to `state/install/native-extensions.json`.
 
-`install refresh` writes `state/install/refresh-report.json`, persists schedule/checkpoint metadata in `state/install/refresh-state.json`, compares the installed upstream fingerprint stamped into each install manifest against the latest bundle-lock mirror, and can apply safe staged refreshes when `AGENT_HARNESS_INSTALL_REFRESH_POLICY=apply-safe` and `--apply` are both used. `--due-only` makes the command suitable for cron/background checks by skipping runs until the configured refresh interval is due. When stale VS Code-family extension assets are applied through refresh, the native extension install step is executed too so host-native installs stay in sync with the refreshed bundle state.
+`stage refresh` writes `state/install/refresh-report.json`, persists schedule/checkpoint metadata in `state/install/refresh-state.json`, compares the installed upstream fingerprint stamped into each install manifest against the latest bundle-lock mirror, and can apply safe staged refreshes when `AGENT_HARNESS_INSTALL_REFRESH_POLICY=apply-safe` and `--apply` are both used. `--due-only` makes the command suitable for cron/background checks by skipping runs until the configured refresh interval is due. When stale VS Code-family extension assets are applied through refresh, the native extension install step is executed too so host-native installs stay in sync with the refreshed bundle state. `install refresh` remains a supported alias.
 
 For report-only vs due-only vs apply-safe update workflows, see [`ASSET-UPDATE-PLAYBOOK.md`](./ASSET-UPDATE-PLAYBOOK.md).
 
@@ -548,7 +550,7 @@ npm run wire:pi
 
 ### Workspace
 
-Workspace commands run discover, mirror, install, activate, and wire-in for the selected adapter:
+Workspace commands run discover, recommend, mirror, stage, activate, and wire-in for the selected adapter:
 
 ```bash
 agent-harness workspace vscode --intent frontend
@@ -579,7 +581,7 @@ npm run rebuild:clean
 npm run rebuild:full
 ```
 
-`rebuild:full` runs the clean, discovery, mirror, install, reconcile, recommendation, and activation flow from repository state.
+`rebuild:full` runs the clean, discovery, recommendation, mirror, stage/reconcile, and activation flow from repository state.
 
 ## Host wire-in details
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The project intentionally separates these stages:
 
 Two host concepts are important:
 
-- **Lifecycle host**: the install/activation package layout used to materialize assets.
+- **Lifecycle host**: the stage/activation package layout used to materialize assets.
 - **Recommendation host**: the host-specific policy used for ranking and budgets.
 
 Some adapters intentionally reuse another lifecycle host while keeping their own recommendation host. For example, Cursor reuses the Copilot-compatible lifecycle host but ranks through the `cursor` policy.
@@ -216,6 +216,14 @@ Preview output is written under `activate/<host>/` and can be reviewed before `-
 When you want another agent to operate `agent-harness` for you, start with a dry run before any apply/install step. This keeps workspace mutation, extension installation, and MCP/tool authentication separate from discovery and recommendation review.
 
 For the full playbook, reusable prompts, classification rules, and decision tree, see [`AGENT-SETUP-PLAYBOOK.md`](./AGENT-SETUP-PLAYBOOK.md).
+
+Available playbooks:
+
+- [`AGENT-SETUP-PLAYBOOK.md`](./AGENT-SETUP-PLAYBOOK.md) - dry-run setup workflow, decision tree, and reusable agent prompts for workspace/host asset setup
+- [`DISCOVERY-BREADTH-PLAYBOOK.md`](./DISCOVERY-BREADTH-PLAYBOOK.md) - maximize the practical candidate pool before judging recommendation quality
+- [`AI-ENRICHMENT-PLAYBOOK.md`](./AI-ENRICHMENT-PLAYBOOK.md) - choose enrichment modes, bounded AI review, and operator workflows
+- [`ASSET-UPDATE-PLAYBOOK.md`](./ASSET-UPDATE-PLAYBOOK.md) - refresh staged assets safely with report-only, due-only, and apply-safe flows
+- [`RECOMMENDATION-POLICY-PLAYBOOK.md`](./RECOMMENDATION-POLICY-PLAYBOOK.md) - inspect and tune ranking only after recall looks healthy
 
 Short version:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ const HELP_DEFAULT_DOMAINS = new Set([
   "activate",
   "discover",
   "install",
+  "stage",
   "mirror",
   "quarantine",
   "rebuild",
@@ -58,6 +59,7 @@ async function main(): Promise<number> {
     case "mirror":
       return runMirror(args, workingDirectory, projectRoot);
     case "install":
+    case "stage":
       return runInstall(args, workingDirectory, projectRoot);
     case "activate":
       return runActivate(args, workingDirectory, projectRoot);
@@ -114,6 +116,7 @@ function runHelpCommand(
     case "mirror":
       return runMirror(["help"], workingDirectory, "");
     case "install":
+    case "stage":
       return runInstall(["help"], workingDirectory, "");
     case "activate":
       return runActivate(["help"], workingDirectory, "");
@@ -201,11 +204,12 @@ function printHelp(): void {
   discover stats            Print catalog/source stats
   mirror locks             Generate mirror bundle locks
   mirror acquire           Acquire raw mirror artifacts and resolve bundle locks
-  install bundle            Stage installed assets from bundle locks
-  install native            Plan/verify/apply/remove host-native installs
-  install refresh           Refresh mirrored install state and report/apply stale assets
-  install reconcile         Recompute install progress and generations
-  install reset             Remove install state
+  stage bundle              Stage mirrored assets from bundle locks
+  stage native              Plan/verify/apply/remove host-native installs
+  stage refresh             Refresh staged install state and report/apply stale assets
+  stage reconcile           Recompute staged install progress and generations
+  stage reset               Remove staged install state
+  install <...>             Alias for stage <...>
   activate host             Materialize active host views from installed bundles
   activate rollback         Point a host to a previous generation
   activate reset            Remove activation state

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -208,9 +208,12 @@ function printHelp(): void {
   stage native              Plan/verify/apply/remove host-native installs
   stage refresh             Refresh staged install state and report/apply stale assets
   stage reconcile           Recompute staged install progress and generations
+  stage diff                Compare current vs previous or explicit staged generations
+  stage explain             Explain where a staged asset is present and active
+  stage generations         Manage staged generation list, pinning, and pruning
   stage reset               Remove staged install state
   install <...>             Alias for stage <...>
-  activate host             Materialize active host views from installed bundles
+  activate host             Materialize active host views from staged bundles
   activate rollback         Point a host to a previous generation
   activate reset            Remove activation state
   recommend report          Recompute the recommendation report

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -229,51 +229,56 @@ async function generateCatalog(projectRoot: string): Promise<{
 
   for (const source of nonRepoSources) {
     if (indexedSourceIds.has(source.id)) {
-      catalogEntries.push(
-        ...(indexedCatalogEntriesBySourceId.get(source.id) ?? []),
+      appendCatalogEntries(
+        catalogEntries,
+        indexedCatalogEntriesBySourceId.get(source.id) ?? [],
       );
       continue;
     }
 
     switch (source.kind) {
       case "local-manifest":
-        catalogEntries.push(
-          ...(await harvestLocalManifestSource(
+        appendCatalogEntries(
+          catalogEntries,
+          await harvestLocalManifestSource(
             source,
             demandProfile,
             selectionRegistry,
             projectRoot,
-          )),
+          ),
         );
         break;
       case "local-directory":
-        catalogEntries.push(
-          ...(await harvestLocalDirectorySource(
+        appendCatalogEntries(
+          catalogEntries,
+          await harvestLocalDirectorySource(
             source,
             demandProfile,
             selectionRegistry,
             projectRoot,
-          )),
+          ),
         );
         break;
       case "package-registry":
-        catalogEntries.push(
-          ...(await harvestPackageRegistrySource(
+        appendCatalogEntries(
+          catalogEntries,
+          await harvestPackageRegistrySource(
             source,
             demandProfile,
             selectionRegistry,
-          )),
+          ),
         );
         break;
       case "docs":
       case "marketplace":
       case "registry":
-        catalogEntries.push(
-          ...(await harvestReferenceSource(
+        appendCatalogEntries(
+          catalogEntries,
+          await harvestReferenceSource(
             source,
             demandProfile,
             selectionRegistry,
-          )),
+          ),
         );
         break;
       default:
@@ -289,13 +294,14 @@ async function generateCatalog(projectRoot: string): Promise<{
 
   for (const source of repoSlice) {
     if (isGitHubRepoSource(source)) {
-      harvestedRepoEntries.push(
-        ...(await harvestGitHubRepoSource(
+      appendCatalogEntries(
+        harvestedRepoEntries,
+        await harvestGitHubRepoSource(
           source,
           demandProfile,
           selectionRegistry,
           projectRoot,
-        )),
+        ),
       );
     }
   }
@@ -311,14 +317,15 @@ async function generateCatalog(projectRoot: string): Promise<{
     mergedRemoteCatalogEntries,
   );
 
-  catalogEntries.push(...mergedRemoteCatalogEntries);
+  appendCatalogEntries(catalogEntries, mergedRemoteCatalogEntries);
 
-  catalogEntries.push(
-    ...(await harvestOfficialSkillIndexes(
+  appendCatalogEntries(
+    catalogEntries,
+    await harvestOfficialSkillIndexes(
       projectRoot,
       demandProfile,
       selectionRegistry,
-    )),
+    ),
   );
 
   const sortedEntries = [
@@ -353,6 +360,15 @@ async function generateCatalog(projectRoot: string): Promise<{
     enabledSources,
     sourceSyncState,
   };
+}
+
+function appendCatalogEntries(
+  target: AssetCatalogEntry[],
+  entries: readonly AssetCatalogEntry[],
+): void {
+  for (const entry of entries) {
+    target.push(entry);
+  }
 }
 
 async function generateSelectionOutputs(projectRoot: string): Promise<{
@@ -496,8 +512,9 @@ async function runDiscoveryBreadth(
     workingDirectory,
     projectRoot,
   );
-  const sourceIndex = await generateSourceIndex(projectRoot);
+  await generateSourceIndex(projectRoot);
   await syncIndexedSources(projectRoot);
+  const sourceIndex = await generateSourceIndex(projectRoot);
   const { catalogEntries, enabledSources } = await generateCatalog(projectRoot);
   const { selectionReport } = await generateSelectionOutputs(projectRoot);
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -512,7 +512,6 @@ async function runDiscoveryBreadth(
     workingDirectory,
     projectRoot,
   );
-  await generateSourceIndex(projectRoot);
   await syncIndexedSources(projectRoot);
   const sourceIndex = await generateSourceIndex(projectRoot);
   const { catalogEntries, enabledSources } = await generateCatalog(projectRoot);

--- a/src/install.ts
+++ b/src/install.ts
@@ -53,15 +53,15 @@ export async function runInstall(
 }
 
 function printInstallHelp(): void {
-  console.log(`install commands:
-  bundle      Stage installed assets from mirror bundle locks
+  console.log(`stage commands (install is a supported alias):
+  bundle      Stage mirrored assets from mirror bundle locks
   native      Plan/verify/apply/remove host-native installs
-  refresh     Refresh mirrored install state and report/apply stale assets
-  reconcile   Recompute install progress from bundle install manifests
+  refresh     Refresh staged install state and report/apply stale assets
+  reconcile   Recompute staged install progress from bundle install manifests
   diff        Compare current vs previous or explicit install generations
-  explain     Explain where an installed asset is present and active
+  explain     Explain where a staged asset is present and active
   generations Manage generation list, pinning, and pruning
-  reset       Remove install state, packages, bundles, and generations
+  reset       Remove staged install state, packages, bundles, and generations
 
 Native install options:
   --host <vscode|opencode|cursor|zed|claude-code|pi>

--- a/src/install.ts
+++ b/src/install.ts
@@ -68,7 +68,7 @@ Native install options:
   --operation <plan|install|verify|remove>
   --apply     Required for mutating install/remove operations
 
-Install refresh options:
+Stage refresh options:
   --host <copilot-vscode|opencode|shared>
   --apply     Apply eligible stale bundle refreshes after reporting
   --due-only  Skip the run unless the persisted refresh interval says a check is due

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -47,6 +47,7 @@ export async function runWorkspacePipeline(options: {
   await runDiscover(["demand-profile"], workspaceRoot, projectRoot);
   await runDiscover(["sources"], workspaceRoot, projectRoot);
   await runDiscover(["sync"], workspaceRoot, projectRoot);
+  await runDiscover(["sources"], workspaceRoot, projectRoot);
   await runDiscover(["catalog"], workspaceRoot, projectRoot);
   await runDiscover(["select"], workspaceRoot, projectRoot);
   await runRecommend(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -20,8 +20,9 @@ const MIRROR_ACQUIRE_STATE_PATH = ["state", "mirror", "acquire-state.json"];
 const INSTALL_PROGRESS_STATE_PATH = ["state", "install", "progress.json"];
 
 /**
- * Runs discover, mirror, install, activation, and shared activation phases for
- * a workspace before the selected adapter performs final wire-in.
+ * Runs discover, recommendation, mirror, stage/install, activation, and shared
+ * activation phases for a workspace before the selected adapter performs final
+ * wire-in.
  */
 export async function runWorkspacePipeline(options: {
   projectRoot: string;
@@ -45,6 +46,7 @@ export async function runWorkspacePipeline(options: {
 
   await runDiscover(["demand-profile"], workspaceRoot, projectRoot);
   await runDiscover(["sources"], workspaceRoot, projectRoot);
+  await runDiscover(["sync"], workspaceRoot, projectRoot);
   await runDiscover(["catalog"], workspaceRoot, projectRoot);
   await runDiscover(["select"], workspaceRoot, projectRoot);
   await runRecommend(

--- a/src/tests/cli-help.test.ts
+++ b/src/tests/cli-help.test.ts
@@ -71,6 +71,26 @@ void test("subcommand --help exits without preparing state", async () => {
     );
 
     assert.match(directGroupHelpStdout, /discover commands:/u);
+
+    const { stdout: stageHelpStdout } = await execFileAsync(
+      process.execPath,
+      [cliPath, "--no-dotenv", "--state-root", stateRoot, "help", "stage"],
+      {
+        cwd: workspaceRoot,
+        env: process.env,
+        timeout: 30_000,
+        windowsHide: true,
+      },
+    );
+
+    assert.match(
+      stageHelpStdout,
+      /stage commands \(install is a supported alias\):/u,
+    );
+    assert.match(
+      stageHelpStdout,
+      /bundle\s+Stage mirrored assets from mirror bundle locks/u,
+    );
     assert.equal(existsSync(stateRoot), false);
   } finally {
     await rm(tempRoot, { force: true, recursive: true });

--- a/src/tests/discover-breadth.test.ts
+++ b/src/tests/discover-breadth.test.ts
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
 
-import { writeJsonFile } from "../files.js";
+import { writeJsonFile, writeJsonLinesFile } from "../files.js";
+import {
+  CATALOG_OUTPUT_PATH,
+  SOURCE_SYNC_ENTRIES_OUTPUT_PATH,
+  SOURCE_SYNC_STATE_OUTPUT_PATH,
+} from "../domains/discovery/output-paths.js";
 import { runDiscover } from "../discover.js";
 
 void test("discover breadth runs the full breadth workflow and prints guidance", async () => {
@@ -123,6 +128,163 @@ void test("discover breadth runs the full breadth workflow and prints guidance",
     await rm(tempRoot, { force: true, recursive: true });
   }
 });
+
+void test("discover catalog handles large indexed source populations without overflowing the stack", async () => {
+  const tempRoot = await mkdtemp(
+    join(tmpdir(), "agent-harness-discover-catalog-"),
+  );
+  const workspaceRoot = join(tempRoot, "workspace");
+  const stateRoot = join(tempRoot, "state");
+  const indexedEntryCount = 120_000;
+
+  try {
+    await mkdir(workspaceRoot, { recursive: true });
+    await mkdir(stateRoot, { recursive: true });
+    await writeJsonFile(join(stateRoot, "discover", "sources.json"), {
+      schemaVersion: 1,
+      sources: [
+        {
+          id: "huge-indexed-source",
+          name: "huge-indexed-source",
+          kind: "registry",
+          authorityTier: "official-compatible",
+          publisher: { name: "fixture", verified: true },
+          hosts: ["copilot-vscode"],
+          assetKinds: ["skill"],
+          discoveryMode: "catalog",
+          priority: 100,
+          enabled: true,
+          endpoints: { baseUrl: "https://example.com/registry" },
+          rules: {
+            officialPreferred: true,
+            allowMirror: true,
+            allowInstall: true,
+          },
+        },
+      ],
+    });
+    await writeJsonFile(join(stateRoot, "discover", "selections.json"), {
+      schemaVersion: 1,
+      selectionPolicies: {
+        officialBeatsPopularity: true,
+        starsAreTieBreakerOnly: true,
+        preferNativeOverAdaptable: true,
+        preferLowerRiskWhenEquivalent: true,
+        preferLowerContextCostWhenEquivalent: true,
+        communityDefaultPolicy: "catalog-only-unless-promoted",
+      },
+      rankingOrder: [],
+      duplicateGroups: [],
+    });
+    await writeJsonFile(join(stateRoot, ...SOURCE_SYNC_STATE_OUTPUT_PATH), {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      sources: [
+        {
+          sourceId: "huge-indexed-source",
+          coverageMode: "indexed",
+          status: "complete",
+          indexedEntryCount,
+          lastSyncedAt: new Date().toISOString(),
+          cursors: [],
+        },
+      ],
+    });
+    await writeJsonLinesFile(
+      join(stateRoot, ...SOURCE_SYNC_ENTRIES_OUTPUT_PATH),
+      Array.from({ length: indexedEntryCount }, (_, index) =>
+        createIndexedCatalogEntry(index),
+      ),
+    );
+
+    assert.equal(await runDiscover(["catalog"], workspaceRoot, stateRoot), 0);
+
+    const catalogEntries = await readCatalogEntryIds(
+      join(stateRoot, ...CATALOG_OUTPUT_PATH),
+    );
+    assert.equal(catalogEntries.length, indexedEntryCount);
+    assert.equal(catalogEntries[0], "huge-indexed-source/asset-0");
+    assert.ok(
+      catalogEntries.includes(
+        `huge-indexed-source/asset-${indexedEntryCount - 1}`,
+      ),
+    );
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+async function readCatalogEntryIds(filePath: string): Promise<string[]> {
+  const content = await readFile(filePath, "utf8");
+  return content
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as { id: string })
+    .map((entry) => entry.id);
+}
+
+function createIndexedCatalogEntry(index: number): Record<string, unknown> {
+  return {
+    id: `huge-indexed-source/asset-${index}`,
+    displayName: `asset-${index}`,
+    assetKind: "skill",
+    hosts: ["copilot-vscode"],
+    compatibilityMode: "native",
+    source: {
+      sourceId: "huge-indexed-source",
+      sourceKind: "registry",
+      authorityTier: "official-compatible",
+      sourcePriority: 100,
+      originUrl: `https://example.com/registry/asset-${index}`,
+      publisher: "fixture",
+      publisherVerified: true,
+    },
+    trust: {
+      score: 100,
+      signals: ["fixture"],
+    },
+    capabilities: ["typescript", "testing", `asset-${index}`],
+    install: {
+      method: "registry",
+      nativeHosts: ["copilot-vscode"],
+    },
+    evidence: {
+      manifestFound: true,
+      readmeFound: true,
+      examplesFound: false,
+      docsLinked: true,
+    },
+    maintenance: {
+      lastUpdated: "2026-05-11T00:00:00.000Z",
+      stars: 0,
+      releaseCadence: "active",
+    },
+    risk: {
+      level: "low",
+      hasHooks: false,
+      hasExecScripts: false,
+      requiresNetwork: false,
+    },
+    contextCost: {
+      sizeClass: "small",
+      estimatedPromptWeight: 1,
+    },
+    fit: {
+      portfolioFit: 0.9,
+      hostFit: 0.9,
+    },
+    dedupe: {
+      candidateRankHint: "fixture",
+    },
+    status: {
+      cataloged: true,
+      mirrorEligible: true,
+      installEligible: true,
+      activationEligible: true,
+    },
+  };
+}
 
 async function writeText(filePath: string, content: string): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true });

--- a/src/tests/workspace-smoke.ts
+++ b/src/tests/workspace-smoke.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { clearRuntimeConfig } from "../config/runtime.js";
 import {
+  pathExists,
   readJsonFileOrNull,
   readJsonLinesFile,
   writeJsonFile,
@@ -114,6 +115,14 @@ try {
       sessionIntent: "testing",
       bundleIds: adapter.defaultBundleIds,
     });
+
+    if (
+      !(await pathExists(
+        join(stateRoot, "discover", "output", "source-sync.json"),
+      ))
+    ) {
+      throw new Error(`[${host}] source-sync report missing after pipeline`);
+    }
 
     // Assert mirror acquire state consistency
     const acquireState = await readJsonFileOrNull<MirrorAcquireState>(

--- a/src/tests/workspace-smoke.ts
+++ b/src/tests/workspace-smoke.ts
@@ -107,6 +107,14 @@ try {
       throw new Error(`Unknown workspace smoke host: ${host}`);
     }
 
+    const sourceSyncReportPath = join(
+      stateRoot,
+      "discover",
+      "output",
+      "source-sync.json",
+    );
+    await removePath(sourceSyncReportPath);
+
     await runWorkspacePipeline({
       projectRoot: stateRoot,
       workspaceRoot,
@@ -116,11 +124,7 @@ try {
       bundleIds: adapter.defaultBundleIds,
     });
 
-    if (
-      !(await pathExists(
-        join(stateRoot, "discover", "output", "source-sync.json"),
-      ))
-    ) {
+    if (!(await pathExists(sourceSyncReportPath))) {
       throw new Error(`[${host}] source-sync report missing after pipeline`);
     }
 


### PR DESCRIPTION
# Fix release audit discovery regressions

## Summary

This PR closes the concrete release-audit blockers found after PR #173 merged by making the discovery pipeline safer at real workspace scale and by aligning lifecycle wording with how the CLI actually behaves.

Closes #174
Closes #175
Closes #176
Closes #177

## Background

Latest-`main` release auditing exposed three real issues:

1. docs/help still implied the wrong lifecycle order and used `install` in ways that suggested catalog-wide installation rather than bounded harness-managed staging
2. `workspace` flows skipped `discover sync`, so one-shot pipeline runs did not use the same indexed discovery universe as explicit breadth audits
3. large indexed catalogs from real workspaces (~450k entries) could crash in `discover catalog` with `RangeError: Maximum call stack size exceeded`

While validating those fixes, `discover breadth` also turned out to print a stale indexed-source count because it reused the pre-sync source index for its final summary.

## Changes

- introduced `stage` as the clearer preferred lifecycle term in docs/help while keeping `install` as a supported alias for compatibility and host-native install operations
- updated workspace pipeline execution to run `discover sync` before catalog/recommendation generation
- replaced stack-unsafe spread-based catalog appends with stack-safe iterative appends in `src/discover.ts`
- regenerated source-index after sync inside `discover breadth` so indexed-source counts reflect post-sync reality
- updated README/lifecycle wording and added regression coverage for:
  - stage/install help output
  - large indexed catalog generation
  - workspace pipeline source-sync execution

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `node --test dist/tests/cli-help.test.js dist/tests/discover-breadth.test.js`
- `npm run smoke:workspace`
- `npm run validate && npm test`
- `npm run validate:release`
- `npm pack --dry-run`
- `node .\dist\cli.js setup doctor --host vscode`
- `node .\dist\cli.js setup doctor --host cursor`
- `node .\dist\cli.js setup doctor --host opencode`
- `node .\dist\cli.js setup doctor --host zed`
- `node .\dist\cli.js setup doctor --host claude-code`
- `node .\dist\cli.js setup doctor --host pi`
- real-workspace breadth reruns:
  - `C:\Projects\agent-harness`
  - `C:\Projects\InterActNote`
  - `C:\Projects\Apify\Webhook Debugger and Logger`

- [x] I ran `npm run validate` for code/config/doc changes.
- [x] I ran `npm run validate:release` for release, packaging, lifecycle, host adapter, or supply-chain changes.
- [x] I documented any intentionally skipped checks and why.

## Documentation Impact

- README lifecycle wording now reflects the real order: discover -> recommend -> mirror -> stage/install -> activate -> wire
- CLI/install help now teaches `stage` as the preferred operator term
- CHANGELOG unreleased notes cover the audit-driven fixes

## Additional Notes

- Real-workspace breadth reruns that previously crashed now complete successfully:
  - `agent-harness`: `455503` catalog entries
  - `InterActNote`: `454477` catalog entries
  - `Webhook Debugger and Logger`: `454589` catalog entries
- Host doctor checks passed for VS Code, OpenCode, Zed, and Pi.
- Cursor and Claude Code still report environment-limited warnings on this machine because their CLIs are not on PATH; no code failure was observed in those adapters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stage` command as the preferred lifecycle phase; `install` remains a supported alias.

* **Changed**
  * Updated documentation and CLI help text to use `stage` terminology throughout.
  * Refined workspace pipeline sequence to reorder recommendation, staging, and installation phases.

* **Improvements**
  * Enhanced JSONL state streaming robustness and discovery catalog generation reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/agent-harness/pull/178)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->