### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![npm version](https://img.shields.io/npm/v/%40ar27111994%2Fagent-harness?logo=npm&color=CB3837)](https://www.npmjs.com/package/@ar27111994/agent-harness)
 [![npm downloads](https://img.shields.io/npm/dm/%40ar27111994%2Fagent-harness?logo=npm&color=CB3837)](https://www.npmjs.com/package/@ar27111994/agent-harness)
 [![Sponsor](https://img.shields.io/badge/Sponsor-support-ff69b4?logo=githubsponsors&logoColor=white)](#sponsor)
-
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ar27111994/agent-harness)
 
 `agent-harness` is a Node.js 22+ TypeScript CLI, published as `@ar27111994/agent-harness`, for discovering, curating, staging, activating, and wiring reusable AI-agent assets into developer workspaces.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![npm downloads](https://img.shields.io/npm/dm/%40ar27111994%2Fagent-harness?logo=npm&color=CB3837)](https://www.npmjs.com/package/@ar27111994/agent-harness)
 [![Sponsor](https://img.shields.io/badge/Sponsor-support-ff69b4?logo=githubsponsors&logoColor=white)](#sponsor)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ar27111994/agent-harness)
+
 `agent-harness` is a Node.js 22+ TypeScript CLI, published as `@ar27111994/agent-harness`, for discovering, curating, staging, activating, and wiring reusable AI-agent assets into developer workspaces.
 
 It is built around one generic command surface and a host-adapter model. The lifecycle stays consistent across hosts, while each adapter owns the host-specific files, settings, and reset behavior required by VS Code / GitHub Copilot, OpenCode, Cursor, Zed, Claude Code, and Pi.


### PR DESCRIPTION
Added the DeepWiki badge to the README to improve documentation discoverability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new "Ask DeepWiki" badge to the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ar27111994/agent-harness/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an "Ask DeepWiki" badge to the `README.md` header, placed contiguously at the end of the existing badge row.

- The badge image is fetched from `https://deepwiki.com/badge.svg` and links to `https://deepwiki.com/ar27111994/agent-harness`, which is the standard DeepWiki integration pattern.
- No code, configuration, or logic is affected; this is a purely cosmetic documentation change.

<h3>Confidence Score: 5/5</h3>

A single-line badge addition to the README with no impact on code, configuration, or runtime behavior.

The change only appends one badge markdown line to the existing badge block. Nothing functional is touched, and the new badge follows the same pattern used by all other badges in the file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds the DeepWiki badge inline with the existing badge block; no functional or structural issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as README Viewer
    participant GitHub as GitHub Pages
    participant DeepWiki as deepwiki.com

    User->>GitHub: Opens README.md
    GitHub->>DeepWiki: Fetches badge image (badge.svg)
    DeepWiki-->>GitHub: Returns badge SVG
    GitHub-->>User: Renders badge in header
    User->>DeepWiki: Clicks badge
    DeepWiki-->>User: Opens ar27111994/agent-harness docs
```

<sub>Reviews (2): Last reviewed commit: ["docs: align DeepWiki badge with existing..."](https://github.com/ar27111994/agent-harness/commit/905a2e58e5965600959c3c6857187b7c27b906cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32579039)</sub>

<!-- /greptile_comment -->