### PR TITLE
Clarify single-intent CLI usage

### DIFF
--- a/AGENT-SETUP-PLAYBOOK.md
+++ b/AGENT-SETUP-PLAYBOOK.md
@@ -19,11 +19,13 @@ Use this playbook when:
 
 - recommendations look noisy or surprising
 - you want help choosing a host (`vscode`, `cursor`, `opencode`, `zed`, `claude-code`, `pi`)
-- you want setup help for one or more intents such as `frontend`, `backend`, or `docs`
+- you want setup help for a primary intent such as `frontend`, `backend`, or `docs`
 - you want an agent to guide setup without immediately mutating your workspace or global host config
 - you want a clean separation between staged/wired assets and native/manual installation steps
 
 If your first question is "how do I give recommendations the widest sensible candidate pool?", start with [`DISCOVERY-BREADTH-PLAYBOOK.md`](./DISCOVERY-BREADTH-PLAYBOOK.md) and then return to this playbook for dry-run setup/apply decisions.
+
+`--intent` is a single-value option throughout the CLI. Pick one primary intent per run; if you want to compare `frontend` vs `docs` vs `product`, rerun the command once per intent instead of passing a list.
 
 ## Dry-run workflow
 
@@ -240,7 +242,7 @@ You are setting up agent assets for this workspace with agent-harness.
 
 Workspace root: <workspace-path>
 Host: <vscode|cursor|opencode|zed|claude-code|pi>
-Intent(s): <optional intent list such as frontend, backend, docs>
+Intent: <optional primary intent such as frontend, backend, or docs>
 
 Use agent-harness as the source of truth and do a dry run first.
 
@@ -285,7 +287,7 @@ When ready, give me:
 
 ```text
 Proceed with the approved agent-harness setup plan for this workspace.
-Use the same workspace root, host, and intents we already reviewed.
+Use the same workspace root, host, and primary intent we already reviewed.
 
 Rules:
 - Apply wire changes only after confirming the preview still matches.

--- a/AI-ENRICHMENT-PLAYBOOK.md
+++ b/AI-ENRICHMENT-PLAYBOOK.md
@@ -139,7 +139,7 @@ You are using agent-harness to configure and review the optional AI-assisted sta
 
 Workspace root: <workspace-path>
 Host: <vscode|cursor|opencode|zed|claude-code|pi>
-Intent(s): <optional intent list>
+Intent: <optional primary intent>
 
 Goals:
 1. Keep deterministic discovery/recommendation as the baseline.

--- a/DISCOVERY-BREADTH-PLAYBOOK.md
+++ b/DISCOVERY-BREADTH-PLAYBOOK.md
@@ -161,7 +161,7 @@ You are using agent-harness to maximize the practical candidate asset pool for t
 
 Workspace root: <workspace-path>
 Host: <vscode|cursor|opencode|zed|claude-code|pi>
-Intent(s): <optional intent list>
+Intent: <optional primary intent>
 
 Goals:
 1. Verify that demand detection sees the real workspace.
@@ -173,7 +173,7 @@ Required workflow:
 - Run `agent-harness setup doctor --host <host>`.
 - Run `agent-harness discover breadth`.
 - Run `agent-harness discover stats`.
-- Run `agent-harness recommend report --intent <intent>` when an intent is provided.
+- Run `agent-harness recommend report --intent <intent>` when a primary intent is provided.
 - Inspect these files when they exist, relative to the active state root:
   - `discover/output/demand-profile.json`
   - `discover/output/source-index.json`

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ npm run workspace:pi -- --intent product
 
 Use the adapter-driven `agent-harness workspace <host>` command for end-to-end host setup. Add `--ai-enrich` when you want the bounded enrichment sidecar as part of the same run, or configure `AGENT_HARNESS_AI_ENRICHMENT_MODE` for conservative automatic behavior.
 
-Supported canonical intents are `general`, `frontend`, `backend`, `mobile`, `devops`, `security`, `docs`, `testing`, `research`, `data`, `design`, `product`, and `marketing`. Common aliases are normalized automatically, for example `documentation` → `docs`, `ci-cd` / `infra` → `devops`, `branding` → `design`, and `ba` / `planning` / `product-research` → `product`.
+Supported canonical intents are `general`, `frontend`, `backend`, `mobile`, `devops`, `security`, `docs`, `testing`, `research`, `data`, `design`, `product`, and `marketing`. Common aliases are normalized automatically, for example `documentation` → `docs`, `ci-cd` / `infra` → `devops`, `branding` → `design`, and `ba` / `planning` / `product-research` → `product`. `--intent` is a single-value option: pass exactly one primary intent per run, not a comma-separated or repeated list. If you want to compare multiple task shapes, rerun the command once per intent.
 
 ### Mutable state root
 
@@ -513,7 +513,7 @@ You can also activate one lifecycle host using another recommendation policy:
 node ./dist/cli.js activate host --host copilot-vscode --recommendation-host cursor
 ```
 
-`--recommendation-host` is validated against the supported host set. `--intent` is also validated (`general | frontend | backend | mobile | devops | security | docs | testing | research | data | design | product | marketing`), accepts common aliases such as `documentation`, `ci-cd`, `branding`, and `ba`, and is written into recommendation reports and workspace manifests so downstream activation stays aligned with the requested task shape.
+`--recommendation-host` is validated against the supported host set. `--intent` is also validated (`general | frontend | backend | mobile | devops | security | docs | testing | research | data | design | product | marketing`), accepts common aliases such as `documentation`, `ci-cd`, `branding`, and `ba`, and is written into recommendation reports and workspace manifests so downstream activation stays aligned with the requested task shape. Only one `--intent` value is allowed per command.
 
 ### Wire
 

--- a/RECOMMENDATION-POLICY-PLAYBOOK.md
+++ b/RECOMMENDATION-POLICY-PLAYBOOK.md
@@ -99,7 +99,7 @@ You are using agent-harness to diagnose recommendation quality and justify any r
 
 Workspace root: <workspace-path>
 Host: <vscode|cursor|opencode|zed|claude-code|pi>
-Intent(s): <optional intent list>
+Intent: <optional primary intent>
 
 Goals:
 1. Prove whether the problem is recall or ranking.

--- a/src/activate.ts
+++ b/src/activate.ts
@@ -13,7 +13,7 @@ import {
   writeJsonFile,
 } from "./files.js";
 import { listHostAdapters } from "./host-adapters/registry.js";
-import { getOptionValue } from "./lib/cli-options.js";
+import { getOptionValue, getSingleOptionValue } from "./lib/cli-options.js";
 import {
   parseSessionIntent,
   recommendationMatchesSessionIntent,
@@ -90,7 +90,9 @@ async function activateHosts(
   projectRoot: string,
   args: string[] = [],
 ): Promise<void> {
-  const sessionIntent = parseSessionIntent(getOptionValue(args, "--intent"));
+  const sessionIntent = parseSessionIntent(
+    getSingleOptionValue(args, "--intent"),
+  );
   const requestedRecommendationHost = parseHostTargetOption(
     getOptionalOptionValue(args, "--recommendation-host"),
     "--recommendation-host",
@@ -431,7 +433,7 @@ function printActivateHelp(): void {
 Options:
   --host <copilot-vscode|opencode|shared>
   --recommendation-host <host-policy-id>
-  --intent <${SESSION_INTENT_CHOICES}>`);
+  --intent <${SESSION_INTENT_CHOICES}>   Exactly one intent per run`);
 }
 
 function getDefaultBundleIdsForHost(host: ActivationHost): string[] {

--- a/src/lib/cli-options.ts
+++ b/src/lib/cli-options.ts
@@ -21,6 +21,27 @@ export function getOptionValue(
 }
 
 /**
+ * Returns the single value provided for a non-repeatable CLI option, rejecting
+ * duplicate occurrences instead of silently choosing one.
+ */
+export function getSingleOptionValue(
+  args: readonly string[],
+  optionName: string,
+): string | undefined {
+  const values = getOptionValues(args, optionName);
+
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  if (values.length > 1) {
+    throw new Error(`Option '${optionName}' may only be provided once.`);
+  }
+
+  return values[0];
+}
+
+/**
  * Returns every value provided for a repeatable CLI option, rejecting valueless
  * occurrences instead of accidentally consuming the next flag as data.
  */

--- a/src/recommend/commands.ts
+++ b/src/recommend/commands.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { readJsonFile, writeJsonFile } from "../files.js";
-import { getOptionValue } from "../lib/cli-options.js";
+import { getOptionValue, getSingleOptionValue } from "../lib/cli-options.js";
 import {
   parseSessionIntent,
   SESSION_INTENT_CHOICES,
@@ -36,7 +36,7 @@ export async function runRecommend(
     case "report": {
       const shouldRunAiReview = rest.includes("--ai-review");
       const sessionIntent = parseSessionIntent(
-        getOptionValue(rest, "--intent"),
+        getSingleOptionValue(rest, "--intent"),
       );
       const policy = shouldRunAiReview
         ? await loadRecommendationPolicy(projectRoot)
@@ -85,7 +85,7 @@ export async function runRecommend(
     case "ai-review": {
       const policy = await loadRecommendationPolicy(projectRoot);
       const sessionIntent = parseSessionIntent(
-        getOptionValue(rest, "--intent"),
+        getSingleOptionValue(rest, "--intent"),
       );
       const deterministicReport = await writeRecommendationReport(projectRoot, {
         policy,
@@ -363,7 +363,7 @@ function printRecommendHelp(): void {
   policy:print  Print the merged effective policy (--host <host> to scope)
 
 Recommendation options:
-  --intent <${SESSION_INTENT_CHOICES}>
+  --intent <${SESSION_INTENT_CHOICES}>   Exactly one intent per run
 
 AI review options:
   --host <host>

--- a/src/tests/cli-options.test.ts
+++ b/src/tests/cli-options.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getOptionValue, getOptionValues } from "../lib/cli-options.js";
+import {
+  getOptionValue,
+  getOptionValues,
+  getSingleOptionValue,
+} from "../lib/cli-options.js";
 import { getWireMode } from "../wire.js";
 
 void test("CLI option parsing rejects missing values and flag tokens", () => {
@@ -25,6 +29,22 @@ void test("wire mode parsing honors explicit apply and defaults to preview", () 
   assert.throws(
     () => getWireMode(["--apply", "--preview"]),
     /Conflicting wire mode flags/u,
+  );
+});
+
+void test("single-value CLI option parsing rejects duplicates", () => {
+  assert.equal(
+    getSingleOptionValue(["--intent", "frontend"], "--intent"),
+    "frontend",
+  );
+  assert.equal(getSingleOptionValue([], "--intent"), undefined);
+  assert.throws(
+    () =>
+      getSingleOptionValue(
+        ["--intent", "frontend", "--intent", "backend"],
+        "--intent",
+      ),
+    /Option '--intent' may only be provided once\./u,
   );
 });
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,7 +3,7 @@
 import { fileURLToPath } from "node:url";
 
 import { resolveProjectRoot } from "./files.js";
-import { getOptionValue } from "./lib/cli-options.js";
+import { getSingleOptionValue } from "./lib/cli-options.js";
 import {
   parseSessionIntent,
   SESSION_INTENT_CHOICES,
@@ -35,7 +35,9 @@ export async function runWorkspace(
   projectRoot: string,
 ): Promise<number> {
   const [target = "help", ...rest] = args;
-  const sessionIntent = parseSessionIntent(getOptionValue(rest, "--intent"));
+  const sessionIntent = parseSessionIntent(
+    getSingleOptionValue(rest, "--intent"),
+  );
   const aiEnrichmentFlags = parseAiEnrichmentFlags(rest);
 
   if (target === "help") {
@@ -110,7 +112,7 @@ function printWorkspaceHelp(): void {
 ${commands}
 
 Options:
-  --intent <${SESSION_INTENT_CHOICES}>
+  --intent <${SESSION_INTENT_CHOICES}>   Exactly one intent per run
   --ai-enrich            Explicitly request enrichment after workspace wiring
   --no-ai-enrich         Explicitly skip enrichment for this workspace run
   --force                Bypass cache reuse and automatic policy skips, forcing a new provider call when enrichment runs


### PR DESCRIPTION
# Clarify single-intent CLI usage

## Summary

This PR closes #180 by making the current `--intent` contract explicit and fail-fast.

Closes #180

## Changes

- documented that `--intent` accepts exactly one primary intent per run
- updated README/help/playbooks to stop implying intent lists
- changed CLI option parsing so duplicate `--intent` flags fail clearly instead of remaining ambiguous
- added regression coverage for duplicate single-value options

## Validation

- `npm run build`
- `node --test dist/tests/cli-options.test.js`

## Notes

This PR intentionally does **not** add multi-intent support. That is tracked separately in #182.
The deeper `recommend report` stall on a real large workspace is also tracked separately in #181.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Introduces `getSingleOptionValue` in `src/lib/cli-options.ts` that delegates to `getOptionValues` and throws a clear error when `--intent` is supplied more than once, replacing the silent "first wins" behaviour of `getOptionValue`.
- All three call sites that parse `--intent` from CLI args (`activate.ts`, `recommend/commands.ts`, `workspace.ts`) are updated, and a focused regression test is added.
- Documentation files (README and four playbooks) are updated to drop "Intent(s)" / list-style phrasing and reinforce the single-value contract.

<h3>Confidence Score: 5/5</h3>

Safe to merge — narrowly scoped, well-tested change with no logic regressions.

All three CLI entry points that parse `--intent` are updated consistently; no other files use `getOptionValue` for `--intent`; new function correctly delegates to the existing validated `getOptionValues` helper; regression test covers the key cases; documentation updates are accurate and consistent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/cli-options.ts | Adds `getSingleOptionValue`, which wraps `getOptionValues` and throws on duplicate flags; implementation is correct and consistent with existing helpers. |
| src/tests/cli-options.test.ts | New test covers the happy path, absent option, and duplicate-rejection for `getSingleOptionValue`; missing a valueless-flag case but that path is implicitly exercised by existing `getOptionValues` tests. |
| src/activate.ts | Switches `--intent` parsing from `getOptionValue` to `getSingleOptionValue`; help text updated to document the single-value constraint. |
| src/recommend/commands.ts | Both `report` and `ai-review` sub-commands switch to `getSingleOptionValue`; consistent with the new contract. |
| src/workspace.ts | Switches to `getSingleOptionValue` for `--intent`; help text updated; no other logic changes. |
| README.md | Two paragraphs updated to explicitly state that `--intent` is a single-value option and advise rerunning per intent for comparisons. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["CLI args\n(e.g. --intent frontend)"]
    getSingle["getSingleOptionValue(args, '--intent')"]
    getValues["getOptionValues(args, '--intent')"]
    count{values.length}
    zero["return undefined"]
    one["return values[0]"]
    many["throw Error:\n'--intent may only be provided once'"]
    parse["parseSessionIntent(value)"]
    session["SessionIntent\n(frontend | backend | docs | ...)"]

    CLI --> getSingle
    getSingle --> getValues
    getValues --> count
    count -- "0" --> zero
    count -- "1" --> one
    count -- "> 1" --> many
    one --> parse
    zero --> parse
    parse --> session
```

<sub>Reviews (1): Last reviewed commit: ["Clarify single-intent CLI usage"](https://github.com/ar27111994/agent-harness/commit/7df53f8fa3f4bb58c267efe7a21d56a60da1c7d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31653540)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `--intent` option now strictly enforces a single primary intent per command run and rejects multiple values.

* **Documentation**
  * Updated command documentation and playbooks to clarify that only one primary intent value is allowed per execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/agent-harness/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->