### PR TITLE
Fix rebuild full stale mirror artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - `rebuild full` now refreshes selected mirror artifacts whose raw cache directory predates the mirror `manifest.json` format, preventing install from failing on stale `mirror/index.jsonl` entries after upgrading existing workspaces
+- CodeQL URL-sanitization alerts in mirror/install regression tests are resolved by parsing mocked request URLs before checking allowed hostnames
 
 ## [1.0.7] - 2026-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ All notable changes to this project will be documented in this file.
 
 - improved release synchronization, version-check, GitHub resilience, guarded HTTP, path/file, native wire, install refresh, mirror acquisition, and recommendation validation regression coverage with deterministic tests
 
+## [1.0.8] - 2026-05-17
+
+### Fixed
+
+- `rebuild full` now refreshes selected mirror artifacts whose raw cache directory predates the mirror `manifest.json` format, preventing install from failing on stale `mirror/index.jsonl` entries after upgrading existing workspaces
+
 ## [1.0.7] - 2026-05-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ar27111994/agent-harness",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ar27111994/agent-harness",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Node.js TypeScript CLI for discovering, staging, activating, and wiring reusable AI-agent assets across supported developer hosts.",
   "license": "MIT",
   "author": "ar27111994",

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
-import { access } from "node:fs/promises";
+import { access, stat } from "node:fs/promises";
 import { join } from "node:path";
 
 import { getRuntimeConfig } from "../config/runtime.js";
@@ -1153,8 +1153,15 @@ function buildGitHubCachePath(
 }
 
 async function pathLooksReadable(filePath: string): Promise<boolean> {
-  return access(filePath, fsConstants.R_OK)
-    .then(() => true)
+  return stat(filePath)
+    .then(async (stats) => {
+      if (!stats.isFile()) {
+        return false;
+      }
+
+      await access(filePath, fsConstants.R_OK);
+      return true;
+    })
     .catch(() => false);
 }
 

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -164,6 +164,11 @@ export async function acquireMirrorArtifacts(
   const existingMirrorIdsByAssetId = new Map(
     existingMirrorIndexEntries.map((entry) => [entry.assetId, entry.mirrorId]),
   );
+  const staleMirrorAssetIds = await findAssetIdsMissingMirrorManifests(
+    projectRoot,
+    existingMirrorIndexEntries,
+    mirrorEligibleAssetIds,
+  );
   const fullRefreshRequested = refreshRequested && refreshAssetIds.size === 0;
   const refreshProcessedCount = fullRefreshRequested
     ? restoreRefreshProcessedCount(
@@ -175,7 +180,9 @@ export async function acquireMirrorArtifacts(
     ? mirrorEligibleEntries.slice(refreshProcessedCount)
     : mirrorEligibleEntries.filter((entry) => {
         const shouldRefreshEntry =
-          refreshRequested || refreshAssetIds.has(entry.id);
+          refreshRequested ||
+          refreshAssetIds.has(entry.id) ||
+          staleMirrorAssetIds.has(entry.id);
 
         if (shouldRefreshEntry) {
           return true;
@@ -1054,6 +1061,33 @@ async function readPersistedSkippedAssets(
   };
 }
 
+async function findAssetIdsMissingMirrorManifests(
+  projectRoot: string,
+  mirrorIndexEntries: MirrorIndexEntry[],
+  eligibleAssetIds: Set<string>,
+): Promise<Set<string>> {
+  const assetIds = new Set<string>();
+
+  for (const entry of mirrorIndexEntries) {
+    if (!eligibleAssetIds.has(entry.assetId)) {
+      continue;
+    }
+
+    const manifestPath = join(
+      projectRoot,
+      "mirror",
+      "raw",
+      sanitizeMirrorId(entry.mirrorId),
+      "manifest.json",
+    );
+    if (!(await pathLooksReadable(manifestPath))) {
+      assetIds.add(entry.assetId);
+    }
+  }
+
+  return assetIds;
+}
+
 function buildSortedReasonRecord(
   reasons: Map<string, string>,
 ): Record<string, string> {
@@ -1143,6 +1177,7 @@ export const mirrorAcquireInternals = {
   normalizePromptInjectionText,
   createGitBlobSha,
   isGitBlobSha,
+  findAssetIdsMissingMirrorManifests,
   buildSortedReasonRecord,
   mergeMirrorIndexEntries,
   buildGitHubCachePath,

--- a/src/mirror/acquire.ts
+++ b/src/mirror/acquire.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
 import { join } from "node:path";
 
 import { getRuntimeConfig } from "../config/runtime.js";
@@ -164,12 +166,14 @@ export async function acquireMirrorArtifacts(
   const existingMirrorIdsByAssetId = new Map(
     existingMirrorIndexEntries.map((entry) => [entry.assetId, entry.mirrorId]),
   );
-  const staleMirrorAssetIds = await findAssetIdsMissingMirrorManifests(
-    projectRoot,
-    existingMirrorIndexEntries,
-    mirrorEligibleAssetIds,
-  );
   const fullRefreshRequested = refreshRequested && refreshAssetIds.size === 0;
+  const staleMirrorAssetIds = fullRefreshRequested
+    ? new Set<string>()
+    : await findAssetIdsMissingMirrorManifests(
+        projectRoot,
+        existingMirrorIndexEntries,
+        mirrorEligibleAssetIds,
+      );
   const refreshProcessedCount = fullRefreshRequested
     ? restoreRefreshProcessedCount(
         previousAcquireState,
@@ -1149,8 +1153,8 @@ function buildGitHubCachePath(
 }
 
 async function pathLooksReadable(filePath: string): Promise<boolean> {
-  return readTextFileOrNull(filePath)
-    .then((content) => content !== null)
+  return access(filePath, fsConstants.R_OK)
+    .then(() => true)
     .catch(() => false);
 }
 

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -567,6 +567,57 @@ void test("acquireMirrorArtifacts refreshes stale mirror entries without manifes
       "utf8",
     );
     assert.match(refreshedManifest, /"aggregateHash"/u);
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts refreshes stale mirror entries with manifest directories", async () => {
+  const entries = [buildAsset("mirror-a")];
+  const projectRoot = await createAcquireFixture(entries);
+  const staleMirrorEntry = createMirrorIndexEntry("mirror-a");
+
+  try {
+    await writeJsonLinesFile(mirrorIndexPath(projectRoot), [staleMirrorEntry]);
+    await mkdir(
+      join(
+        projectRoot,
+        "mirror",
+        "raw",
+        staleMirrorEntry.mirrorId,
+        "manifest.json",
+      ),
+      { recursive: true },
+    );
+
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer([]) },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.deepEqual(state.lastBatchAssetIds, ["mirror-a"]);
+    assert.equal(mirrorIndex.length, 1);
+    assert.notEqual(mirrorIndex[0]?.mirrorId, staleMirrorEntry.mirrorId);
+    assert.equal(
+      await mirrorAcquireInternals.pathLooksReadable(
+        join(
+          projectRoot,
+          "mirror",
+          "raw",
+          staleMirrorEntry.mirrorId,
+          "manifest.json",
+        ),
+      ),
+      false,
+    );
   } finally {
     await rm(projectRoot, { force: true, recursive: true });
   }

--- a/src/tests/mirror-acquire-state.test.ts
+++ b/src/tests/mirror-acquire-state.test.ts
@@ -17,7 +17,10 @@ import {
   assertMirrorIndexEntry,
 } from "../manifest-validation/mirror.js";
 import { assertMirrorAcquireCheckpoint } from "../mirror/acquire-state.js";
-import { acquireMirrorArtifacts } from "../mirror/acquire.js";
+import {
+  acquireMirrorArtifacts,
+  mirrorAcquireInternals,
+} from "../mirror/acquire.js";
 import type {
   AssetCatalogEntry,
   MirrorAcquireState,
@@ -493,6 +496,77 @@ void test("acquireMirrorArtifacts ignores stale persisted skipped ids outside th
       mirrorIndex.map((entry) => entry.assetId),
       ["mirror-a"],
     );
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("mirror acquire stale-manifest detection ignores ineligible index entries", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "agent-harness-acquire-"));
+
+  try {
+    const staleAssetIds =
+      await mirrorAcquireInternals.findAssetIdsMissingMirrorManifests(
+        projectRoot,
+        [createMirrorIndexEntry("outside-current-selection")],
+        new Set(["mirror-a"]),
+      );
+
+    assert.deepEqual([...staleAssetIds], []);
+  } finally {
+    await rm(projectRoot, { force: true, recursive: true });
+  }
+});
+
+void test("acquireMirrorArtifacts refreshes stale mirror entries without manifests", async () => {
+  const entries = [buildAsset("mirror-a")];
+  const projectRoot = await createAcquireFixture(entries);
+  const staleMirrorEntry = createMirrorIndexEntry("mirror-a");
+
+  try {
+    await writeJsonLinesFile(mirrorIndexPath(projectRoot), [staleMirrorEntry]);
+    await writeTextFile(
+      join(
+        projectRoot,
+        "mirror",
+        "raw",
+        staleMirrorEntry.mirrorId,
+        "content.txt",
+      ),
+      "legacy mirror content without a file manifest",
+    );
+
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer([]) },
+    );
+
+    const state = await readAcquireStateFixture(projectRoot);
+    const mirrorIndex = await readMirrorIndexFixture(projectRoot);
+
+    assert.equal(state.terminal, true);
+    assert.equal(state.mirroredCount, 1);
+    assert.equal(state.skippedCount, 0);
+    assert.equal(state.remainingCount, 0);
+    assert.equal(state.lastBatchMirroredCount, 1);
+    assert.deepEqual(state.lastBatchAssetIds, ["mirror-a"]);
+    assert.equal(mirrorIndex.length, 1);
+    assert.equal(mirrorIndex[0]?.assetId, "mirror-a");
+    assert.notEqual(mirrorIndex[0]?.mirrorId, staleMirrorEntry.mirrorId);
+
+    const refreshedManifest = await readFile(
+      join(
+        projectRoot,
+        "mirror",
+        "raw",
+        mirrorIndex[0]!.mirrorId,
+        "manifest.json",
+      ),
+      "utf8",
+    );
+    assert.match(refreshedManifest, /"aggregateHash"/u);
   } finally {
     await rm(projectRoot, { force: true, recursive: true });
   }
@@ -1609,9 +1683,12 @@ void test("acquireMirrorArtifacts treats mirrored overlap ids as mirrored instea
   const projectRoot = await createAcquireFixture(entries);
 
   try {
-    await writeJsonLinesFile(mirrorIndexPath(projectRoot), [
-      createMirrorIndexEntry("mirror-a"),
-    ]);
+    await acquireMirrorArtifacts(
+      projectRoot,
+      projectRoot,
+      ["--batch-size", "10"],
+      { materializeArtifact: createMaterializer([]) },
+    );
     await writeJsonFile(
       acquireStatePath(projectRoot),
       createAcquireState({

--- a/src/tests/mirror-install-gap-coverage.test.ts
+++ b/src/tests/mirror-install-gap-coverage.test.ts
@@ -52,6 +52,14 @@ import type {
   MirrorPolicy,
 } from "../types.js";
 
+function parseMockFetchUrl(input: string | URL | Request): URL {
+  return new URL(String(input instanceof Request ? input.url : input));
+}
+
+function hasHostname(url: URL, hostname: string): boolean {
+  return url.hostname === hostname;
+}
+
 function buildPolicy(): MirrorPolicy {
   return {
     schemaVersion: 1,
@@ -1597,20 +1605,20 @@ void test("mirror acquire internals cover summary, evidence, cache, GitHub parsi
     });
 
     t.mock.method(globalThis, "fetch", async (input: string | URL) => {
-      const url = String(input);
-      if (url.includes("officialskills.sh")) {
+      const url = parseMockFetchUrl(input);
+      if (hasHostname(url, "officialskills.sh")) {
         return new Response(
           '<html><title>Summary Entry - Agent Skills | officialskills.sh</title><meta name="description" content="Summary description"><h2>What This Skill Does</h2><section><p>Helpful summary.</p></section></html>',
           { status: 200, headers: { "content-type": "text/html" } },
         );
       }
-      if (url.includes("api.github.com")) {
+      if (hasHostname(url, "api.github.com")) {
         return new Response(JSON.stringify({ sha: "abcdef123456" }), {
           status: 200,
           headers: { "content-type": "application/json" },
         });
       }
-      if (url.includes("/null-content/")) {
+      if (url.pathname.includes("/null-content/")) {
         return new Response("missing", {
           status: 404,
           headers: { "content-type": "text/plain" },
@@ -1914,7 +1922,11 @@ void test("mirror acquire internals cover summary, evidence, cache, GitHub parsi
         }),
         "cloudflare",
       );
-    assert.ok(repoCandidates.some((url) => url.includes("github.com")));
+    assert.ok(
+      repoCandidates.some(
+        (url) => parseMockFetchUrl(url).hostname === "github.com",
+      ),
+    );
     assert.equal(
       mirrorAcquireInternals.isGitHubHttpsRepositoryUrl("not-a-url"),
       false,
@@ -2176,19 +2188,22 @@ void test("official index package materialization handles caps, content fallback
       globalThis,
       "fetch",
       async (input: string | URL | Request) => {
-        const url = String(input instanceof Request ? input.url : input);
-        if (url.includes("officialskills.sh/nullraw")) {
+        const url = parseMockFetchUrl(input);
+        if (
+          hasHostname(url, "officialskills.sh") &&
+          url.pathname.endsWith("/nullraw")
+        ) {
           return new Response("missing", { status: 404 });
         }
-        if (url.includes("officialskills.sh")) {
-          const slug = url.split("/").at(-1) ?? "fixture";
+        if (hasHostname(url, "officialskills.sh")) {
+          const slug = url.pathname.split("/").at(-1) ?? "fixture";
           return new Response(
             `<html><title>${slug}</title><a href="https://github.com/fixture/${slug}repo">GitHub</a><h2>What This Skill Does</h2><p>${slug} fallback summary.</p></html>`,
             { status: 200, headers: { "content-type": "text/html" } },
           );
         }
-        if (url.includes("raw.githubusercontent.com")) {
-          if (url.includes("nullraw")) {
+        if (hasHostname(url, "raw.githubusercontent.com")) {
+          if (url.pathname.includes("nullraw")) {
             return new Response("missing", { status: 404 });
           }
           return new Response("# Skill\n", {
@@ -2196,10 +2211,10 @@ void test("official index package materialization handles caps, content fallback
             headers: { "content-type": "text/plain" },
           });
         }
-        if (url.includes("api.github.com")) {
-          const repoMatch = /\/repos\/fixture\/([^/?]+)/u.exec(url);
+        if (hasHostname(url, "api.github.com")) {
+          const repoMatch = /\/repos\/fixture\/([^/?]+)/u.exec(url.pathname);
           const repo = repoMatch?.[1] ?? "unknown";
-          if (url.includes("/git/trees/")) {
+          if (url.pathname.includes("/git/trees/")) {
             const slug = repo.replace(/repo$/u, "").replace(/-skills$/u, "");
             if (repo.includes("truncated")) {
               return new Response(
@@ -2276,7 +2291,7 @@ void test("official index package materialization handles caps, content fallback
               { status: 200, headers: { "content-type": "application/json" } },
             );
           }
-          if (url.includes("/commits/")) {
+          if (url.pathname.includes("/commits/")) {
             return new Response(
               JSON.stringify({
                 sha: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",


### PR DESCRIPTION
## Summary

- bump package metadata to `1.0.8`
- update the changelog with the rebuild-full stale mirror cache fix
- refresh selected mirror artifacts when their raw cache directory is missing `manifest.json`
- add regression coverage for legacy mirror artifacts and preserve valid mirrored-overlap behavior

## Verification

- `npm run build && node --test dist/tests/mirror-acquire-state.test.js`
- `npm run rebuild:full`
- `npm run test:coverage && npm run coverage:gaps` — 688/688 tests, 100% statements/branches/functions/lines
- `npm run validate`

Fixes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `rebuild full` command to properly refresh mirror artifacts whose cache predates the new manifest format, preventing installation failures when upgrading existing workspaces with stale mirror index entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/agent-harness/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `rebuild full` for workspaces whose mirror cache predates the `manifest.json` format: stale entries are now re-acquired instead of silently failing at install time. It also improves the efficiency of `pathLooksReadable` and hardens test URL matching to address CodeQL alerts.

- **Stale-manifest detection** (`src/mirror/acquire.ts`): introduces `findAssetIdsMissingMirrorManifests`, which is called only when a selective (non-full) refresh is running; it stat-checks each eligible index entry's raw cache directory and flags any entry missing `manifest.json` for re-acquisition.
- **`pathLooksReadable` refactor**: replaces the old read-to-check-readability approach with a `stat` + `access` check, eliminating unnecessary file I/O.
- **Test updates**: adds regression coverage for the legacy-manifest scenario and the directory-as-manifest edge case; updates the \"mirrored overlap\" test to first materialise a proper mirror entry before simulating the overlap state; replaces `url.includes(host)` substring checks with proper URL hostname comparison helpers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the stale-manifest detection path and does not affect full-refresh or normal incremental-acquire flows.

The new findAssetIdsMissingMirrorManifests function is correctly short-circuited for full refreshes, integrates cleanly into the existing entry filter, and uses the same assetId key that the rest of the pipeline uses. The pathLooksReadable refactor eliminates unnecessary file reads without changing observable behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/mirror/acquire.ts | Introduces findAssetIdsMissingMirrorManifests (short-circuited for full refreshes) and integrates stale-entry detection into the entry filter; refactors pathLooksReadable to use stat+access instead of reading file content; exports the new function via mirrorAcquireInternals. |
| src/tests/mirror-acquire-state.test.ts | Adds three new regression tests for stale-manifest detection; fixes the mirrored overlap test to create a proper materialized mirror entry (with manifest) before simulating the overlap acquire state. |
| src/tests/mirror-install-gap-coverage.test.ts | Introduces parseMockFetchUrl and hasHostname helpers; replaces all url.includes(host) substring checks with proper URL hostname comparisons to resolve CodeQL URL-sanitization alerts. |
| CHANGELOG.md | Adds v1.0.8 entry documenting the stale-manifest fix and CodeQL alert resolution. |
| package.json | Version bump from 1.0.7 to 1.0.8. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Require manifest paths to be files"](https://github.com/ar27111994/agent-harness/commit/24b6725247301c832df9d8dc077f749383ed5f35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32511714)</sub>

<!-- /greptile_comment -->