### PR TITLE
Fix recommend report stalls and add progress output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `recommend report` no longer hangs on large selected candidate sets; policy-derived search term Sets (`concernKeywordMap`, `taskModeKeywordMap`, `domainKeywordGroups`) are now precomputed once per host run via `buildPolicySearchContext(...)` instead of once per candidate per host, reducing time from ~7 minutes to under 5 seconds on a 5.5k-entry selected pool
+- `recommend report` no longer hangs on large selected candidate sets; policy-derived search term sets (`concernKeywordMap`, `taskModeKeywordMap`, `domainKeywordGroups`) are now precomputed once per report build via `buildPolicySearchContext(...)` instead of once per candidate per host, reducing time from ~7 minutes to under 5 seconds on a 5.5k-entry selected pool
 
 ## [1.0.3] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-No unreleased changes yet.
+### Added
+
+- `--intent` now accepts repeated values to combine multiple session intents additively in a single run (e.g. `--intent backend --intent docs`); the first intent is recorded as the primary for backward compatibility; single-intent runs are unaffected
+
+### Fixed
+
+- `recommend report` no longer hangs on large selected candidate sets; policy-derived search term Sets (`concernKeywordMap`, `taskModeKeywordMap`, `domainKeywordGroups`) are now precomputed once per host run via `buildPolicySearchContext(...)` instead of once per candidate per host, reducing time from ~7 minutes to under 5 seconds on a 5.5k-entry selected pool
 
 ## [1.0.3] - 2026-05-11
 

--- a/src/activate.ts
+++ b/src/activate.ts
@@ -13,7 +13,7 @@ import {
   writeJsonFile,
 } from "./files.js";
 import { listHostAdapters } from "./host-adapters/registry.js";
-import { getOptionValue } from "./lib/cli-options.js";
+import { getOptionValue, getOptionValues } from "./lib/cli-options.js";
 import {
   parseSessionIntent,
   recommendationMatchesSessionIntent,
@@ -90,7 +90,10 @@ async function activateHosts(
   projectRoot: string,
   args: string[] = [],
 ): Promise<void> {
-  const sessionIntent = parseSessionIntent(getOptionValue(args, "--intent"));
+  const intentRawValues = getOptionValues(args, "--intent");
+  const sessionIntent = parseSessionIntent(
+    intentRawValues.length > 0 ? intentRawValues[0] : undefined,
+  );
   const requestedRecommendationHost = parseHostTargetOption(
     getOptionalOptionValue(args, "--recommendation-host"),
     "--recommendation-host",
@@ -431,7 +434,7 @@ function printActivateHelp(): void {
 Options:
   --host <copilot-vscode|opencode|shared>
   --recommendation-host <host-policy-id>
-  --intent <${SESSION_INTENT_CHOICES}>`);
+  --intent <${SESSION_INTENT_CHOICES}>   Repeatable; first intent is used for activation context`);
 }
 
 function getDefaultBundleIdsForHost(host: ActivationHost): string[] {

--- a/src/activate.ts
+++ b/src/activate.ts
@@ -90,10 +90,10 @@ async function activateHosts(
   projectRoot: string,
   args: string[] = [],
 ): Promise<void> {
-  const intentRawValues = getOptionValues(args, "--intent");
-  const sessionIntent = parseSessionIntent(
-    intentRawValues.length > 0 ? intentRawValues[0] : undefined,
+  const sessionIntents = getOptionValues(args, "--intent").map((value) =>
+    parseSessionIntent(value),
   );
+  const sessionIntent = sessionIntents[0] ?? parseSessionIntent(undefined);
   const requestedRecommendationHost = parseHostTargetOption(
     getOptionalOptionValue(args, "--recommendation-host"),
     "--recommendation-host",

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -90,19 +90,29 @@ export async function runDiscover(
 
   switch (command) {
     case "demand-profile":
+      logDiscoverPhase(
+        "discover demand-profile",
+        1,
+        1,
+        "Scanning workspace demand",
+      );
       await generateDemandProfile(workingDirectory, projectRoot);
       return 0;
     case "sources":
+      logDiscoverPhase("discover sources", 1, 1, "Refreshing source index");
       await generateSourceIndex(projectRoot);
       return 0;
     case "catalog":
+      logDiscoverPhase("discover catalog", 1, 1, "Building discovery catalog");
       await generateCatalog(projectRoot);
       return 0;
     case "sync":
+      logDiscoverPhase("discover sync", 1, 1, "Syncing indexed sources");
       await syncIndexedSources(projectRoot);
       return 0;
     case "select": {
       const aiEnrichmentFlags = parseAiEnrichmentFlags(rest);
+      logDiscoverPhase("discover select", 1, 1, "Applying selection rules");
       await generateSelectionOutputs(projectRoot);
       return handleAiEnrichmentResult(
         await orchestrateAiEnrichment(projectRoot, {
@@ -117,10 +127,15 @@ export async function runDiscover(
     }
     case "full": {
       const aiEnrichmentFlags = parseAiEnrichmentFlags(rest);
+      logDiscoverPhase("discover full", 1, 5, "Scanning workspace demand");
       await generateDemandProfile(workingDirectory, projectRoot);
+      logDiscoverPhase("discover full", 2, 5, "Refreshing source index");
       await generateSourceIndex(projectRoot);
+      logDiscoverPhase("discover full", 3, 5, "Syncing indexed sources");
       await syncIndexedSources(projectRoot);
+      logDiscoverPhase("discover full", 4, 5, "Building discovery catalog");
       await generateCatalog(projectRoot);
+      logDiscoverPhase("discover full", 5, 5, "Applying selection rules");
       await generateSelectionOutputs(projectRoot);
       return handleAiEnrichmentResult(
         await orchestrateAiEnrichment(projectRoot, {
@@ -504,17 +519,31 @@ function handleAiEnrichmentResult(
   return result.shouldFail ? 1 : 0;
 }
 
+function logDiscoverPhase(
+  commandLabel: string,
+  step: number,
+  total: number,
+  description: string,
+): void {
+  console.log(`[${commandLabel}] ${step}/${total} ${description}...`);
+}
+
 async function runDiscoveryBreadth(
   workingDirectory: string,
   projectRoot: string,
 ): Promise<void> {
+  logDiscoverPhase("discover breadth", 1, 5, "Scanning workspace demand");
   const demandProfile = await generateDemandProfile(
     workingDirectory,
     projectRoot,
   );
+  logDiscoverPhase("discover breadth", 2, 5, "Syncing indexed sources");
   await syncIndexedSources(projectRoot);
+  logDiscoverPhase("discover breadth", 3, 5, "Refreshing source index");
   const sourceIndex = await generateSourceIndex(projectRoot);
+  logDiscoverPhase("discover breadth", 4, 5, "Building discovery catalog");
   const { catalogEntries, enabledSources } = await generateCatalog(projectRoot);
+  logDiscoverPhase("discover breadth", 5, 5, "Applying selection rules");
   const { selectionReport } = await generateSelectionOutputs(projectRoot);
 
   printDiscoveryBreadthSummary({

--- a/src/manifest-validation/recommendation.ts
+++ b/src/manifest-validation/recommendation.ts
@@ -47,6 +47,17 @@ export function assertRecommendationReport(
   } else {
     record.sessionIntent = "general";
   }
+  if (Object.prototype.hasOwnProperty.call(record, "sessionIntents")) {
+    assertArray(record.sessionIntents, `${context}.sessionIntents`).forEach(
+      (v, i) => {
+        assertLiteral(
+          v,
+          [...SESSION_INTENTS],
+          `${context}.sessionIntents[${i}]`,
+        );
+      },
+    );
+  }
   const topByHost = assertRecord(record.topByHost, `${context}.topByHost`);
 
   for (const expectedHost of HOST_TARGETS) {

--- a/src/manifest-validation/recommendation.ts
+++ b/src/manifest-validation/recommendation.ts
@@ -48,15 +48,25 @@ export function assertRecommendationReport(
     record.sessionIntent = "general";
   }
   if (Object.prototype.hasOwnProperty.call(record, "sessionIntents")) {
-    assertArray(record.sessionIntents, `${context}.sessionIntents`).forEach(
-      (v, i) => {
-        assertLiteral(
-          v,
-          [...SESSION_INTENTS],
-          `${context}.sessionIntents[${i}]`,
-        );
-      },
+    const sessionIntents = assertArray(
+      record.sessionIntents,
+      `${context}.sessionIntents`,
     );
+    if (sessionIntents.length <= 1) {
+      fail(
+        `${context}.sessionIntents`,
+        "must contain at least two intents when present",
+      );
+    }
+    sessionIntents.forEach((v, i) => {
+      assertLiteral(v, [...SESSION_INTENTS], `${context}.sessionIntents[${i}]`);
+    });
+    if (sessionIntents[0] !== record.sessionIntent) {
+      fail(
+        `${context}.sessionIntents[0]`,
+        "must match sessionIntent when sessionIntents is present",
+      );
+    }
   }
   const topByHost = assertRecord(record.topByHost, `${context}.topByHost`);
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -58,7 +58,7 @@ export async function runWorkspacePipeline(options: {
     sessionIntents && sessionIntents.length > 1
       ? sessionIntents
       : [sessionIntent];
-  const primaryIntent = resolvedIntents[0] ?? sessionIntent;
+  const primaryIntent = resolvedIntents[0];
   const config = getRuntimeConfig();
   const mirrorBatchSize = String(config.batches.mirrorAcquire);
   const installBatchSize = String(config.batches.installBundle);
@@ -128,7 +128,7 @@ async function acquireAllMirrorBatches(
 
   for (let batchIndex = 0; batchIndex < maxBatches; batchIndex += 1) {
     writeWorkspaceProgress(
-      `[workspace] mirror batch ${batchIndex + 1}/${maxBatches} acquiring artifacts...`,
+      `[workspace] mirror batch ${batchIndex + 1} acquiring artifacts...`,
     );
     await runMirror(
       ["acquire", "--batch-size", batchSize],
@@ -169,7 +169,7 @@ async function installBundleBatches(
       batchIndex += 1
     ) {
       writeWorkspaceProgress(
-        `[workspace] install batch ${batchIndex + 1}/${maxBatchesPerBundle} for bundle '${bundleId}'...`,
+        `[workspace] install batch ${batchIndex + 1} for bundle '${bundleId}'...`,
       );
       await runInstall(
         ["bundle", "--bundle", bundleId, "--batch-size", batchSize],

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -19,6 +19,18 @@ import type {
 const MIRROR_ACQUIRE_STATE_PATH = ["state", "mirror", "acquire-state.json"];
 const INSTALL_PROGRESS_STATE_PATH = ["state", "install", "progress.json"];
 
+function writeWorkspaceProgress(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+function logWorkspacePhase(
+  step: number,
+  total: number,
+  description: string,
+): void {
+  writeWorkspaceProgress(`[workspace] ${step}/${total} ${description}...`);
+}
+
 /**
  * Runs discover, recommendation, mirror, stage/install, activation, and shared
  * activation phases for a workspace before the selected adapter performs final
@@ -30,6 +42,7 @@ export async function runWorkspacePipeline(options: {
   targetHost: "copilot-vscode" | "opencode";
   recommendationHost: HostTarget;
   sessionIntent: SessionIntent;
+  sessionIntents?: readonly SessionIntent[];
   bundleIds: string[];
 }): Promise<void> {
   const {
@@ -38,25 +51,41 @@ export async function runWorkspacePipeline(options: {
     targetHost,
     recommendationHost,
     sessionIntent,
+    sessionIntents,
     bundleIds,
   } = options;
+  const resolvedIntents: readonly SessionIntent[] =
+    sessionIntents && sessionIntents.length > 1
+      ? sessionIntents
+      : [sessionIntent];
+  const primaryIntent = resolvedIntents[0] ?? sessionIntent;
   const config = getRuntimeConfig();
   const mirrorBatchSize = String(config.batches.mirrorAcquire);
   const installBatchSize = String(config.batches.installBundle);
 
+  logWorkspacePhase(1, 11, "Scanning workspace demand");
   await runDiscover(["demand-profile"], workspaceRoot, projectRoot);
+  logWorkspacePhase(2, 11, "Refreshing source index");
   await runDiscover(["sources"], workspaceRoot, projectRoot);
+  logWorkspacePhase(3, 11, "Syncing indexed sources");
   await runDiscover(["sync"], workspaceRoot, projectRoot);
+  logWorkspacePhase(4, 11, "Refreshing source index after sync");
   await runDiscover(["sources"], workspaceRoot, projectRoot);
+  logWorkspacePhase(5, 11, "Building discovery catalog");
   await runDiscover(["catalog"], workspaceRoot, projectRoot);
+  logWorkspacePhase(6, 11, "Applying selection rules");
   await runDiscover(["select"], workspaceRoot, projectRoot);
+  logWorkspacePhase(7, 11, "Ranking recommendations");
   await runRecommend(
-    ["report", "--intent", sessionIntent],
+    ["report", ...resolvedIntents.flatMap((i) => ["--intent", i])],
     workspaceRoot,
     projectRoot,
   );
+  logWorkspacePhase(8, 11, "Planning mirror work");
   await runMirror(["plan"], workspaceRoot, projectRoot);
+  logWorkspacePhase(9, 11, "Preparing mirror locks");
   await runMirror(["locks"], workspaceRoot, projectRoot);
+  logWorkspacePhase(10, 11, "Acquiring and staging assets");
   await acquireAllMirrorBatches(projectRoot, workspaceRoot, mirrorBatchSize);
   await installBundleBatches(
     projectRoot,
@@ -65,6 +94,7 @@ export async function runWorkspacePipeline(options: {
     installBatchSize,
   );
   await runInstall(["reconcile"], workspaceRoot, projectRoot);
+  logWorkspacePhase(11, 11, "Activating host views");
   await runActivate(
     [
       "host",
@@ -73,13 +103,13 @@ export async function runWorkspacePipeline(options: {
       "--recommendation-host",
       recommendationHost,
       "--intent",
-      sessionIntent,
+      primaryIntent,
     ],
     workspaceRoot,
     projectRoot,
   );
   await runActivate(
-    ["host", "--host", "shared", "--intent", sessionIntent],
+    ["host", "--host", "shared", "--intent", primaryIntent],
     workspaceRoot,
     projectRoot,
   );
@@ -97,6 +127,9 @@ async function acquireAllMirrorBatches(
   const maxBatches = 200;
 
   for (let batchIndex = 0; batchIndex < maxBatches; batchIndex += 1) {
+    writeWorkspaceProgress(
+      `[workspace] mirror batch ${batchIndex + 1}/${maxBatches} acquiring artifacts...`,
+    );
     await runMirror(
       ["acquire", "--batch-size", batchSize],
       workspaceRoot,
@@ -129,11 +162,15 @@ async function installBundleBatches(
   const maxBatchesPerBundle = 200;
 
   for (const bundleId of bundleIds) {
+    writeWorkspaceProgress(`[workspace] staging bundle '${bundleId}'...`);
     for (
       let batchIndex = 0;
       batchIndex < maxBatchesPerBundle;
       batchIndex += 1
     ) {
+      writeWorkspaceProgress(
+        `[workspace] install batch ${batchIndex + 1}/${maxBatchesPerBundle} for bundle '${bundleId}'...`,
+      );
       await runInstall(
         ["bundle", "--bundle", bundleId, "--batch-size", batchSize],
         workspaceRoot,

--- a/src/recommend/candidates.ts
+++ b/src/recommend/candidates.ts
@@ -18,7 +18,12 @@ import type {
   RecommendationSignalMatch,
 } from "../types.js";
 import type { RecommendationHost } from "./hosts.js";
-import type { CandidateRecommendation, DemandContext } from "./model.js";
+import type {
+  CandidateRecommendation,
+  CandidateRecommendationBase,
+  DemandContext,
+  PolicySearchContext,
+} from "./model.js";
 
 const WRAPPER_LIKE_TERMS = new Set([
   "config",
@@ -39,6 +44,38 @@ interface MatchQuality {
 }
 
 /**
+ * Precomputes all policy-derived Set lookups so they are built once per host
+ * run rather than once per candidate, eliminating the O(n × policy) hot path.
+ */
+export function buildPolicySearchContext(
+  policy: RecommendationPolicy,
+): PolicySearchContext {
+  const genericToolingTerms = buildGenericToolingTerms(policy);
+  const wrapperLikeTerms = buildSearchTerms([...WRAPPER_LIKE_TERMS], policy);
+  const concernTermSets = new Map<string, Set<string>>();
+  const taskModeTermSets = new Map<string, Set<string>>();
+  const domainGroupTermSets = new Map<string, Set<string>>();
+
+  for (const [concern, keywords] of Object.entries(policy.concernKeywordMap)) {
+    concernTermSets.set(concern, buildSearchTerms(keywords, policy));
+  }
+  for (const [mode, keywords] of Object.entries(policy.taskModeKeywordMap)) {
+    taskModeTermSets.set(mode, buildSearchTerms(keywords, policy));
+  }
+  for (const [group, keywords] of Object.entries(policy.domainKeywordGroups)) {
+    domainGroupTermSets.set(group, buildSearchTerms(keywords, policy));
+  }
+
+  return {
+    genericToolingTerms,
+    wrapperLikeTerms,
+    concernTermSets,
+    taskModeTermSets,
+    domainGroupTermSets,
+  };
+}
+
+/**
  * Provides compute entry preselection score for the lifecycle pipeline.
  */
 export function computeEntryPreselectionScore(
@@ -55,20 +92,21 @@ export function computeEntryPreselectionScore(
 }
 
 /**
- * Builds candidate recommendation from the provided inputs.
+ * Precomputes host-independent recommendation analysis for one catalog entry so
+ * large report builds do not repeat the same demand/search work for every host.
  */
-export function buildCandidateRecommendation(
+export function buildCandidateRecommendationBase(
   entry: AssetCatalogEntry,
-  host: RecommendationHost,
   demandContext: DemandContext,
   policy: RecommendationPolicy,
-): CandidateRecommendation | null {
+  policyContext?: PolicySearchContext,
+): CandidateRecommendationBase | null {
+  const resolvedPolicyContext =
+    policyContext ?? buildPolicySearchContext(policy);
   const capabilitySearchTerms = buildSearchTerms(
     [entry.id, entry.displayName, ...entry.capabilities],
     policy,
   );
-  const genericToolingTerms = buildGenericToolingTerms(policy);
-  const wrapperLikeTerms = buildSearchTerms([...WRAPPER_LIKE_TERMS], policy);
   const rawKeywordTerms = buildRawKeywordTerms([
     entry.id,
     entry.displayName,
@@ -89,9 +127,6 @@ export function buildCandidateRecommendation(
     policy,
   );
 
-  if (isSuppressedForHost(entry, host, searchTerms, policy)) {
-    return null;
-  }
   if (
     isSuppressedBySpecializedDemandGate(entry, rawKeywordTerms, demandContext)
   ) {
@@ -112,20 +147,24 @@ export function buildCandidateRecommendation(
   const matchQuality = analyzeMatchQuality(
     matchedSignals,
     capabilitySearchTerms,
-    wrapperLikeTerms,
-    genericToolingTerms,
+    resolvedPolicyContext.wrapperLikeTerms,
+    resolvedPolicyContext.genericToolingTerms,
   );
   const availableLocally = isLocallyAvailable(entry);
   const recommendationBasis = determineRecommendationBasis(
     availableLocally,
     matchQuality,
   );
-  const coverageTags = buildCoverageTags(searchTerms, matchedSignals, policy);
+  const coverageTags = buildCoverageTags(
+    searchTerms,
+    matchedSignals,
+    resolvedPolicyContext.concernTermSets,
+  );
   const taskModes = buildTaskModes(
     searchTerms,
     coverageTags,
     matchedSignals,
-    policy,
+    resolvedPolicyContext.taskModeTermSets,
     entry.contextCost,
   );
   const duplicateGroup = buildDuplicateGroup(
@@ -133,12 +172,6 @@ export function buildCandidateRecommendation(
     matchedSignals,
     coverageTags,
     entry.dedupe.duplicateGroup,
-  );
-  const hostDeprioritizationPenalty = computeHostDeprioritizationPenalty(
-    entry,
-    host,
-    searchTerms,
-    policy,
   );
 
   const breakdown: RecommendationScoreBreakdown = {
@@ -158,13 +191,7 @@ export function buildCandidateRecommendation(
       matchedSignals.reduce((total, match) => total + match.weight, 0) +
         computeDemandExactnessBonus(matchQuality),
     ),
-    hostPreference: computeHostPreference(
-      entry,
-      host,
-      coverageTags,
-      demandContext,
-      policy,
-    ),
+    hostPreference: 0,
     coverage: 0,
     diversity: 0,
     freshness: computeFreshnessScore(entry, policy),
@@ -178,17 +205,17 @@ export function buildCandidateRecommendation(
       (entry.risk.requiresNetwork
         ? policy.scoring.riskFlagPenalties.requiresNetwork
         : 0),
-    negativePenalty:
-      computeNegativePenalty(
-        entry,
-        searchTerms,
-        matchedSignals,
-        matchQuality,
-        availableLocally,
-        recommendationBasis,
-        demandContext,
-        policy,
-      ) + hostDeprioritizationPenalty,
+    negativePenalty: computeNegativePenalty(
+      entry,
+      searchTerms,
+      matchedSignals,
+      matchQuality,
+      availableLocally,
+      recommendationBasis,
+      demandContext,
+      policy,
+      resolvedPolicyContext,
+    ),
     redundancyPenalty: 0,
     budgetPenalty: 0,
     total: 0,
@@ -197,7 +224,6 @@ export function buildCandidateRecommendation(
 
   return {
     entry,
-    host,
     sourceFamily: deriveSourceFamily(entry),
     availableLocally,
     recommendationBasis,
@@ -214,6 +240,63 @@ export function buildCandidateRecommendation(
       availableLocally,
       recommendationBasis,
     ),
+    searchTerms,
+    breakdown,
+  };
+}
+
+/**
+ * Builds candidate recommendation from precomputed entry analysis plus one host
+ * specific scoring/suppression pass.
+ */
+export function buildCandidateRecommendation(
+  base: CandidateRecommendationBase,
+  host: RecommendationHost,
+  demandContext: DemandContext,
+  policy: RecommendationPolicy,
+): CandidateRecommendation | null {
+  if (isSuppressedForHost(base.entry, host, base.searchTerms, policy)) {
+    return null;
+  }
+
+  const hostDeprioritizationPenalty = computeHostDeprioritizationPenalty(
+    base.entry,
+    host,
+    base.searchTerms,
+    policy,
+  );
+  const hostPreference = computeHostPreference(
+    base.entry,
+    host,
+    base.coverageTags,
+    demandContext,
+    policy,
+  );
+  const breakdown: RecommendationScoreBreakdown = {
+    ...base.breakdown,
+    hostPreference,
+    negativePenalty:
+      base.breakdown.negativePenalty + hostDeprioritizationPenalty,
+    total: 0,
+  };
+  breakdown.total = calculateBreakdownTotal(breakdown);
+
+  return {
+    entry: base.entry,
+    host,
+    sourceFamily: base.sourceFamily,
+    availableLocally: base.availableLocally,
+    recommendationBasis: base.recommendationBasis,
+    coverageTags: [...base.coverageTags],
+    taskModes: [...base.taskModes],
+    matchedSignals: base.matchedSignals.map((match) => ({
+      ...match,
+      ...(match.evidenceStrengthCounts
+        ? { evidenceStrengthCounts: { ...match.evidenceStrengthCounts } }
+        : {}),
+    })),
+    duplicateGroup: base.duplicateGroup,
+    reasons: [...base.reasons],
     breakdown,
   };
 }
@@ -412,6 +495,7 @@ function computeNegativePenalty(
   recommendationBasis: RecommendationBasis,
   demandContext: DemandContext,
   policy: RecommendationPolicy,
+  policyContext: PolicySearchContext,
 ): number {
   let penalty = 0;
 
@@ -423,7 +507,12 @@ function computeNegativePenalty(
     penalty += policy.scoring.weakDemandPenalty;
   }
 
-  penalty += computeOutOfDomainPenalty(searchTerms, demandContext, policy);
+  penalty += computeOutOfDomainPenalty(
+    searchTerms,
+    demandContext,
+    policyContext.domainGroupTermSets,
+    policy.scoring.outOfDomainGroupPenalty,
+  );
 
   const specificTerms = [...searchTerms].filter(
     (term) => !GENERIC_CAPABILITY_TERMS.has(term) && term.length > 2,

--- a/src/recommend/commands.ts
+++ b/src/recommend/commands.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 import { readJsonFile, writeJsonFile } from "../files.js";
-import { getOptionValue } from "../lib/cli-options.js";
+import { getOptionValue, getOptionValues } from "../lib/cli-options.js";
 import {
   parseSessionIntent,
   SESSION_INTENT_CHOICES,
@@ -20,6 +20,7 @@ import type {
   RecommendationReport,
   RecommendationScoreBreakdown,
   RecommendationSignalMatch,
+  SessionIntent,
 } from "../types.js";
 
 /**
@@ -35,15 +36,16 @@ export async function runRecommend(
   switch (command) {
     case "report": {
       const shouldRunAiReview = rest.includes("--ai-review");
-      const sessionIntent = parseSessionIntent(
-        getOptionValue(rest, "--intent"),
-      );
+      const sessionIntents = parseSessionIntents(rest);
       const policy = shouldRunAiReview
         ? await loadRecommendationPolicy(projectRoot)
         : undefined;
+      console.log(
+        `Building recommendation report for intents: ${sessionIntents.join(", ")}`,
+      );
       const deterministicReport = await writeRecommendationReport(projectRoot, {
         policy,
-        sessionIntent,
+        sessionIntents,
       });
       const report =
         shouldRunAiReview && policy
@@ -84,12 +86,13 @@ export async function runRecommend(
     }
     case "ai-review": {
       const policy = await loadRecommendationPolicy(projectRoot);
-      const sessionIntent = parseSessionIntent(
-        getOptionValue(rest, "--intent"),
+      const sessionIntents = parseSessionIntents(rest);
+      console.log(
+        `Building recommendation report for intents: ${sessionIntents.join(", ")}`,
       );
       const deterministicReport = await writeRecommendationReport(projectRoot, {
         policy,
-        sessionIntent,
+        sessionIntents,
       });
       const result = await runRecommendationAiReview({
         projectRoot,
@@ -298,6 +301,15 @@ function getRequestedReviewHost(
   return requestedHostRaw;
 }
 
+function parseSessionIntents(args: string[]): readonly SessionIntent[] {
+  const rawValues = getOptionValues(args, "--intent");
+  if (rawValues.length === 0) {
+    return ["general"];
+  }
+
+  return rawValues.map((v) => parseSessionIntent(v));
+}
+
 function getReviewLimit(args: string[]): number | undefined {
   const reviewLimitRaw = getOptionValue(args, "--review-limit");
   if (!reviewLimitRaw) {
@@ -363,7 +375,7 @@ function printRecommendHelp(): void {
   policy:print  Print the merged effective policy (--host <host> to scope)
 
 Recommendation options:
-  --intent <${SESSION_INTENT_CHOICES}>
+  --intent <${SESSION_INTENT_CHOICES}>   Repeatable; multiple intents are merged additively
 
 AI review options:
   --host <host>

--- a/src/recommend/model.ts
+++ b/src/recommend/model.ts
@@ -49,7 +49,37 @@ export interface CandidateRecommendation {
 }
 
 /**
- * Describes dynamic score data exchanged by the lifecycle pipeline.
+ * Describes host-independent recommendation analysis shared across all host
+ * ranking passes for one report build.
+ */
+export interface CandidateRecommendationBase {
+  entry: AssetCatalogEntry;
+  sourceFamily: string;
+  availableLocally: boolean;
+  recommendationBasis: RecommendationBasis;
+  coverageTags: string[];
+  taskModes: string[];
+  matchedSignals: RecommendationSignalMatch[];
+  duplicateGroup?: string;
+  reasons: string[];
+  searchTerms: Set<string>;
+  breakdown: RecommendationScoreBreakdown;
+}
+
+/**
+ * Describes precomputed policy search sets shared across all candidates for one
+ * recommendation host run, avoiding per-candidate policy-map rebuilds.
+ */
+export interface PolicySearchContext {
+  genericToolingTerms: Set<string>;
+  wrapperLikeTerms: Set<string>;
+  concernTermSets: Map<string, Set<string>>;
+  taskModeTermSets: Map<string, Set<string>>;
+  domainGroupTermSets: Map<string, Set<string>>;
+}
+
+/**
+ * Describes one candidate's dynamic score after host-selection adjustments.
  */
 export interface DynamicScore {
   total: number;

--- a/src/recommend/report.ts
+++ b/src/recommend/report.ts
@@ -13,6 +13,10 @@ import { REPORT_FILE_PATH } from "./constants.js";
 import { getRecommendationHosts } from "./hosts.js";
 import { loadRecommendationPolicy } from "./policy.js";
 import { buildDemandContext } from "./signals.js";
+import {
+  buildCandidateRecommendationBase,
+  buildPolicySearchContext,
+} from "./candidates.js";
 import { buildTopRecommendationsForHost } from "./selection.js";
 import { buildHostSummary, buildSuggestedBundle } from "./summary.js";
 import type {
@@ -24,6 +28,7 @@ import type {
   RecommendationReport,
   SessionIntent,
 } from "../types.js";
+import type { CandidateRecommendationBase } from "./model.js";
 import type { RecommendationHost } from "./hosts.js";
 
 /**
@@ -34,6 +39,7 @@ export async function writeRecommendationReport(
   options: {
     policy?: RecommendationPolicy;
     sessionIntent?: SessionIntent;
+    sessionIntents?: readonly SessionIntent[];
   } = {},
 ): Promise<RecommendationReport> {
   const resolvedPolicy =
@@ -46,11 +52,14 @@ export async function writeRecommendationReport(
     join(projectRoot, "discover", "output", "catalog.selected.jsonl"),
     assertAssetCatalogEntry,
   );
+  const resolvedIntents: readonly SessionIntent[] =
+    options.sessionIntents ??
+    (options.sessionIntent ? [options.sessionIntent] : ["general"]);
   const report = buildRecommendationReport(
     selectedEntries,
     demandProfile,
     resolvedPolicy,
-    options.sessionIntent ?? "general",
+    resolvedIntents,
   );
 
   await writeJsonFile(join(projectRoot, ...REPORT_FILE_PATH), report);
@@ -60,23 +69,51 @@ export async function writeRecommendationReport(
 
 /**
  * Builds recommendation report from the provided inputs.
+ * Accepts one or more session intents; multiple intents are merged additively
+ * through the demand context so the ranking reflects the combined task shape.
+ * The first intent is recorded as the primary intent in the report output for
+ * backward compatibility. A sessionIntents array is included only when more
+ * than one intent was requested.
  */
 export function buildRecommendationReport(
   entries: AssetCatalogEntry[],
   demandProfile: DemandProfile | null,
   policy: RecommendationPolicy,
-  sessionIntent: SessionIntent = "general",
+  sessionIntents: SessionIntent | readonly SessionIntent[] = "general",
 ): RecommendationReport {
+  const resolvedIntents: readonly SessionIntent[] = Array.isArray(
+    sessionIntents,
+  )
+    ? (sessionIntents as readonly SessionIntent[])
+    : [sessionIntents as SessionIntent];
+  const primaryIntent: SessionIntent = resolvedIntents[0] ?? "general";
   const demandContext = buildDemandContext(
     demandProfile,
     policy,
-    sessionIntent,
+    resolvedIntents,
   );
   const recommendationHosts = getRecommendationHosts();
+  const policyContext = buildPolicySearchContext(policy);
+  const candidateBases = entries
+    .filter((entry) => entry.compatibilityMode !== "incompatible")
+    .map((entry) =>
+      buildCandidateRecommendationBase(
+        entry,
+        demandContext,
+        policy,
+        policyContext,
+      ),
+    )
+    .filter((base): base is CandidateRecommendationBase => base !== null);
   const topByHost = Object.fromEntries(
     recommendationHosts.map((host) => [
       host,
-      buildTopRecommendationsForHost(host, entries, demandContext, policy),
+      buildTopRecommendationsForHost(
+        host,
+        candidateBases,
+        demandContext,
+        policy,
+      ),
     ]),
   ) as Record<RecommendationHost, RecommendationEntry[]>;
   const hostSummaries = Object.fromEntries(
@@ -93,7 +130,10 @@ export function buildRecommendationReport(
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     policyVersion: policy.schemaVersion,
-    sessionIntent,
+    sessionIntent: primaryIntent,
+    ...(resolvedIntents.length > 1
+      ? { sessionIntents: [...resolvedIntents] }
+      : {}),
     topByHost,
     hostSummaries,
     suggestedBundles,

--- a/src/recommend/report.ts
+++ b/src/recommend/report.ts
@@ -84,8 +84,8 @@ export function buildRecommendationReport(
   const resolvedIntents: readonly SessionIntent[] = Array.isArray(
     sessionIntents,
   )
-    ? (sessionIntents as readonly SessionIntent[])
-    : [sessionIntents as SessionIntent];
+    ? sessionIntents
+    : [sessionIntents];
   const primaryIntent: SessionIntent = resolvedIntents[0] ?? "general";
   const demandContext = buildDemandContext(
     demandProfile,

--- a/src/recommend/report.ts
+++ b/src/recommend/report.ts
@@ -52,9 +52,9 @@ export async function writeRecommendationReport(
     join(projectRoot, "discover", "output", "catalog.selected.jsonl"),
     assertAssetCatalogEntry,
   );
-  const resolvedIntents: readonly SessionIntent[] =
-    options.sessionIntents ??
-    (options.sessionIntent ? [options.sessionIntent] : ["general"]);
+  const resolvedIntents = resolveSessionIntents(
+    options.sessionIntents ?? options.sessionIntent,
+  );
   const report = buildRecommendationReport(
     selectedEntries,
     demandProfile,
@@ -81,12 +81,8 @@ export function buildRecommendationReport(
   policy: RecommendationPolicy,
   sessionIntents: SessionIntent | readonly SessionIntent[] = "general",
 ): RecommendationReport {
-  const resolvedIntents: readonly SessionIntent[] = Array.isArray(
-    sessionIntents,
-  )
-    ? sessionIntents
-    : [sessionIntents];
-  const primaryIntent: SessionIntent = resolvedIntents[0] ?? "general";
+  const resolvedIntents = resolveSessionIntents(sessionIntents);
+  const primaryIntent: SessionIntent = resolvedIntents[0];
   const demandContext = buildDemandContext(
     demandProfile,
     policy,
@@ -138,4 +134,18 @@ export function buildRecommendationReport(
     hostSummaries,
     suggestedBundles,
   };
+}
+
+function resolveSessionIntents(
+  sessionIntents?: SessionIntent | readonly SessionIntent[],
+): readonly SessionIntent[] {
+  if (sessionIntents === undefined) {
+    return ["general"];
+  }
+
+  if (typeof sessionIntents === "string") {
+    return [sessionIntents];
+  }
+
+  return sessionIntents.length > 0 ? sessionIntents : ["general"];
 }

--- a/src/recommend/selection.ts
+++ b/src/recommend/selection.ts
@@ -11,6 +11,7 @@ import type {
   RecommendationPolicy,
   RecommendationScoreBreakdown,
 } from "../types.js";
+import type { CandidateRecommendationBase } from "./model.js";
 import type { RecommendationHost } from "./hosts.js";
 import type {
   CandidateRecommendation,
@@ -23,16 +24,16 @@ import type {
  */
 export function buildTopRecommendationsForHost(
   host: RecommendationHost,
-  entries: AssetCatalogEntry[],
+  candidateBases: CandidateRecommendationBase[],
   demandContext: DemandContext,
   policy: RecommendationPolicy,
 ): RecommendationEntry[] {
-  const scoredCandidates = entries
-    .filter((entry) => isEntryCompatibleWithRecommendationHost(entry, host))
-    .filter((entry) => entry.compatibilityMode !== "incompatible")
-    .map((entry) => {
+  const scoredCandidates = candidateBases
+    .filter((base) => isEntryCompatibleWithRecommendationHost(base.entry, host))
+    .filter((base) => base.entry.compatibilityMode !== "incompatible")
+    .map((base) => {
       const candidate = buildCandidateRecommendation(
-        entry,
+        base,
         host,
         demandContext,
         policy,

--- a/src/recommend/signals.ts
+++ b/src/recommend/signals.ts
@@ -284,9 +284,6 @@ function buildActiveDomainGroups(
 }
 
 /**
- * Provides compute out of domain penalty for the lifecycle pipeline.
- */
-/**
  * Computes out-of-domain penalty for an entry.
  * Accepts precomputed domainGroupTermSets to avoid rebuilding per-candidate.
  */

--- a/src/recommend/signals.ts
+++ b/src/recommend/signals.ts
@@ -53,12 +53,18 @@ export function collectMatchedSignals(
 
 /**
  * Builds demand context from the provided inputs.
+ * Accepts one or more session intents; multiple intents are merged additively.
  */
 export function buildDemandContext(
   demandProfile: DemandProfile | null,
   policy: RecommendationPolicy,
-  sessionIntent: SessionIntent = "general",
+  sessionIntents: SessionIntent | readonly SessionIntent[] = "general",
 ): DemandContext {
+  const resolvedIntents: readonly SessionIntent[] = Array.isArray(
+    sessionIntents,
+  )
+    ? (sessionIntents as readonly SessionIntent[])
+    : [sessionIntents as SessionIntent];
   const demandTermMap = new Map<string, DemandTermContext>();
 
   const registerTerm = (
@@ -106,7 +112,9 @@ export function buildDemandContext(
 
     registerBridgeDemandTerms(demandProfile, registerTerm);
   }
-  registerSessionIntentTerms(sessionIntent, registerTerm);
+  for (const intent of resolvedIntents) {
+    registerSessionIntentTerms(intent, registerTerm);
+  }
 
   const terms = [...demandTermMap.values()].sort((left, right) =>
     left.key.localeCompare(right.key),
@@ -119,7 +127,11 @@ export function buildDemandContext(
     packageManifestEntries: demandProfile
       ? buildPackageManifestEntrySet(demandProfile)
       : new Set<string>(),
-    demandKeywords: buildDemandKeywordSet(demandProfile, policy, sessionIntent),
+    demandKeywords: buildDemandKeywordSet(
+      demandProfile,
+      policy,
+      resolvedIntents,
+    ),
   };
 }
 
@@ -182,7 +194,7 @@ function registerSessionIntentTerms(
 function buildDemandKeywordSet(
   demandProfile: DemandProfile | null,
   policy: RecommendationPolicy,
-  sessionIntent: SessionIntent,
+  sessionIntents: readonly SessionIntent[],
 ): Set<string> {
   const keywords = new Set<string>();
 
@@ -207,8 +219,10 @@ function buildDemandKeywordSet(
     }
   }
 
-  for (const keyword of getSessionIntentKeywords(sessionIntent)) {
-    keywords.add(keyword);
+  for (const intent of sessionIntents) {
+    for (const keyword of getSessionIntentKeywords(intent)) {
+      keywords.add(keyword);
+    }
   }
 
   return keywords;
@@ -272,15 +286,19 @@ function buildActiveDomainGroups(
 /**
  * Provides compute out of domain penalty for the lifecycle pipeline.
  */
+/**
+ * Computes out-of-domain penalty for an entry.
+ * Accepts precomputed domainGroupTermSets to avoid rebuilding per-candidate.
+ */
 export function computeOutOfDomainPenalty(
   searchTerms: Set<string>,
   demandContext: DemandContext,
-  policy: RecommendationPolicy,
+  domainGroupTermSets: Map<string, Set<string>>,
+  outOfDomainGroupPenalty: number,
 ): number {
   let penalty = 0;
 
-  for (const [group, keywords] of Object.entries(policy.domainKeywordGroups)) {
-    const groupTerms = buildSearchTerms(keywords, policy);
+  for (const [group, groupTerms] of domainGroupTermSets) {
     if (!intersects(searchTerms, groupTerms)) {
       continue;
     }
@@ -288,7 +306,7 @@ export function computeOutOfDomainPenalty(
       continue;
     }
 
-    penalty += policy.scoring.outOfDomainGroupPenalty;
+    penalty += outOfDomainGroupPenalty;
   }
 
   return penalty;
@@ -296,16 +314,17 @@ export function computeOutOfDomainPenalty(
 
 /**
  * Builds coverage tags from the provided inputs.
+ * Accepts precomputed concernTermSets to avoid rebuilding per-candidate.
  */
 export function buildCoverageTags(
   searchTerms: Set<string>,
   matchedSignals: RecommendationSignalMatch[],
-  policy: RecommendationPolicy,
+  concernTermSets: Map<string, Set<string>>,
 ): string[] {
   const tags = new Set<string>();
 
-  for (const [concern, keywords] of Object.entries(policy.concernKeywordMap)) {
-    if (intersects(searchTerms, buildSearchTerms(keywords, policy))) {
+  for (const [concern, terms] of concernTermSets) {
+    if (intersects(searchTerms, terms)) {
       tags.add(concern);
     }
   }
@@ -321,18 +340,19 @@ export function buildCoverageTags(
 
 /**
  * Builds task modes from the provided inputs.
+ * Accepts precomputed taskModeTermSets to avoid rebuilding per-candidate.
  */
 export function buildTaskModes(
   searchTerms: Set<string>,
   coverageTags: string[],
   matchedSignals: RecommendationSignalMatch[],
-  policy: RecommendationPolicy,
+  taskModeTermSets: Map<string, Set<string>>,
   contextCost: AssetContextCost,
 ): string[] {
   const modes = new Set<string>();
 
-  for (const [mode, keywords] of Object.entries(policy.taskModeKeywordMap)) {
-    if (intersects(searchTerms, buildSearchTerms(keywords, policy))) {
+  for (const [mode, terms] of taskModeTermSets) {
+    if (intersects(searchTerms, terms)) {
       modes.add(mode);
     }
   }

--- a/src/tests/activate-cli.test.ts
+++ b/src/tests/activate-cli.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runActivate } from "../activate.js";
+
+void test("activate validates every repeated intent value", async () => {
+  await assert.rejects(
+    () =>
+      runActivate(
+        ["host", "--intent", "backend", "--intent", "docss"],
+        process.cwd(),
+        process.cwd(),
+      ),
+    /Invalid --intent value 'docss'/u,
+  );
+});

--- a/src/tests/cli-options.test.ts
+++ b/src/tests/cli-options.test.ts
@@ -28,6 +28,14 @@ void test("wire mode parsing honors explicit apply and defaults to preview", () 
   );
 });
 
+void test("repeatable CLI option parsing collects multi-intent values", () => {
+  assert.deepEqual(
+    getOptionValues(["--intent", "backend", "--intent", "docs"], "--intent"),
+    ["backend", "docs"],
+  );
+  assert.deepEqual(getOptionValues([], "--intent"), []);
+});
+
 void test("repeatable CLI option parsing rejects valueless entries", () => {
   assert.deepEqual(
     getOptionValues(["--bundle", "one", "--bundle", "two"], "--bundle"),

--- a/src/tests/discover-breadth.test.ts
+++ b/src/tests/discover-breadth.test.ts
@@ -33,71 +33,13 @@ void test("discover breadth runs the full breadth workflow and prints guidance",
   };
 
   try {
-    await mkdir(workspaceRoot, { recursive: true });
-    await mkdir(stateRoot, { recursive: true });
-    await mkdir(homeRoot, { recursive: true });
-    await mkdir(appDataRoot, { recursive: true });
-    await mkdir(xdgConfigRoot, { recursive: true });
-    await writeText(
-      join(workspaceRoot, "package.json"),
-      JSON.stringify(
-        {
-          name: "workspace",
-          private: true,
-          dependencies: {
-            react: "^19.0.0",
-            typescript: "^5.0.0",
-          },
-        },
-        null,
-        2,
-      ),
-    );
-    await writeText(
-      join(workspaceRoot, "README.md"),
-      "React frontend workspace with testing and UI concerns.\n",
-    );
-    await writeText(join(localSourceRoot, "AGENTS.md"), "Project guidance\n");
-    await writeText(
-      join(localSourceRoot, "skills", "react-helper", "SKILL.md"),
-      "---\nname: react-helper\ndescription: React helper\n---\n# React helper\n",
-    );
-
-    await writeJsonFile(join(stateRoot, "discover", "sources.json"), {
-      schemaVersion: 1,
-      sources: [
-        {
-          id: "local-workspace-guidance",
-          name: "local-workspace-guidance",
-          kind: "local-directory",
-          authorityTier: "trusted-local",
-          publisher: { name: "local", verified: true },
-          hosts: ["copilot-vscode"],
-          assetKinds: ["skill", "instruction", "prompt-pack", "agent"],
-          discoveryMode: "catalog",
-          priority: 100,
-          enabled: true,
-          endpoints: { path: localSourceRoot },
-          rules: {
-            officialPreferred: true,
-            allowMirror: true,
-            allowInstall: true,
-          },
-        },
-      ],
-    });
-    await writeJsonFile(join(stateRoot, "discover", "selections.json"), {
-      schemaVersion: 1,
-      selectionPolicies: {
-        officialBeatsPopularity: true,
-        starsAreTieBreakerOnly: true,
-        preferNativeOverAdaptable: true,
-        preferLowerRiskWhenEquivalent: true,
-        preferLowerContextCostWhenEquivalent: true,
-        communityDefaultPolicy: "catalog-only-unless-promoted",
-      },
-      rankingOrder: [],
-      duplicateGroups: [],
+    await prepareDiscoveryFixture({
+      workspaceRoot,
+      stateRoot,
+      localSourceRoot,
+      homeRoot,
+      appDataRoot,
+      xdgConfigRoot,
     });
 
     process.env.AGENT_HARNESS_HOME = homeRoot;
@@ -115,9 +57,81 @@ void test("discover breadth runs the full breadth workflow and prints guidance",
     assert.equal(await runDiscover(["breadth"], workspaceRoot, stateRoot), 0);
 
     const stdout = stdoutChunks.join("");
+    assert.match(
+      stdout,
+      /\[discover breadth\] 1\/5 Scanning workspace demand\.\.\./u,
+    );
+    assert.match(
+      stdout,
+      /\[discover breadth\] 4\/5 Building discovery catalog\.\.\./u,
+    );
     assert.match(stdout, /Discovery breadth complete\./u);
     assert.match(stdout, /Assessment: /u);
     assert.match(stdout, /Next steps:/u);
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.env.AGENT_HARNESS_HOME = previousEnv.AGENT_HARNESS_HOME;
+    process.env.APPDATA = previousEnv.APPDATA;
+    process.env.HOME = previousEnv.HOME;
+    process.env.USERPROFILE = previousEnv.USERPROFILE;
+    process.env.XDG_CONFIG_HOME = previousEnv.XDG_CONFIG_HOME;
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+});
+
+void test("discover full prints visible phase progress before finishing", async () => {
+  const tempRoot = await mkdtemp(
+    join(tmpdir(), "agent-harness-discover-full-"),
+  );
+  const workspaceRoot = join(tempRoot, "workspace");
+  const stateRoot = join(tempRoot, "state");
+  const localSourceRoot = join(tempRoot, "local-source");
+  const homeRoot = join(tempRoot, "home");
+  const appDataRoot = join(tempRoot, "appdata");
+  const xdgConfigRoot = join(tempRoot, "xdg");
+  const stdoutChunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const previousEnv = {
+    AGENT_HARNESS_HOME: process.env.AGENT_HARNESS_HOME,
+    APPDATA: process.env.APPDATA,
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+    XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+  };
+
+  try {
+    await prepareDiscoveryFixture({
+      workspaceRoot,
+      stateRoot,
+      localSourceRoot,
+      homeRoot,
+      appDataRoot,
+      xdgConfigRoot,
+    });
+
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdoutChunks.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+      );
+      return true;
+    }) as typeof process.stdout.write;
+
+    assert.equal(await runDiscover(["full"], workspaceRoot, stateRoot), 0);
+
+    const stdout = stdoutChunks.join("");
+    assert.match(
+      stdout,
+      /\[discover full\] 1\/5 Scanning workspace demand\.\.\./u,
+    );
+    assert.match(
+      stdout,
+      /\[discover full\] 3\/5 Syncing indexed sources\.\.\./u,
+    );
+    assert.match(
+      stdout,
+      /\[discover full\] 5\/5 Applying selection rules\.\.\./u,
+    );
+    assert.match(stdout, /Selection outputs written to /u);
   } finally {
     process.stdout.write = originalStdoutWrite;
     process.env.AGENT_HARNESS_HOME = previousEnv.AGENT_HARNESS_HOME;
@@ -213,6 +227,91 @@ void test("discover catalog handles large indexed source populations without ove
     await rm(tempRoot, { force: true, recursive: true });
   }
 });
+
+async function prepareDiscoveryFixture(input: {
+  workspaceRoot: string;
+  stateRoot: string;
+  localSourceRoot: string;
+  homeRoot: string;
+  appDataRoot: string;
+  xdgConfigRoot: string;
+}): Promise<void> {
+  await mkdir(input.workspaceRoot, { recursive: true });
+  await mkdir(input.stateRoot, { recursive: true });
+  await mkdir(input.homeRoot, { recursive: true });
+  await mkdir(input.appDataRoot, { recursive: true });
+  await mkdir(input.xdgConfigRoot, { recursive: true });
+  await writeText(
+    join(input.workspaceRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "workspace",
+        private: true,
+        dependencies: {
+          react: "^19.0.0",
+          typescript: "^5.0.0",
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  await writeText(
+    join(input.workspaceRoot, "README.md"),
+    "React frontend workspace with testing and UI concerns.\n",
+  );
+  await writeText(
+    join(input.localSourceRoot, "AGENTS.md"),
+    "Project guidance\n",
+  );
+  await writeText(
+    join(input.localSourceRoot, "skills", "react-helper", "SKILL.md"),
+    "---\nname: react-helper\ndescription: React helper\n---\n# React helper\n",
+  );
+
+  await writeJsonFile(join(input.stateRoot, "discover", "sources.json"), {
+    schemaVersion: 1,
+    sources: [
+      {
+        id: "local-workspace-guidance",
+        name: "local-workspace-guidance",
+        kind: "local-directory",
+        authorityTier: "trusted-local",
+        publisher: { name: "local", verified: true },
+        hosts: ["copilot-vscode"],
+        assetKinds: ["skill", "instruction", "prompt-pack", "agent"],
+        discoveryMode: "catalog",
+        priority: 100,
+        enabled: true,
+        endpoints: { path: input.localSourceRoot },
+        rules: {
+          officialPreferred: true,
+          allowMirror: true,
+          allowInstall: true,
+        },
+      },
+    ],
+  });
+  await writeJsonFile(join(input.stateRoot, "discover", "selections.json"), {
+    schemaVersion: 1,
+    selectionPolicies: {
+      officialBeatsPopularity: true,
+      starsAreTieBreakerOnly: true,
+      preferNativeOverAdaptable: true,
+      preferLowerRiskWhenEquivalent: true,
+      preferLowerContextCostWhenEquivalent: true,
+      communityDefaultPolicy: "catalog-only-unless-promoted",
+    },
+    rankingOrder: [],
+    duplicateGroups: [],
+  });
+
+  process.env.AGENT_HARNESS_HOME = input.homeRoot;
+  process.env.APPDATA = input.appDataRoot;
+  process.env.HOME = input.homeRoot;
+  process.env.USERPROFILE = input.homeRoot;
+  process.env.XDG_CONFIG_HOME = input.xdgConfigRoot;
+}
 
 async function readCatalogEntryIds(filePath: string): Promise<string[]> {
   const content = await readFile(filePath, "utf8");

--- a/src/tests/discover-breadth.test.ts
+++ b/src/tests/discover-breadth.test.ts
@@ -42,11 +42,6 @@ void test("discover breadth runs the full breadth workflow and prints guidance",
       xdgConfigRoot,
     });
 
-    process.env.AGENT_HARNESS_HOME = homeRoot;
-    process.env.APPDATA = appDataRoot;
-    process.env.HOME = homeRoot;
-    process.env.USERPROFILE = homeRoot;
-    process.env.XDG_CONFIG_HOME = xdgConfigRoot;
     process.stdout.write = ((chunk: string | Uint8Array) => {
       stdoutChunks.push(
         typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),

--- a/src/tests/recommend-report.test.ts
+++ b/src/tests/recommend-report.test.ts
@@ -63,6 +63,48 @@ void test("recommendation report validation defaults missing session intent to g
   assert.equal(report.sessionIntent, "general");
 });
 
+void test("recommendation reports support multiple intents and merge them additively", async () => {
+  clearRuntimeConfigForTests();
+  const policy = await loadRecommendationPolicy(process.cwd());
+  const demandProfile = createDemandProfile();
+  const entries = [
+    createEntry("frontend-skill", ["frontend", "ui", "react"]),
+    createEntry("backend-skill", ["backend", "api", "service"]),
+    createEntry("docs-skill", ["documentation", "guide", "readme"]),
+  ];
+
+  const multiReport = buildRecommendationReport(
+    entries,
+    demandProfile,
+    policy,
+    ["backend", "docs"],
+  );
+
+  assert.equal(multiReport.sessionIntent, "backend");
+  assert.deepEqual(multiReport.sessionIntents, ["backend", "docs"]);
+  // Both backend and docs skills should appear in results since intents are merged
+  const copilotEntries = multiReport.topByHost["copilot-vscode"];
+  const ids = copilotEntries.map((e) => e.assetId);
+  assert.ok(
+    ids.includes("backend-skill") || ids.includes("docs-skill"),
+    `expected backend or docs skill in results but got: ${ids.join(", ")}`,
+  );
+});
+
+void test("recommendation reports with one intent omit sessionIntents from output", async () => {
+  clearRuntimeConfigForTests();
+  const policy = await loadRecommendationPolicy(process.cwd());
+  const demandProfile = createDemandProfile();
+  const entries = [createEntry("backend-skill", ["backend", "api"])];
+
+  const report = buildRecommendationReport(entries, demandProfile, policy, [
+    "backend",
+  ]);
+
+  assert.equal(report.sessionIntent, "backend");
+  assert.equal(report.sessionIntents, undefined);
+});
+
 void test("recommendation reports rank entries for expanded session intent families", async () => {
   clearRuntimeConfigForTests();
   const policy = await loadRecommendationPolicy(process.cwd());
@@ -108,6 +150,34 @@ void test("recommendation reports rank entries for expanded session intent famil
     "mobile-skill",
   );
 });
+
+void test(
+  "recommendation reports handle large candidate sets without stalling",
+  { timeout: 15_000 },
+  async () => {
+    clearRuntimeConfigForTests();
+    const policy = await loadRecommendationPolicy(process.cwd());
+    const demandProfile = createDemandProfile();
+    const entries = Array.from({ length: 2_000 }, (_, index) =>
+      createEntry(
+        `fixture-skill-${index}`,
+        index % 2 === 0
+          ? ["backend", "api", `service-${index}`]
+          : ["docs", "guide", `reference-${index}`],
+      ),
+    );
+
+    const report = buildRecommendationReport(entries, demandProfile, policy, [
+      "backend",
+      "docs",
+    ]);
+
+    assert.equal(report.sessionIntent, "backend");
+    assert.deepEqual(report.sessionIntents, ["backend", "docs"]);
+    assert.ok(report.topByHost["copilot-vscode"].length > 0);
+    assert.ok(report.topByHost["shared"].length > 0);
+  },
+);
 
 void test("recommendation reports expose env-sourced recommendation limits", async () => {
   clearRuntimeConfigForTests();

--- a/src/tests/recommend-report.test.ts
+++ b/src/tests/recommend-report.test.ts
@@ -82,12 +82,39 @@ void test("recommendation reports support multiple intents and merge them additi
 
   assert.equal(multiReport.sessionIntent, "backend");
   assert.deepEqual(multiReport.sessionIntents, ["backend", "docs"]);
-  // Both backend and docs skills should appear in results since intents are merged
   const copilotEntries = multiReport.topByHost["copilot-vscode"];
   const ids = copilotEntries.map((e) => e.assetId);
   assert.ok(
-    ids.includes("backend-skill") || ids.includes("docs-skill"),
-    `expected backend or docs skill in results but got: ${ids.join(", ")}`,
+    ids.includes("backend-skill"),
+    `expected backend-skill in results but got: ${ids.join(", ")}`,
+  );
+  assert.ok(
+    ids.includes("docs-skill"),
+    `expected docs-skill in results but got: ${ids.join(", ")}`,
+  );
+});
+
+void test("recommendation report validation rejects malformed sessionIntents", async () => {
+  clearRuntimeConfigForTests();
+  const policy = await loadRecommendationPolicy(process.cwd());
+  const demandProfile = createDemandProfile();
+  const report = buildRecommendationReport(
+    [createEntry("backend-skill", ["backend", "api"])],
+    demandProfile,
+    policy,
+    ["backend", "docs"],
+  ) as unknown as Record<string, unknown>;
+
+  report.sessionIntents = ["docs", "backend"];
+  assert.throws(
+    () => assertRecommendationReport(report, "report"),
+    /must match sessionIntent/u,
+  );
+
+  report.sessionIntents = ["backend"];
+  assert.throws(
+    () => assertRecommendationReport(report, "report"),
+    /must contain at least two intents/u,
   );
 });
 

--- a/src/tests/recommend-report.test.ts
+++ b/src/tests/recommend-report.test.ts
@@ -132,6 +132,19 @@ void test("recommendation reports with one intent omit sessionIntents from outpu
   assert.equal(report.sessionIntents, undefined);
 });
 
+void test("recommendation reports normalize empty intent arrays to general", async () => {
+  clearRuntimeConfigForTests();
+  const policy = await loadRecommendationPolicy(process.cwd());
+  const demandProfile = createDemandProfile();
+  const entries = [createEntry("backend-skill", ["backend", "api"])];
+
+  const report = buildRecommendationReport(entries, demandProfile, policy, []);
+
+  assert.equal(report.sessionIntent, "general");
+  assert.equal(report.sessionIntents, undefined);
+  assert.ok(report.topByHost["copilot-vscode"].length > 0);
+});
+
 void test("recommendation reports rank entries for expanded session intent families", async () => {
   clearRuntimeConfigForTests();
   const policy = await loadRecommendationPolicy(process.cwd());

--- a/src/tests/recommendation-selection.test.ts
+++ b/src/tests/recommendation-selection.test.ts
@@ -1,10 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import {
+  buildCandidateRecommendationBase,
+  buildPolicySearchContext,
+} from "../recommend/candidates.js";
 import { buildTopRecommendationsForHost } from "../recommend/selection.js";
 import { buildDemandContext } from "../recommend/signals.js";
 import { buildSuggestedBundle } from "../recommend/summary.js";
 import { isPublisherVerifiedForAuthorityTier } from "../source-metadata.js";
+import type {
+  CandidateRecommendationBase,
+  DemandContext,
+} from "../recommend/model.js";
 import type {
   AssetCatalogEntry,
   DemandProfile,
@@ -25,7 +33,7 @@ void test("recommendation preselection preserves minimum counts above one", () =
     ),
   ];
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     entries,
     createEmptyDemandContext(),
@@ -55,7 +63,7 @@ void test("recommendation fallback keeps source-family and duplicate caps", () =
     buildCatalogEntry("other-a", "skill", 80, { sourceId: "other-a" }),
   ];
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     entries,
     createEmptyDemandContext(),
@@ -126,7 +134,7 @@ void test("exact stack matches outrank generic concern overlap", () => {
     policy,
   );
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     [
       buildCatalogEntry("generic-backend", "skill", 95, {
@@ -169,7 +177,7 @@ void test("wrapper-like assets do not claim exact-stack fit from generic aliases
     policy,
   );
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     [
       buildCatalogEntry("scenario-wrapper", "skill", 80, {
@@ -206,7 +214,7 @@ void test("path tokens do not block exact-stack fit", () => {
     policy,
   );
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     [
       buildCatalogEntry("apify-helper", "skill", 80, {
@@ -249,7 +257,7 @@ void test("canonicalized concern targets still enforce coverage goals", () => {
     policy,
   );
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     [
       buildCatalogEntry("other-skill", "skill", 100, {
@@ -294,7 +302,7 @@ void test("local availability is surfaced separately from workspace fit", () => 
     policy,
   );
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     [
       buildCatalogEntry("local-generic-toolkit", "skill", 100, {
@@ -374,7 +382,7 @@ void test("weak-only concern demand does not force coverage-gap fill", () => {
     policy,
   );
 
-  const recommendations = buildTopRecommendationsForHost(
+  const recommendations = buildRecommendationsForTest(
     "copilot-vscode",
     [
       buildCatalogEntry("generic-backend", "skill", 95, {
@@ -393,6 +401,32 @@ void test("weak-only concern demand does not force coverage-gap fill", () => {
   assert.equal(recommendations[0]?.assetId, "apify-exact");
   assert.ok(!recommendations[0]?.reasons.includes("coverage-gap-fill"));
 });
+
+function buildRecommendationsForTest(
+  host: "copilot-vscode",
+  entries: AssetCatalogEntry[],
+  demandContext: DemandContext,
+  policy: RecommendationPolicy,
+): RecommendationEntry[] {
+  const policyContext = buildPolicySearchContext(policy);
+  const candidateBases = entries
+    .map((entry) =>
+      buildCandidateRecommendationBase(
+        entry,
+        demandContext,
+        policy,
+        policyContext,
+      ),
+    )
+    .filter((base): base is CandidateRecommendationBase => base !== null);
+
+  return buildTopRecommendationsForHost(
+    host,
+    candidateBases,
+    demandContext,
+    policy,
+  );
+}
 
 function buildPolicy(
   overrides: Partial<RecommendationPolicy["hosts"]["copilot-vscode"]> = {},

--- a/src/types/recommendation.ts
+++ b/src/types/recommendation.ts
@@ -257,7 +257,10 @@ export interface RecommendationReport {
   schemaVersion: number;
   generatedAt: string;
   policyVersion: number;
+  /** Primary intent; always present for backward compatibility. */
   sessionIntent: SessionIntent;
+  /** Full intent list when more than one intent was requested. */
+  sessionIntents?: SessionIntent[];
   topByHost: Record<string, RecommendationEntry[]>;
   hostSummaries: Record<string, RecommendationHostSummary>;
   suggestedBundles: RecommendationSuggestedBundle[];

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,7 +3,7 @@
 import { fileURLToPath } from "node:url";
 
 import { resolveProjectRoot } from "./files.js";
-import { getOptionValue } from "./lib/cli-options.js";
+import { getOptionValues } from "./lib/cli-options.js";
 import {
   parseSessionIntent,
   SESSION_INTENT_CHOICES,
@@ -35,7 +35,13 @@ export async function runWorkspace(
   projectRoot: string,
 ): Promise<number> {
   const [target = "help", ...rest] = args;
-  const sessionIntent = parseSessionIntent(getOptionValue(rest, "--intent"));
+  const sessionIntents = getOptionValues(rest, "--intent").map((v) =>
+    parseSessionIntent(v),
+  );
+  const sessionIntent =
+    sessionIntents.length > 0
+      ? sessionIntents[0]
+      : parseSessionIntent(undefined);
   const aiEnrichmentFlags = parseAiEnrichmentFlags(rest);
 
   if (target === "help") {
@@ -48,6 +54,10 @@ export async function runWorkspace(
     printWorkspaceHelp();
     return 1;
   }
+
+  console.log(
+    `[workspace ${getPreferredHostCommand(hostAdapter.id)}] Starting ${hostAdapter.displayName} workspace pipeline...`,
+  );
 
   const requiresLifecycleHostPaths =
     hostAdapter.requiresLifecycleHostPaths ?? hostAdapter.mutatesHostPaths;
@@ -68,6 +78,7 @@ export async function runWorkspace(
     targetHost: hostAdapter.lifecycleHost,
     recommendationHost: hostAdapter.recommendationHost,
     sessionIntent,
+    sessionIntents: sessionIntents.length > 1 ? sessionIntents : undefined,
     bundleIds: hostAdapter.defaultBundleIds,
   });
 
@@ -82,11 +93,18 @@ export async function runWorkspace(
   }
   assertNoPreflightErrors(prerequisiteDiagnostics);
 
+  console.log(
+    `[workspace ${getPreferredHostCommand(hostAdapter.id)}] Applying final host wire-in...`,
+  );
   await hostAdapter.wire({
     projectRoot,
     workspaceRoot: workingDirectory,
     mode: "apply",
   });
+
+  console.log(
+    `[workspace ${getPreferredHostCommand(hostAdapter.id)}] Final wire-in complete.`,
+  );
 
   return handleAiEnrichmentResult(
     await orchestrateAiEnrichment(projectRoot, {


### PR DESCRIPTION
## Summary
- precompute host-independent recommendation analysis once per report build so large candidate sets do not repeat the same work for every host
- add visible progress output to long-running discovery, recommendation, and workspace pipeline flows
- extend regression coverage for large recommendation sets and visible command progress output

## Testing
- npm run validate
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repeatable `--intent` CLI support to combine multiple session intents (first intent remains primary).
  * Recommendation reports and pipelines now accept and surface multiple intents (reports include the full intent list when applicable).

* **Improvements**
  * Numbered, phased progress logging across discovery, recommendation, acquisition, staging, and activation (including per-batch/stage messages).

* **Bug Fixes**
  * Fixed recommendation-report hang on large candidate sets by reusing precomputed search context.

* **Documentation**
  * Updated CLI help text for repeatable `--intent`.

* **Tests**
  * Added/expanded tests for multi-intent reports, CLI parsing, progress logging, and performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/agent-harness/pull/184)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Fixes a report-build stall on large candidate sets by splitting recommendation scoring into a host-independent `buildCandidateRecommendationBase` pass (run once per entry) and a host-specific `buildCandidateRecommendation` pass, with policy search term sets precomputed once via `buildPolicySearchContext`.
- Adds repeatable `--intent` CLI support across `activate`, `recommend`, and `workspace` commands; multiple intents are merged additively into the demand context and the first is recorded as `sessionIntent` for backward compatibility.
- Adds numbered phase progress logs across discover, recommendation, and workspace pipeline flows, and extends regression coverage for multi-intent reports and performance on 2k-entry candidate sets.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic regressions identified; only a minor redundant filter found.

Only P2 findings (redundant compatibilityMode guard in selection.ts). Core performance fix, multi-intent support, and schema changes are all correctly implemented with good test coverage including a 2,000-entry regression test.

src/recommend/selection.ts (redundant guard), src/recommend/candidates.ts (intermediate breakdown.total computed then discarded — minor inefficiency).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/recommend/candidates.ts | Splits buildCandidateRecommendation into a host-independent base pass and a host-specific pass; adds buildPolicySearchContext for once-per-build precomputation. The base computes an intermediate breakdown.total with hostPreference=0 that is discarded in the host pass — harmless but slightly wasteful. |
| src/recommend/report.ts | Precomputes PolicySearchContext and CandidateRecommendationBase once per report build; adds resolveSessionIntents helper; multi-intent support is correctly backward-compatible. |
| src/recommend/selection.ts | Accepts CandidateRecommendationBase[] instead of raw entries. Still redundantly filters compatibilityMode !== "incompatible" even though report.ts already pre-filters before building bases. |
| src/recommend/signals.ts | buildDemandContext, buildCoverageTags, buildTaskModes, and computeOutOfDomainPenalty updated to accept precomputed term sets; multi-intent loop for registerSessionIntentTerms is correct. |
| src/manifest-validation/recommendation.ts | Adds sessionIntents validation: must have ≥2 elements when present, each must be a valid SessionIntent, first must match sessionIntent. Since fail() is never-returning, checks are correctly short-circuiting. |
| src/pipeline.ts | Adds 11-step phase logging for workspace pipeline and per-batch progress for mirror/install loops; multi-intent forwarding to runRecommend is correct; activation correctly uses only primaryIntent. |
| src/tests/recommend-report.test.ts | Good coverage: multi-intent merge, single-intent omits sessionIntents, empty array normalizes to general, malformed sessionIntents validation, and a 2,000-entry performance regression test. |
| src/tests/recommendation-selection.test.ts | Adds buildRecommendationsForTest helper to adapt tests to the new two-pass API; helper omits the compatibilityMode pre-filter present in production code, but has no effect on existing tests since none use incompatible entries. |
| src/types/recommendation.ts | Adds optional sessionIntents?: SessionIntent[] to RecommendationReport; backward-compatible since field is absent for single-intent runs. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI
    participant commands as recommend/commands
    participant report as recommend/report
    participant candidates as recommend/candidates
    participant selection as recommend/selection

    CLI->>commands: runRecommend(["report", "--intent", "backend", "--intent", "docs"])
    commands->>commands: parseSessionIntents() → ["backend","docs"]
    commands->>report: "writeRecommendationReport({sessionIntents})"

    report->>report: "resolveSessionIntents() → primaryIntent="backend""
    report->>candidates: buildPolicySearchContext(policy)
    Note over candidates: Built ONCE per report build
    candidates-->>report: PolicySearchContext

    loop For each catalog entry
        report->>candidates: buildCandidateRecommendationBase(entry, demandCtx, policy, policyCtx)
        Note over candidates: Shared policyCtx reused — no per-entry rebuild
        candidates-->>report: "CandidateRecommendationBase | null"
    end

    loop For each RecommendationHost
        report->>selection: buildTopRecommendationsForHost(host, candidateBases, ...)
        loop For each base
            selection->>candidates: buildCandidateRecommendation(base, host, ...)
            Note over candidates: Host-specific: isSuppressedForHost,<br/>hostPreference, hostDeprioritizationPenalty
            candidates-->>selection: "CandidateRecommendation | null"
        end
        selection-->>report: RecommendationEntry[]
    end

    report-->>commands: "RecommendationReport {sessionIntent:"backend", sessionIntents:["backend","docs"]}"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/tests/discover-breadth.test.ts`, line 36-49 ([link](https://github.com/ar27111994/agent-harness/blob/f6fc38fab029a7f7bcad2964e67e86bfaeec48c5/src/tests/discover-breadth.test.ts#L36-L49)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant env-var assignment after `prepareDiscoveryFixture`**

   `prepareDiscoveryFixture` already sets all five environment variables at the end of the helper. The breadth test then immediately re-assigns the same variables to the same values on lines 45–49. The `discover full` test (added in this PR) does not have this duplication, confirming the breadth test just wasn't cleaned up when the helper was extracted. The double-set is harmless now, but it means future changes to `prepareDiscoveryFixture`'s env assignments won't be reflected here unless both locations are updated.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Fix PR review follow-ups"](https://github.com/ar27111994/agent-harness/commit/6fd8fc45d6b3e3dc333a4eb2a08d17fcf1712cbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31759851)</sub>

<!-- /greptile_comment -->